### PR TITLE
StagingRodada de correções pós-review (A-I): 5 ondas

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,7 +2,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from slowapi import _rate_limit_exceeded_handler
 from slowapi.errors import RateLimitExceeded
-from app.routers import auth, wallets, transactions, ai, recurring, goals
+from app.routers import auth, wallets, transactions, ai, recurring, goals, dashboard
 from app.config import get_settings
 from app.limiter import limiter
 
@@ -32,6 +32,7 @@ app.include_router(transactions.router)
 app.include_router(ai.router)
 app.include_router(recurring.router)
 app.include_router(goals.router)
+app.include_router(dashboard.router)
 
 @app.get("/health", tags=["Health"]) 
 async def health_check():

--- a/backend/app/routers/ai.py
+++ b/backend/app/routers/ai.py
@@ -2,7 +2,8 @@ from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 from datetime import datetime, timezone
 from uuid import uuid4
-from app.dependencies import get_current_user
+from sqlalchemy.ext.asyncio import AsyncSession
+from app.dependencies import get_db, get_current_user
 from app.models.sql_models import User
 from app.services.ai_service import get_or_generate_insight, chat_with_ai
 from app.database import chat_history_collection
@@ -18,10 +19,13 @@ class ChatMessage(BaseModel):
     session_id: str | None = None
     
 @router.get("/insight")
-async def get_dashboard_insight(current_user: User = Depends(get_current_user)):
+async def get_dashboard_insight(
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
     try:
         now = datetime.now(timezone.utc)
-        insight = await get_or_generate_insight(str(current_user.id), now.month, now.year)
+        insight = await get_or_generate_insight(db, str(current_user.id), now.month, now.year)
         return insight
     except Exception:
         # Widget opcional do dashboard: degrada com elegância em vez de derrubar a tela.
@@ -35,7 +39,11 @@ async def get_dashboard_insight(current_user: User = Depends(get_current_user)):
         }
         
 @router.post("/chat")
-async def chat(payload: ChatMessage, current_user: User = Depends(get_current_user)): # Chat com o Gemini que lê os dados financeiros do usuário
+async def chat(
+    payload: ChatMessage,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+): # Chat com o Gemini que lê os dados financeiros do usuário
     session_id = payload.session_id or str(uuid4())
     user_id = str(current_user.id)
 
@@ -53,7 +61,7 @@ async def chat(payload: ChatMessage, current_user: User = Depends(get_current_us
 
     # Chama o Gemini (se falhar, devolve 503 claro em vez de 500 sem headers de CORS)
     try:
-        ai_response = await chat_with_ai(user_id, payload.message, history)
+        ai_response = await chat_with_ai(db, user_id, payload.message, history)
     except Exception:
         logger.exception("Falha no chat com a IA (user=%s)", user_id)
         raise HTTPException(

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -1,3 +1,5 @@
+import asyncio
+
 from fastapi import APIRouter, Depends, HTTPException, status, Request
 from fastapi.encoders import jsonable_encoder
 from fastapi.responses import JSONResponse
@@ -26,10 +28,13 @@ async def register(request: Request, payload: UserRegister, db: AsyncSession = D
     if existing.scalar_one_or_none():
         raise HTTPException(status_code=400, detail="Email já cadastrado")
 
+    # bcrypt é CPU-bound e síncrono (~100-300ms). Rodar direto na rota async
+    # travaria o event loop; offload para thread, como já é feito com o Gemini.
+    password_hash = await asyncio.to_thread(hash_password, payload.password)
     user = User(
         name=payload.name,
         email=payload.email,
-        password_hash=hash_password(payload.password)
+        password_hash=password_hash,
     )
     db.add(user)
     await db.commit()
@@ -45,7 +50,11 @@ async def login(request: Request, payload: UserLogin, db: AsyncSession = Depends
     result = await db.execute(select(User).where(User.email == payload.email))
     user = result.scalar_one_or_none()
 
-    if not user or not verify_password(payload.password, user.password_hash):
+    # verify_password (bcrypt) também é bloqueante → offload para thread.
+    password_ok = user and await asyncio.to_thread(
+        verify_password, payload.password, user.password_hash
+    )
+    if not password_ok:
         raise HTTPException(status_code=401, detail="Credenciais inválidas")
 
     access = create_access_token(str(user.id))

--- a/backend/app/routers/dashboard.py
+++ b/backend/app/routers/dashboard.py
@@ -1,0 +1,17 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.dependencies import get_db, get_current_user
+from app.models.sql_models import User
+from app.schemas.dashboard import DashboardSummary
+from app.services.dashboard_service import get_dashboard_summary
+
+router = APIRouter(prefix="/dashboard", tags=["Dashboard"])
+
+
+@router.get("/summary", response_model=DashboardSummary)
+async def dashboard_summary(
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    return await get_dashboard_summary(db, current_user.id)

--- a/backend/app/routers/transactions.py
+++ b/backend/app/routers/transactions.py
@@ -8,6 +8,7 @@ from app.dependencies import get_db, get_current_user
 from app.models.sql_models import User, Transaction, TransactionType, Wallet
 from app.schemas.transaction import TransactionCreate, TransactionUpdate, TransactionResponse
 from app.services.transaction_service import apply_delta, revert_delta
+from app.services.goal_service import current_month_range
 
 router = APIRouter(prefix="/transactions", tags=["Transactions"])
 
@@ -63,9 +64,8 @@ async def list_transactions(
     if type:
         filters.append(Transaction.type == type)
     if month and year:
-        # Intervalo [início do mês, início do mês seguinte) — correto inclusive p/ dezembro
-        start = date(year, month, 1)
-        end = date(year + 1, 1, 1) if month == 12 else date(year, month + 1, 1)
+        # Intervalo [início do mês, início do mês seguinte) — helper único, correto p/ dezembro
+        start, end = current_month_range(date(year, month, 1))
         filters.append(Transaction.date >= start)
         filters.append(Transaction.date < end)
     result = await db.execute(

--- a/backend/app/routers/transactions.py
+++ b/backend/app/routers/transactions.py
@@ -1,16 +1,51 @@
 from fastapi import APIRouter, Depends, Query, HTTPException, status
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select
-from sqlalchemy.orm import selectinload
 from uuid import UUID
 from datetime import date
 from typing import Optional
 from app.dependencies import get_db, get_current_user
 from app.models.sql_models import User, Transaction, TransactionType, Wallet
 from app.schemas.transaction import TransactionCreate, TransactionUpdate, TransactionResponse
-from decimal import Decimal
+from app.services.transaction_service import apply_delta, revert_delta
 
 router = APIRouter(prefix="/transactions", tags=["Transactions"])
+
+
+async def _get_owned_wallet(
+    wallet_id: UUID,
+    user: User,
+    db: AsyncSession,
+    *,
+    for_update: bool = False,
+    required: bool = True,
+) -> Optional[Wallet]:
+    """Carteira do usuário, com lock opcional (with_for_update) p/ mutar saldo.
+
+    Espelha o padrão de `_get_owned_goal` em goals.py. Com required=True (padrão)
+    levanta 404 se não for do usuário; required=False devolve None (usado para a
+    carteira de origem no update, cujo efeito antigo é revertido de forma tolerante).
+    """
+    stmt = select(Wallet).where(Wallet.id == wallet_id, Wallet.user_id == user.id)
+    if for_update:
+        stmt = stmt.with_for_update()
+    wallet = (await db.execute(stmt)).scalar_one_or_none()
+    if wallet is None and required:
+        raise HTTPException(status_code=404, detail="Carteira não encontrada")
+    return wallet
+
+
+async def _get_owned_transaction(transaction_id: UUID, user: User, db: AsyncSession) -> Transaction:
+    transaction = (await db.execute(
+        select(Transaction).where(
+            Transaction.id == transaction_id,
+            Transaction.user_id == user.id,
+        )
+    )).scalar_one_or_none()
+    if not transaction:
+        raise HTTPException(status_code=404, detail="Transação não encontrada")
+    return transaction
+
 
 @router.get("/", response_model=list[TransactionResponse])
 async def list_transactions(
@@ -41,31 +76,22 @@ async def list_transactions(
     )
     return result.scalars().all()
 
+
 @router.post("/", response_model=TransactionResponse, status_code=status.HTTP_201_CREATED)
 async def create_transaction(
     payload: TransactionCreate,
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
-    # Verifica se a carteira pertence ao usuário
-    wallet_result = await db.execute(
-        select(Wallet).where(Wallet.id == payload.wallet_id, Wallet.user_id == current_user.id)
-    )
-    wallet = wallet_result.scalar_one_or_none()
-    if not wallet:
-        raise HTTPException(status_code=404, detail="Carteira não encontrada")
+    wallet = await _get_owned_wallet(payload.wallet_id, current_user, db, for_update=True)
+    apply_delta(wallet, payload.type, payload.amount)
 
-    # Atualiza o saldo
-    if payload.type == TransactionType.INCOME:
-        wallet.balance += payload.amount
-    else:
-        wallet.balance -= payload.amount
-        
     transaction = Transaction(user_id=current_user.id, **payload.model_dump())
     db.add(transaction)
     await db.commit()
     await db.refresh(transaction)
     return transaction
+
 
 @router.put("/{transaction_id}", response_model=TransactionResponse)
 async def update_transaction(
@@ -74,16 +100,7 @@ async def update_transaction(
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
-    # Busca a transação do usuário
-    result = await db.execute(
-        select(Transaction).where(
-            Transaction.id == transaction_id,
-            Transaction.user_id == current_user.id,
-        )
-    )
-    transaction = result.scalar_one_or_none()
-    if not transaction:
-        raise HTTPException(status_code=404, detail="Transação não encontrada")
+    transaction = await _get_owned_transaction(transaction_id, current_user, db)
 
     data = payload.model_dump(exclude_unset=True)
 
@@ -92,42 +109,25 @@ async def update_transaction(
     new_type = data.get("type", transaction.type)
     new_amount = data.get("amount", transaction.amount)
 
-    # Carteira de origem (onde o efeito antigo está aplicado)
-    old_wallet_result = await db.execute(
-        select(Wallet).where(
-            Wallet.id == transaction.wallet_id,
-            Wallet.user_id == current_user.id,
-        )
+    # Carteira de origem (onde o efeito antigo está aplicado). Tolerante a None:
+    # preserva o comportamento defensivo anterior.
+    old_wallet = await _get_owned_wallet(
+        transaction.wallet_id, current_user, db, for_update=True, required=False
     )
-    old_wallet = old_wallet_result.scalar_one_or_none()
 
     # Carteira de destino (pode ser a mesma)
     if new_wallet_id == transaction.wallet_id:
         new_wallet = old_wallet
     else:
-        new_wallet_result = await db.execute(
-            select(Wallet).where(
-                Wallet.id == new_wallet_id,
-                Wallet.user_id == current_user.id,
-            )
-        )
-        new_wallet = new_wallet_result.scalar_one_or_none()
-        if not new_wallet:
-            raise HTTPException(status_code=404, detail="Carteira não encontrada")
+        new_wallet = await _get_owned_wallet(new_wallet_id, current_user, db, for_update=True)
 
     # 1) Reverte o efeito antigo (usa os valores AINDA não alterados da transação)
     if old_wallet:
-        if transaction.type == TransactionType.INCOME:
-            old_wallet.balance -= transaction.amount
-        else:
-            old_wallet.balance += transaction.amount
+        revert_delta(old_wallet, transaction.type, transaction.amount)
 
     # 2) Aplica o efeito novo na carteira de destino
     if new_wallet:
-        if new_type == TransactionType.INCOME:
-            new_wallet.balance += new_amount
-        else:
-            new_wallet.balance -= new_amount
+        apply_delta(new_wallet, new_type, new_amount)
 
     # 3) Atualiza os campos da transação
     for field, value in data.items():
@@ -137,34 +137,20 @@ async def update_transaction(
     await db.refresh(transaction)
     return transaction
 
+
 @router.delete("/{transaction_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_transaction(
     transaction_id: UUID,
     current_user: User = Depends(get_current_user),
-    db: AsyncSession = Depends(get_db)
+    db: AsyncSession = Depends(get_db),
 ):
-    result = await db.execute(
-        select(Transaction).where(
-            Transaction.id == transaction_id,
-            Transaction.user_id == current_user.id,
-        )
-    )
-    transaction = result.scalar_one_or_none()
-    if not transaction:
-        raise HTTPException(status_code=404, detail="Transação não encontrada")
+    transaction = await _get_owned_transaction(transaction_id, current_user, db)
 
-    wallet_result = await db.execute(
-        select(Wallet).where(
-            Wallet.id == transaction.wallet_id,
-            Wallet.user_id == current_user.id,
-        )
+    wallet = await _get_owned_wallet(
+        transaction.wallet_id, current_user, db, for_update=True, required=False
     )
-    wallet = wallet_result.scalar_one_or_none()
     if wallet:
-        if transaction.type == TransactionType.INCOME:
-            wallet.balance -= transaction.amount
-        else:
-            wallet.balance += transaction.amount
-            
+        revert_delta(wallet, transaction.type, transaction.amount)
+
     await db.delete(transaction)
     await db.commit()

--- a/backend/app/schemas/dashboard.py
+++ b/backend/app/schemas/dashboard.py
@@ -1,0 +1,23 @@
+from decimal import Decimal
+
+from pydantic import BaseModel
+
+
+class CashFlowPoint(BaseModel):
+    month: str  # chave ano-mês, ex.: "2026-07" (o front formata o rótulo)
+    income: Decimal
+    expenses: Decimal
+
+
+class CategorySlice(BaseModel):
+    category: str
+    total: Decimal
+
+
+class DashboardSummary(BaseModel):
+    month_income: Decimal
+    month_expenses: Decimal
+    prev_month_income: Decimal
+    prev_month_expenses: Decimal
+    cash_flow: list[CashFlowPoint]  # até 6 meses com dados, cronológico
+    top_categories: list[CategorySlice]  # top 5 despesas do mês atual

--- a/backend/app/services/ai_service.py
+++ b/backend/app/services/ai_service.py
@@ -2,7 +2,7 @@ import google.generativeai as genai
 from datetime import datetime, timezone
 from sqlalchemy import select, func
 from sqlalchemy.ext.asyncio import AsyncSession
-from app.database import AsyncSessionLocal, ai_insights_collection
+from app.database import ai_insights_collection
 from app.models.sql_models import Transaction, TransactionType
 from app.services.goal_service import current_month_range
 from app.config import get_settings
@@ -17,50 +17,49 @@ settings = get_settings()
 genai.configure(api_key=settings.gemini_api_key)
 model = genai.GenerativeModel("models/gemini-2.5-flash")
 
-async def _get_user_financial_summary(user_id: str) -> dict:
-    async with AsyncSessionLocal() as db:
-        now = datetime.now(timezone.utc)
-        # Range [início do mês, mês seguinte) como date — mesmo helper de goals,
-        # indexável e sem cast de timezone (antes usava func.extract mês/ano).
-        start, end = current_month_range(now)
+async def _get_user_financial_summary(db: AsyncSession, user_id: str) -> dict:
+    now = datetime.now(timezone.utc)
+    # Range [início do mês, mês seguinte) como date — mesmo helper de goals,
+    # indexável e sem cast de timezone (antes usava func.extract mês/ano).
+    start, end = current_month_range(now)
 
-        # Total de receitas no mês
-        income_result = await db.execute(
-            select(func.sum(Transaction.amount)).where(
-                Transaction.user_id == user_id,
-                Transaction.type == TransactionType.INCOME,
-                Transaction.date >= start,
-                Transaction.date < end,
-            )
+    # Total de receitas no mês
+    income_result = await db.execute(
+        select(func.sum(Transaction.amount)).where(
+            Transaction.user_id == user_id,
+            Transaction.type == TransactionType.INCOME,
+            Transaction.date >= start,
+            Transaction.date < end,
         )
-        total_income = float(income_result.scalar() or 0)
+    )
+    total_income = float(income_result.scalar() or 0)
 
-        # Total de gastos no mês
-        expense_result = await db.execute(
-            select(func.sum(Transaction.amount)).where(
-                Transaction.user_id == user_id,
-                Transaction.type == TransactionType.EXPENSE,
-                Transaction.date >= start,
-                Transaction.date < end,
-            )
+    # Total de gastos no mês
+    expense_result = await db.execute(
+        select(func.sum(Transaction.amount)).where(
+            Transaction.user_id == user_id,
+            Transaction.type == TransactionType.EXPENSE,
+            Transaction.date >= start,
+            Transaction.date < end,
         )
-        total_expenses = float(expense_result.scalar() or 0)
+    )
+    total_expenses = float(expense_result.scalar() or 0)
 
-        # Top 5 categorias de despesas
-        category_result = await db.execute(
-            select(Transaction.category, func.sum(Transaction.amount).label("total"))
-            .where(
-                Transaction.user_id == user_id,
-                Transaction.type == TransactionType.EXPENSE,
-                Transaction.date >= start,
-                Transaction.date < end,
-            )
-            .group_by(Transaction.category)
-            .order_by(func.sum(Transaction.amount).desc())
-            .limit(5)
+    # Top 5 categorias de despesas
+    category_result = await db.execute(
+        select(Transaction.category, func.sum(Transaction.amount).label("total"))
+        .where(
+            Transaction.user_id == user_id,
+            Transaction.type == TransactionType.EXPENSE,
+            Transaction.date >= start,
+            Transaction.date < end,
         )
-        categories = [{"category": r.category, "total": float(r.total)} for r in category_result]
-        
+        .group_by(Transaction.category)
+        .order_by(func.sum(Transaction.amount).desc())
+        .limit(5)
+    )
+    categories = [{"category": r.category, "total": float(r.total)} for r in category_result]
+
     return {
         "month": now.strftime("%B %Y"),
         "total_income": total_income,
@@ -69,7 +68,7 @@ async def _get_user_financial_summary(user_id: str) -> dict:
         "top_categories": categories,
     }
     
-async def get_or_generate_insight(user_id: str, month: int, year: int) -> dict:
+async def get_or_generate_insight(db: AsyncSession, user_id: str, month: int, year: int) -> dict:
     reference = f"{year}-{month:02d}"
 
     # Verifica cache
@@ -79,9 +78,9 @@ async def get_or_generate_insight(user_id: str, month: int, year: int) -> dict:
     if cached:
         cached.pop("_id", None)
         return cached
-    
-    # Busca dados fincaneiros
-    summary = await _get_user_financial_summary(user_id)
+
+    # Busca dados financeiros
+    summary = await _get_user_financial_summary(db, user_id)
 
     # Chama o Gemini
     prompt = f"""
@@ -133,9 +132,9 @@ async def get_or_generate_insight(user_id: str, month: int, year: int) -> dict:
     insight.pop("_id", None)
     return insight
 
-async def chat_with_ai(user_id: str, message: str, history: list) -> str:
-    """ Chat contextualizado com dados fincaneiros do usuário """
-    summary = await _get_user_financial_summary(user_id)
+async def chat_with_ai(db: AsyncSession, user_id: str, message: str, history: list) -> str:
+    """ Chat contextualizado com dados financeiros do usuário """
+    summary = await _get_user_financial_summary(db, user_id)
 
     system_context = f"""
     Você é o Norby, um assistente financeiro inteligente e amigável. Responda sempre em português (pt-BR).
@@ -148,11 +147,15 @@ async def chat_with_ai(user_id: str, message: str, history: list) -> str:
     Seja direto, útil e use os dados para personalizar suas respostas.
     """
     
-    # Monta histórico no formato do Gemini
+    # Monta histórico no formato do Gemini. Usa .get() porque um doc antigo ou
+    # malformado no Mongo (sem role/content) não deve derrubar o chat inteiro.
     chat_history = []
     for msg in history[-10:]: # Últimas 10 mensagens para não estourar contexto
-        role = "user" if msg["role"] == "user" else "model"
-        chat_history.append({"role": role, "parts": [msg["content"]]})
+        content = msg.get("content")
+        if not content:
+            continue
+        role = "user" if msg.get("role") == "user" else "model"
+        chat_history.append({"role": role, "parts": [content]})
         
     chat = model.start_chat(history=chat_history)
     # Chamada bloqueante do SDK -> offload p/ thread

--- a/backend/app/services/ai_service.py
+++ b/backend/app/services/ai_service.py
@@ -4,6 +4,7 @@ from sqlalchemy import select, func
 from sqlalchemy.ext.asyncio import AsyncSession
 from app.database import AsyncSessionLocal, ai_insights_collection
 from app.models.sql_models import Transaction, TransactionType
+from app.services.goal_service import current_month_range
 from app.config import get_settings
 import asyncio
 import json
@@ -19,37 +20,40 @@ model = genai.GenerativeModel("models/gemini-2.5-flash")
 async def _get_user_financial_summary(user_id: str) -> dict:
     async with AsyncSessionLocal() as db:
         now = datetime.now(timezone.utc)
+        # Range [início do mês, mês seguinte) como date — mesmo helper de goals,
+        # indexável e sem cast de timezone (antes usava func.extract mês/ano).
+        start, end = current_month_range(now)
 
         # Total de receitas no mês
         income_result = await db.execute(
             select(func.sum(Transaction.amount)).where(
                 Transaction.user_id == user_id,
                 Transaction.type == TransactionType.INCOME,
-                func.extract("month", Transaction.date) == now.month,
-                func.extract("year", Transaction.date) == now.year,
+                Transaction.date >= start,
+                Transaction.date < end,
             )
         )
         total_income = float(income_result.scalar() or 0)
-        
+
         # Total de gastos no mês
         expense_result = await db.execute(
             select(func.sum(Transaction.amount)).where(
                 Transaction.user_id == user_id,
                 Transaction.type == TransactionType.EXPENSE,
-                func.extract("month", Transaction.date) == now.month,
-                func.extract("year", Transaction.date) == now.year,
+                Transaction.date >= start,
+                Transaction.date < end,
             )
         )
         total_expenses = float(expense_result.scalar() or 0)
-        
+
         # Top 5 categorias de despesas
         category_result = await db.execute(
             select(Transaction.category, func.sum(Transaction.amount).label("total"))
             .where(
                 Transaction.user_id == user_id,
                 Transaction.type == TransactionType.EXPENSE,
-                func.extract("month", Transaction.date) == now.month,
-                func.extract("year", Transaction.date) == now.year,
+                Transaction.date >= start,
+                Transaction.date < end,
             )
             .group_by(Transaction.category)
             .order_by(func.sum(Transaction.amount).desc())

--- a/backend/app/services/dashboard_service.py
+++ b/backend/app/services/dashboard_service.py
@@ -1,0 +1,89 @@
+"""Resumo agregado do Dashboard, calculado no Postgres.
+
+O Dashboard antes montava KPIs, fluxo de caixa e categorias no cliente, em cima
+das 200 transações mais recentes que a listagem devolvia — para usuário ativo os
+números ficavam errados sem aviso. Aqui a agregação é feita no banco, sobre todas
+as transações do usuário.
+"""
+from datetime import date, timedelta
+from decimal import Decimal
+
+from sqlalchemy import select, func, case
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.sql_models import Transaction, TransactionType
+from app.schemas.dashboard import CashFlowPoint, CategorySlice, DashboardSummary
+from app.services.goal_service import current_month_range
+
+CASH_FLOW_MONTHS = 6
+TOP_CATEGORIES = 5
+
+# Soma condicional por tipo, reutilizada nos agregados.
+_income_sum = func.coalesce(
+    func.sum(case((Transaction.type == TransactionType.INCOME, Transaction.amount), else_=0)), 0
+)
+_expense_sum = func.coalesce(
+    func.sum(case((Transaction.type == TransactionType.EXPENSE, Transaction.amount), else_=0)), 0
+)
+
+
+async def _income_expense(db: AsyncSession, user_id, start: date, end: date) -> tuple[Decimal, Decimal]:
+    row = (await db.execute(
+        select(_income_sum.label("income"), _expense_sum.label("expenses")).where(
+            Transaction.user_id == user_id,
+            Transaction.date >= start,
+            Transaction.date < end,
+        )
+    )).one()
+    return Decimal(str(row.income)), Decimal(str(row.expenses))
+
+
+async def get_dashboard_summary(db: AsyncSession, user_id) -> DashboardSummary:
+    start, end = current_month_range()
+    prev_start, _ = current_month_range(start - timedelta(days=1))
+
+    month_income, month_expenses = await _income_expense(db, user_id, start, end)
+    prev_month_income, prev_month_expenses = await _income_expense(db, user_id, prev_start, start)
+
+    # Fluxo de caixa: agrupa por mês sobre TODAS as transações, pega os 6 últimos
+    # meses com dados (desc + limit) e devolve em ordem cronológica.
+    month_col = func.date_trunc("month", Transaction.date)
+    cash_rows = (await db.execute(
+        select(
+            month_col.label("m"),
+            _income_sum.label("income"),
+            _expense_sum.label("expenses"),
+        )
+        .where(Transaction.user_id == user_id)
+        .group_by(month_col)
+        .order_by(month_col.desc())
+        .limit(CASH_FLOW_MONTHS)
+    )).all()
+    cash_flow = [
+        CashFlowPoint(month=r.m.strftime("%Y-%m"), income=r.income, expenses=r.expenses)
+        for r in reversed(cash_rows)
+    ]
+
+    # Top categorias de despesa do mês atual.
+    cat_rows = (await db.execute(
+        select(Transaction.category, func.sum(Transaction.amount).label("total"))
+        .where(
+            Transaction.user_id == user_id,
+            Transaction.type == TransactionType.EXPENSE,
+            Transaction.date >= start,
+            Transaction.date < end,
+        )
+        .group_by(Transaction.category)
+        .order_by(func.sum(Transaction.amount).desc())
+        .limit(TOP_CATEGORIES)
+    )).all()
+    top_categories = [CategorySlice(category=r.category, total=r.total) for r in cat_rows]
+
+    return DashboardSummary(
+        month_income=month_income,
+        month_expenses=month_expenses,
+        prev_month_income=prev_month_income,
+        prev_month_expenses=prev_month_expenses,
+        cash_flow=cash_flow,
+        top_categories=top_categories,
+    )

--- a/backend/app/services/goal_service.py
+++ b/backend/app/services/goal_service.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 from decimal import Decimal
 
 from sqlalchemy import select, func
@@ -7,13 +7,19 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.models.sql_models import Transaction, TransactionType, Goal, GoalType
 
 
-def current_month_range(now: datetime | None = None):
+def current_month_range(now: date | datetime | None = None) -> tuple[date, date]:
+    """Intervalo [início do mês, início do mês seguinte) da referência, como `date`.
+
+    Retorna `date` (não `datetime` tz-aware) de propósito: `Transaction.date` é uma
+    coluna DATE, e comparar date-com-date evita o cast implícito para timestamptz no
+    timezone da sessão do Postgres. Aceita datetime, date ou None (usa agora, UTC).
+    """
     now = now or datetime.now(timezone.utc)
-    start = datetime(now.year, now.month, 1, tzinfo=timezone.utc)
+    start = date(now.year, now.month, 1)
     if now.month == 12:
-        end = datetime(now.year + 1, 1, 1, tzinfo=timezone.utc)
+        end = date(now.year + 1, 1, 1)
     else:
-        end = datetime(now.year, now.month + 1, 1, tzinfo=timezone.utc)
+        end = date(now.year, now.month + 1, 1)
     return start, end
 
 

--- a/backend/app/services/goal_service.py
+++ b/backend/app/services/goal_service.py
@@ -5,6 +5,7 @@ from sqlalchemy import select, func
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.sql_models import Transaction, TransactionType, Goal, GoalType
+from app.schemas.goal import GoalResponse
 
 
 def current_month_range(now: date | datetime | None = None) -> tuple[date, date]:
@@ -37,7 +38,7 @@ async def month_spent(db: AsyncSession, user_id, category: str) -> Decimal:
     return Decimal(str(total))
 
 
-async def build_goal_response(db: AsyncSession, goal: Goal) -> dict:
+async def build_goal_response(db: AsyncSession, goal: Goal) -> GoalResponse:
     if goal.type == GoalType.SAVINGS:
         current = goal.current_amount
     else:
@@ -45,15 +46,15 @@ async def build_goal_response(db: AsyncSession, goal: Goal) -> dict:
 
     target = goal.target_amount
     progress = float(current / target * 100) if target and target > 0 else 0.0
-    return {
-        "id": goal.id,
-        "name": goal.name,
-        "type": goal.type,
-        "target_amount": target,
-        "current_amount": current,
-        "category": goal.category,
-        "deadline": goal.deadline,
-        "created_at": goal.created_at,
-        "progress_pct": round(progress, 1),
-        "remaining": target - current,
-    }
+    return GoalResponse(
+        id=goal.id,
+        name=goal.name,
+        type=goal.type,
+        target_amount=target,
+        current_amount=current,
+        category=goal.category,
+        deadline=goal.deadline,
+        created_at=goal.created_at,
+        progress_pct=round(progress, 1),
+        remaining=target - current,
+    )

--- a/backend/app/services/recurring_service.py
+++ b/backend/app/services/recurring_service.py
@@ -4,8 +4,9 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.sql_models import (
-    User, Wallet, RecurringTransaction, RecurrenceFrequency, Transaction, TransactionType
+    User, Wallet, RecurringTransaction, RecurrenceFrequency, Transaction
 )
+from app.services.transaction_service import apply_delta
 
 
 def add_one_month(d: datetime) -> datetime:
@@ -68,10 +69,7 @@ async def materialize_due_recurring(db: AsyncSession, user: User) -> int:
                 date=tpl.next_run_date.date(),
             ))
             if wallet is not None:
-                if tpl.type == TransactionType.INCOME:
-                    wallet.balance += tpl.amount
-                else:
-                    wallet.balance -= tpl.amount
+                apply_delta(wallet, tpl.type, tpl.amount)
             tpl.next_run_date = advance(tpl.next_run_date, tpl.frequency)
             generated += 1
 

--- a/backend/app/services/transaction_service.py
+++ b/backend/app/services/transaction_service.py
@@ -1,0 +1,24 @@
+"""Regra de saldo das transações, centralizada.
+
+O efeito de uma transação no saldo da carteira (INCOME soma, EXPENSE subtrai) é
+a regra de negócio central do app. Ela aparecia duplicada em create/update/delete
+no router e na materialização de recorrências. Aqui vive em um único lugar.
+"""
+from decimal import Decimal
+
+from app.models.sql_models import TransactionType, Wallet
+
+
+def signed_delta(type_: TransactionType, amount: Decimal) -> Decimal:
+    """Delta com sinal: positivo para INCOME, negativo para EXPENSE."""
+    return amount if type_ == TransactionType.INCOME else -amount
+
+
+def apply_delta(wallet: Wallet, type_: TransactionType, amount: Decimal) -> None:
+    """Aplica o efeito da transação no saldo da carteira."""
+    wallet.balance += signed_delta(type_, amount)
+
+
+def revert_delta(wallet: Wallet, type_: TransactionType, amount: Decimal) -> None:
+    """Desfaz o efeito de uma transação já aplicada no saldo."""
+    wallet.balance -= signed_delta(type_, amount)

--- a/backend/tests/test_ai.py
+++ b/backend/tests/test_ai.py
@@ -1,0 +1,31 @@
+import uuid
+from decimal import Decimal
+
+import pytest
+
+import app.services.ai_service as ai
+from app.models.sql_models import User, Wallet
+
+
+class _FakeChat:
+    def send_message(self, _message):
+        class _Resp:
+            text = "resposta ok"
+        return _Resp()
+
+
+@pytest.mark.asyncio
+async def test_chat_survives_malformed_history_message(db_session, monkeypatch):
+    # Um doc antigo/malformado no Mongo (sem role/content) não pode derrubar o chat.
+    user = User(name="Al", email=f"al_{uuid.uuid4().hex[:8]}@t.com", password_hash="x")
+    db_session.add(user)
+    await db_session.flush()
+    db_session.add(Wallet(user_id=user.id, name="Main", balance=Decimal("0")))
+    await db_session.commit()
+
+    # Não bate na API real do Gemini.
+    monkeypatch.setattr(ai.model, "start_chat", lambda history: _FakeChat())
+
+    history = [{"foo": "bar"}, {"role": "user", "content": "oi"}]  # 1ª é malformada
+    resp = await ai.chat_with_ai(db_session, str(user.id), "olá", history)
+    assert resp == "resposta ok"

--- a/backend/tests/test_dashboard.py
+++ b/backend/tests/test_dashboard.py
@@ -1,0 +1,69 @@
+import uuid
+from datetime import datetime, timezone
+from decimal import Decimal
+
+import pytest
+
+from app.models.sql_models import User, Wallet, Transaction, TransactionType
+from app.services.auth_service import create_access_token
+
+
+def _month_start(ref, n_back):
+    total = ref.year * 12 + (ref.month - 1) - n_back
+    return ref.replace(year=total // 12, month=total % 12 + 1, day=1)
+
+
+@pytest.mark.asyncio
+async def test_dashboard_summary_aggregates_over_all_transactions(db_session, client):
+    # Semeia >200 transações no mês atual: o Dashboard antigo cortava em 200 e
+    # agregava errado no cliente. O endpoint agrega no Postgres, sem cap.
+    user = User(name="Al", email=f"al_{uuid.uuid4().hex[:8]}@t.com", password_hash="x")
+    db_session.add(user)
+    await db_session.flush()
+    wallet = Wallet(user_id=user.id, name="Main", balance=Decimal("0"))
+    db_session.add(wallet)
+    await db_session.commit()
+
+    today = datetime.now(timezone.utc).date()
+    cur = today.replace(day=1)
+    prev1 = _month_start(cur, 1)
+
+    txs = [
+        Transaction(user_id=user.id, wallet_id=wallet.id, type=TransactionType.EXPENSE,
+                    amount=Decimal("10"), category="Food", date=cur)
+        for _ in range(250)
+    ]
+    txs.append(Transaction(user_id=user.id, wallet_id=wallet.id, type=TransactionType.INCOME,
+                           amount=Decimal("500"), category="Salary", date=cur))
+    txs.append(Transaction(user_id=user.id, wallet_id=wallet.id, type=TransactionType.EXPENSE,
+                           amount=Decimal("100"), category="Rent", date=prev1))
+    db_session.add_all(txs)
+    await db_session.commit()
+
+    token = create_access_token(str(user.id))
+    res = await client.get("/dashboard/summary", headers={"Authorization": f"Bearer {token}"})
+    assert res.status_code == 200, res.text
+    body = res.json()
+
+    # KPIs do mês atual — 250 despesas de 10 = 2500 (prova que não capa em 200).
+    assert float(body["month_expenses"]) == 2500.0
+    assert float(body["month_income"]) == 500.0
+    assert float(body["prev_month_expenses"]) == 100.0
+    assert float(body["prev_month_income"]) == 0.0
+
+    # Fluxo de caixa: 2 meses com dados, cronológico, mês atual por último.
+    assert len(body["cash_flow"]) == 2
+    assert body["cash_flow"][-1]["month"] == cur.strftime("%Y-%m")
+    assert float(body["cash_flow"][-1]["expenses"]) == 2500.0
+    assert float(body["cash_flow"][-1]["income"]) == 500.0
+    assert body["cash_flow"][0]["month"] == prev1.strftime("%Y-%m")
+
+    # Top categorias do mês: Food domina com 2500.
+    assert body["top_categories"][0]["category"] == "Food"
+    assert float(body["top_categories"][0]["total"]) == 2500.0
+
+
+@pytest.mark.asyncio
+async def test_dashboard_summary_requires_auth(client):
+    res = await client.get("/dashboard/summary")
+    assert res.status_code == 401

--- a/backend/tests/test_goals.py
+++ b/backend/tests/test_goals.py
@@ -1,6 +1,6 @@
 import pytest
 import uuid
-from datetime import datetime, timezone
+from datetime import date, datetime, timedelta, timezone
 from decimal import Decimal
 
 from pydantic import ValidationError
@@ -31,6 +31,29 @@ async def test_savings_progress_uses_current_amount(db_session):
     assert view["current_amount"] == Decimal("250")
     assert view["progress_pct"] == 25.0
     assert view["remaining"] == Decimal("750")
+
+
+@pytest.mark.asyncio
+async def test_month_spent_includes_month_boundaries(db_session):
+    # Guard de borda: o gasto do dia 1 e do último dia do mês entram no total;
+    # o do último dia do mês anterior fica de fora. Comparando date-com-date,
+    # o limite é exato e independe do timezone da sessão do banco.
+    user, wallet = await _seed(db_session)
+    start, end = current_month_range()
+    first_day = start
+    last_day = end - timedelta(days=1)
+    prev_month_last_day = start - timedelta(days=1)
+    db_session.add_all([
+        Transaction(user_id=user.id, wallet_id=wallet.id, type=TransactionType.EXPENSE,
+                    amount=Decimal("10"), category="Food", date=first_day),
+        Transaction(user_id=user.id, wallet_id=wallet.id, type=TransactionType.EXPENSE,
+                    amount=Decimal("20"), category="Food", date=last_day),
+        Transaction(user_id=user.id, wallet_id=wallet.id, type=TransactionType.EXPENSE,
+                    amount=Decimal("99"), category="Food", date=prev_month_last_day),
+    ])
+    await db_session.commit()
+    total = await month_spent(db_session, user.id, "Food")
+    assert total == Decimal("30")  # 10 + 20; o do mês anterior fica de fora
 
 
 @pytest.mark.asyncio
@@ -162,5 +185,16 @@ def test_contribute_zero_raises():
 
 
 def test_current_month_range_december_rollover():
-    _, end = current_month_range(datetime(2025, 12, 15, tzinfo=timezone.utc))
-    assert end == datetime(2026, 1, 1, tzinfo=timezone.utc)
+    start, end = current_month_range(datetime(2025, 12, 15, tzinfo=timezone.utc))
+    assert start == date(2025, 12, 1)
+    assert end == date(2026, 1, 1)
+
+
+def test_current_month_range_returns_date_not_datetime():
+    # Comparar coluna DATE com date (não datetime tz-aware) elimina o cast
+    # implícito no timezone da sessão do Postgres — a correção de raiz da suspeita
+    # de borda de mês em metas BUDGET.
+    start, end = current_month_range(datetime(2026, 7, 15, tzinfo=timezone.utc))
+    assert type(start) is date and type(end) is date
+    assert start == date(2026, 7, 1)
+    assert end == date(2026, 8, 1)

--- a/backend/tests/test_goals.py
+++ b/backend/tests/test_goals.py
@@ -28,9 +28,9 @@ async def test_savings_progress_uses_current_amount(db_session):
     db_session.add(goal)
     await db_session.commit()
     view = await build_goal_response(db_session, goal)
-    assert view["current_amount"] == Decimal("250")
-    assert view["progress_pct"] == 25.0
-    assert view["remaining"] == Decimal("750")
+    assert view.current_amount == Decimal("250")
+    assert view.progress_pct == 25.0
+    assert view.remaining == Decimal("750")
 
 
 @pytest.mark.asyncio
@@ -74,8 +74,8 @@ async def test_budget_progress_sums_month_expenses(db_session):
     db_session.add(goal)
     await db_session.commit()
     view = await build_goal_response(db_session, goal)
-    assert view["current_amount"] == Decimal("120")
-    assert view["progress_pct"] == 40.0
+    assert view.current_amount == Decimal("120")
+    assert view.progress_pct == 40.0
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_transaction_service.py
+++ b/backend/tests/test_transaction_service.py
@@ -1,0 +1,12 @@
+from decimal import Decimal
+
+from app.models.sql_models import TransactionType
+from app.services.transaction_service import signed_delta
+
+
+def test_signed_delta_income_is_positive():
+    assert signed_delta(TransactionType.INCOME, Decimal("30.00")) == Decimal("30.00")
+
+
+def test_signed_delta_expense_is_negative():
+    assert signed_delta(TransactionType.EXPENSE, Decimal("30.00")) == Decimal("-30.00")

--- a/backend/tests/test_transactions.py
+++ b/backend/tests/test_transactions.py
@@ -1,3 +1,5 @@
+import asyncio
+
 import pytest
 
 
@@ -89,6 +91,27 @@ async def test_user_cannot_update_other_users_tx(make_auth_client):
     tx = (await alice.post("/transactions/", json=tx_payload(w["id"]))).json()
     res = await bob.put(f"/transactions/{tx['id']}", json={"amount": "1.00"})
     assert res.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_concurrent_transactions_do_not_lose_wallet_balance_updates(make_auth_client):
+    # Duas transações simultâneas na MESMA carteira: sem lock (with_for_update),
+    # ambas leem o saldo antigo e a última sobrescreve a outra (lost update).
+    # Cada request usa sua própria sessão/transação (_override_get_db), então o
+    # gather abre duas transações concorrentes de verdade no Postgres.
+    ac = await make_auth_client("Alice")
+    w = await make_wallet(ac, balance=100)
+
+    res_a, res_b = await asyncio.gather(
+        ac.post("/transactions/", json=tx_payload(w["id"], amount="30.00")),
+        ac.post("/transactions/", json=tx_payload(w["id"], amount="30.00")),
+    )
+    assert res_a.status_code == 201, res_a.text
+    assert res_b.status_code == 201, res_b.text
+
+    wallets = (await ac.get("/wallets/")).json()
+    # 100 - 30 - 30 = 40. Sem o lock, o saldo ficaria em 70 (uma das saídas some).
+    assert float(wallets[0]["balance"]) == 40.0
 
 
 @pytest.mark.asyncio

--- a/frontend/src/api/dashboard.js
+++ b/frontend/src/api/dashboard.js
@@ -1,0 +1,5 @@
+import api from "./axios";
+
+export const dashboardApi = {
+    summary: () => api.get("/dashboard/summary"),
+};

--- a/frontend/src/lib/utils.js
+++ b/frontend/src/lib/utils.js
@@ -20,6 +20,21 @@ export function formatDateBR(value) {
   return `${day}/${month}/${year}`;
 }
 
+/**
+ * Converte uma data de calendário (ISO da API) num Date em horário LOCAL.
+ *
+ * Para agrupar/filtrar transações por mês precisamos de um Date, mas
+ * `new Date("2026-07-01")` é interpretado como meia-noite UTC — em UTC-3
+ * (Brasil) `.getMonth()` devolve o mês anterior. Aqui lemos ano/mês/dia da
+ * string e construímos o Date já em horário local, sem qualquer conversão de
+ * fuso (mesmo cuidado de `formatDateBR`). Retorna null para entrada vazia.
+ */
+export function parseDateOnly(value) {
+  if (!value) return null;
+  const [year, month, day] = String(value).slice(0, 10).split("-").map(Number);
+  return new Date(year, month - 1, day);
+}
+
 /** Parte de data (YYYY-MM-DD) de um ISO da API, para inputs type="date". */
 export function toDateInput(value) {
   if (!value) return "";

--- a/frontend/src/lib/utils.test.js
+++ b/frontend/src/lib/utils.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { formatDateBR, toDateInput } from "./utils";
+import { formatDateBR, toDateInput, parseDateOnly } from "./utils";
 
 describe("formatDateBR", () => {
   it("formats an ISO date-only string without timezone shift", () => {
@@ -16,6 +16,30 @@ describe("formatDateBR", () => {
   it("returns empty string for nullish input", () => {
     expect(formatDateBR(null)).toBe("");
     expect(formatDateBR(undefined)).toBe("");
+  });
+});
+
+describe("parseDateOnly", () => {
+  it("builds a LOCAL date from a date-only string, without UTC shift", () => {
+    // new Date("2026-07-01") seria meia-noite UTC → em UTC-3 cairia em 30/06
+    // (mês 5). O helper deve devolver 01/07 (mês 6) em horário LOCAL, seja
+    // qual for o fuso da máquina que roda o teste.
+    const d = parseDateOnly("2026-07-01");
+    expect(d.getFullYear()).toBe(2026);
+    expect(d.getMonth()).toBe(6); // julho (0-indexado)
+    expect(d.getDate()).toBe(1);
+  });
+
+  it("ignores a datetime suffix and uses only the calendar date", () => {
+    const d = parseDateOnly("2026-07-01T00:00:00Z");
+    expect(d.getFullYear()).toBe(2026);
+    expect(d.getMonth()).toBe(6);
+    expect(d.getDate()).toBe(1);
+  });
+
+  it("returns null for nullish input", () => {
+    expect(parseDateOnly(null)).toBeNull();
+    expect(parseDateOnly(undefined)).toBeNull();
   });
 });
 

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -27,8 +27,24 @@ import { transactionsApi } from "@/api/transactions";
 import { walletsApi } from "@/api/wallets";
 import { aiApi } from "@/api/ai";
 import { recurringApi } from "@/api/recurring";
+import { dashboardApi } from "@/api/dashboard";
 import { Button } from "@/components/ui/button";
-import { formatDateBR, parseDateOnly } from "@/lib/utils";
+import { formatDateBR } from "@/lib/utils";
+
+// Rótulo curto pt-BR de uma chave ano-mês ("2026-07" → "jul"), em horário local.
+const monthLabel = (ym) => {
+  const [y, m] = ym.split("-").map(Number);
+  return new Date(y, m - 1, 1).toLocaleString("pt-BR", { month: "short" });
+};
+
+const EMPTY_SUMMARY = {
+  month_income: 0,
+  month_expenses: 0,
+  prev_month_income: 0,
+  prev_month_expenses: 0,
+  cash_flow: [],
+  top_categories: [],
+};
 
 // Paleta categórica de hues distintos (resolve o "2 cores parecidas" do donut)
 const CATEGORY_COLORS = [
@@ -79,6 +95,7 @@ function ChartTooltip({ active, payload, label }) {
 export default function Dashboard() {
   const [wallets, setWallets] = useState([]);
   const [transactions, setTransactions] = useState([]);
+  const [summary, setSummary] = useState(null);
   const [insight, setInsight] = useState(null);
   const [loading, setLoading] = useState(true);
   const navigate = useNavigate();
@@ -86,88 +103,50 @@ export default function Dashboard() {
   useEffect(() => {
     async function loadData() {
       await recurringApi.run().catch(() => {}); // materializa recorrências vencidas
-      // allSettled: falha da IA (insight) não derruba wallets/transactions
-      const [wRes, tRes, iRes] = await Promise.allSettled([
+      // allSettled: falha da IA (insight) não derruba os demais painéis
+      const [wRes, tRes, sRes, iRes] = await Promise.allSettled([
         walletsApi.list(),
         transactionsApi.list(),
+        dashboardApi.summary(),
         aiApi.getInsight(),
       ]);
       if (wRes.status === "fulfilled") setWallets(wRes.value.data);
       if (tRes.status === "fulfilled") setTransactions(tRes.value.data);
+      if (sRes.status === "fulfilled") setSummary(sRes.value.data);
       if (iRes.status === "fulfilled") setInsight(iRes.value.data);
       setLoading(false);
     }
     loadData();
   }, []);
 
-  // --- Recortes de tempo: mês atual e mês anterior ---
-  const now = new Date();
-  const curY = now.getFullYear();
-  const curM = now.getMonth();
-  const prevDate = new Date(curY, curM - 1, 1);
-  const prevY = prevDate.getFullYear();
-  const prevM = prevDate.getMonth();
-
-  const inMonth = (dateStr, y, m) => {
-    const d = parseDateOnly(dateStr);
-    return d.getFullYear() === y && d.getMonth() === m;
-  };
-  const sumBy = (list, type) =>
-    list
-      .filter((t) => t.type === type)
-      .reduce((s, t) => s + parseFloat(t.amount), 0);
   const pctChange = (curr, prev) =>
     prev > 0 ? ((curr - prev) / prev) * 100 : undefined;
 
   // Saldo atual = soma das carteiras (estado real, não recorte de mês)
   const totalBalance = wallets.reduce((s, w) => s + parseFloat(w.balance), 0);
 
-  // KPIs do MÊS atual + variação real vs mês anterior
-  const monthTx = transactions.filter((t) => inMonth(t.date, curY, curM));
-  const prevTx = transactions.filter((t) => inMonth(t.date, prevY, prevM));
-  const monthIncome = sumBy(monthTx, "INCOME");
-  const monthExpenses = sumBy(monthTx, "EXPENSE");
-  const incomeChange = pctChange(monthIncome, sumBy(prevTx, "INCOME"));
-  const expensesChange = pctChange(monthExpenses, sumBy(prevTx, "EXPENSE"));
+  // KPIs, fluxo e categorias vêm agregados do backend (sobre TODAS as transações,
+  // sem o cap de 200 da listagem). O front só formata para os gráficos.
+  const s = summary || EMPTY_SUMMARY;
+  const monthIncome = parseFloat(s.month_income);
+  const monthExpenses = parseFloat(s.month_expenses);
+  const incomeChange = pctChange(monthIncome, parseFloat(s.prev_month_income));
+  const expensesChange = pctChange(monthExpenses, parseFloat(s.prev_month_expenses));
   const monthNet = monthIncome - monthExpenses;
 
-  // Fluxo de caixa: agrupa por ANO-MÊS (não mistura anos), ordena e pega os últimos 6
-  const cashFlowData = (() => {
-    const map = {};
-    transactions.forEach((t) => {
-      const d = parseDateOnly(t.date);
-      const key = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}`;
-      if (!map[key]) {
-        map[key] = {
-          key,
-          month: d.toLocaleString("pt-BR", { month: "short" }),
-          Entradas: 0,
-          Saídas: 0,
-        };
-      }
-      if (t.type === "INCOME") map[key].Entradas += parseFloat(t.amount);
-      if (t.type === "EXPENSE") map[key].Saídas += parseFloat(t.amount);
-    });
-    return Object.values(map)
-      .sort((a, b) => a.key.localeCompare(b.key))
-      .slice(-6);
-  })();
+  const cashFlowData = s.cash_flow.map((p) => ({
+    key: p.month,
+    month: monthLabel(p.month),
+    Entradas: parseFloat(p.income),
+    Saídas: parseFloat(p.expenses),
+  }));
 
-  // Categorias de despesa DO MÊS atual (já ordenado desc → maior fatia às 12h)
-  const categoryData = Object.values(
-    monthTx
-      .filter((t) => t.type === "EXPENSE")
-      .reduce((acc, t) => {
-        const key = t.category;
-        if (!acc[key]) acc[key] = { name: key, value: 0 };
-        acc[key].value += parseFloat(t.amount);
-        return acc;
-      }, {}),
-  )
-    .sort((a, b) => b.value - a.value)
-    .slice(0, 5);
+  const categoryData = s.top_categories.map((c) => ({
+    name: c.category,
+    value: parseFloat(c.total),
+  }));
 
-  const categoryTotal = categoryData.reduce((s, c) => s + c.value, 0);
+  const categoryTotal = categoryData.reduce((sum, c) => sum + c.value, 0);
 
   if (loading) {
     return (

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -28,7 +28,7 @@ import { walletsApi } from "@/api/wallets";
 import { aiApi } from "@/api/ai";
 import { recurringApi } from "@/api/recurring";
 import { Button } from "@/components/ui/button";
-import { formatDateBR } from "@/lib/utils";
+import { formatDateBR, parseDateOnly } from "@/lib/utils";
 
 // Paleta categórica de hues distintos (resolve o "2 cores parecidas" do donut)
 const CATEGORY_COLORS = [
@@ -109,7 +109,7 @@ export default function Dashboard() {
   const prevM = prevDate.getMonth();
 
   const inMonth = (dateStr, y, m) => {
-    const d = new Date(dateStr);
+    const d = parseDateOnly(dateStr);
     return d.getFullYear() === y && d.getMonth() === m;
   };
   const sumBy = (list, type) =>
@@ -135,7 +135,7 @@ export default function Dashboard() {
   const cashFlowData = (() => {
     const map = {};
     transactions.forEach((t) => {
-      const d = new Date(t.date);
+      const d = parseDateOnly(t.date);
       const key = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}`;
       if (!map[key]) {
         map[key] = {


### PR DESCRIPTION
Release da rodada de correções pós-review, validada na branch `staging`
(66 testes backend + 15 frontend verdes; Dashboard conferido visualmente).

## Ondas
- **Onda 1** — timezone shift na agregação do Dashboard (`parseDateOnly`) +
  bcrypt fora do event loop (`asyncio.to_thread`).
- **Onda 2** — `transaction_service` (regra de saldo centralizada) + lock
  `with_for_update` nas carteiras (corrige lost-update em writes concorrentes).
- **Onda 3** — `current_month_range` retorna `date` (fim do cast de timezone em
  metas BUDGET); month range consolidado em um helper.
- **Onda 4** — `GET /dashboard/summary` agrega no Postgres sobre TODAS as
  transações (antes o Dashboard agregava só as 200 mais recentes → números
  errados). Frontend passa a consumir o resumo.
- **Onda 5** — DI no `ai_service` (recebe `db`); `build_goal_response` retorna
  `GoalResponse`; `chat_with_ai` valida history do Mongo com `.get()`.

## Verificação
- Backend: `pytest` no container → **66 passed** (TDD: cada correção de dados
  com teste que falha sem o fix).
- Frontend: `vitest` → **15 passed**; lint dos arquivos alterados limpo; build ok.
- Validação visual do Dashboard na staging: renderiza do endpoint novo, sem
  erros de console, datas sem shift.

## Deploy
Merge dispara auto-deploy: Render (backend, novo `/dashboard/summary`) + Vercel
(frontend). Nenhuma migration nova (nada altera schema).

## Fora desta rodada (adiado)
J-L (response_model nas rotas de IA, OpenAPI de erros, exception handler/logging,
paginação real) e M-R (qualidade de frontend / cosmético).