### PR TITLE
Correções pós-review (A-R): 10 ondas — dados, arquitetura, produção e qualidade

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1,4 +1,4 @@
-from pydantic_settings import BaseSettings
+from pydantic_settings import BaseSettings, SettingsConfigDict
 from functools import lru_cache
 from urllib.parse import urlsplit, urlunsplit, parse_qsl, urlencode
 
@@ -19,9 +19,7 @@ class Settings(BaseSettings):
     # CORS — origens permitidas (separadas por vírgula). Default cobre o dev local.
     cors_origins: str = "http://localhost:5173"
 
-    class Config:
-        env_file = "../.env"
-        extra = "ignore"
+    model_config = SettingsConfigDict(env_file="../.env", extra="ignore")
 
     @property
     def cors_origins_list(self) -> list[str]:

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -57,6 +57,6 @@ class Settings(BaseSettings):
                 return value not in ("disable", "allow")
         return False
 
-@lru_cache()  # Lê o env só uma vez depois reutiliza pra melhorar a perfomance
+@lru_cache()  # Lê o env só uma vez depois reutiliza pra melhorar a performance
 def get_settings() -> Settings:
     return Settings()

--- a/backend/app/dependencies.py
+++ b/backend/app/dependencies.py
@@ -44,7 +44,7 @@ async def get_current_user( # Autenticação
     except (JWTError, ValueError, TypeError):
         raise credentials_exception
 
-    result = await db.execute(select(User).where(User.id == user_uuid)) # Buscca usuário no banco
+    result = await db.execute(select(User).where(User.id == user_uuid)) # Busca usuário no banco
     user = result.scalar_one_or_none()
     if user is None:
         raise credentials_exception

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,10 +1,35 @@
-from fastapi import FastAPI
+import logging
+import uuid
+from contextvars import ContextVar
+
+from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
 from slowapi import _rate_limit_exceeded_handler
 from slowapi.errors import RateLimitExceeded
 from app.routers import auth, wallets, transactions, ai, recurring, goals, dashboard
 from app.config import get_settings
 from app.limiter import limiter
+
+# --- Logging com request-id para correlacionar os logs de uma requisição ---
+request_id_ctx: ContextVar[str] = ContextVar("request_id", default="-")
+
+
+class _RequestIdFilter(logging.Filter):
+    def filter(self, record: logging.LogRecord) -> bool:
+        record.request_id = request_id_ctx.get()
+        return True
+
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s [%(request_id)s] %(name)s: %(message)s",
+    force=True,  # garante nossa config mesmo quando o uvicorn já configurou o root
+)
+for _handler in logging.getLogger().handlers:
+    _handler.addFilter(_RequestIdFilter())
+
+logger = logging.getLogger("norby")
 
 settings = get_settings()
 
@@ -17,6 +42,28 @@ app = FastAPI(
 # Rate limiting (anti brute-force). Respostas 429 passam pelo CORS normalmente.
 app.state.limiter = limiter
 app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
+
+
+# Request-id + captura de exceções não tratadas. Registrado ANTES do CORS para que
+# o CORS fique por fora: assim o 500 gerado aqui ainda recebe os headers de CORS
+# (senão o navegador mascara o erro real como falha de CORS).
+@app.middleware("http")
+async def request_context(request: Request, call_next):
+    rid = request.headers.get("X-Request-ID") or uuid.uuid4().hex
+    token = request_id_ctx.set(rid)
+    request.state.request_id = rid
+    try:
+        response = await call_next(request)
+    except Exception:
+        logger.exception("Erro não tratado")
+        response = JSONResponse(
+            status_code=500, content={"detail": "Erro interno do servidor"}
+        )
+    finally:
+        request_id_ctx.reset(token)
+    response.headers["X-Request-ID"] = rid
+    return response
+
 
 app.add_middleware(
     CORSMiddleware,

--- a/backend/app/routers/ai.py
+++ b/backend/app/routers/ai.py
@@ -14,6 +14,8 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/ai", tags=["AI"])
 
+CHAT_SESSIONS_LIMIT = 20  # nº de sessões de chat recentes listadas
+
 
 class ChatMessage(BaseModel):
     message: str
@@ -97,7 +99,7 @@ async def list_sessions(current_user: User = Depends(get_current_user)): # Lista
     cursor = chat_history_collection.find(
         {"user_id": str(current_user.id)},
         {"session_id": 1, "updated_at": 1, "messages": {"$slice": 1}},
-    ).sort("updated_at", -1).limit(20)
+    ).sort("updated_at", -1).limit(CHAT_SESSIONS_LIMIT)
 
     sessions = []
     async for doc in cursor:

--- a/backend/app/routers/ai.py
+++ b/backend/app/routers/ai.py
@@ -6,6 +6,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.dependencies import get_db, get_current_user
 from app.models.sql_models import User
 from app.services.ai_service import get_or_generate_insight, chat_with_ai
+from app.schemas.ai import InsightResponse, ChatResponse, ChatSessionSummary
 from app.database import chat_history_collection
 import logging
 
@@ -18,7 +19,7 @@ class ChatMessage(BaseModel):
     message: str
     session_id: str | None = None
     
-@router.get("/insight")
+@router.get("/insight", response_model=InsightResponse)
 async def get_dashboard_insight(
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
@@ -38,7 +39,11 @@ async def get_dashboard_insight(
             "error": "IA temporariamente indisponível"
         }
         
-@router.post("/chat")
+@router.post(
+    "/chat",
+    response_model=ChatResponse,
+    responses={503: {"description": "Norby AI temporariamente indisponível"}},
+)
 async def chat(
     payload: ChatMessage,
     current_user: User = Depends(get_current_user),
@@ -87,7 +92,7 @@ async def chat(
 
     return {"response": ai_response, "session_id": session_id}
 
-@router.get("/chat/sessions")
+@router.get("/chat/sessions", response_model=list[ChatSessionSummary])
 async def list_sessions(current_user: User = Depends(get_current_user)): # Lista sessões de chat do usuário
     cursor = chat_history_collection.find(
         {"user_id": str(current_user.id)},

--- a/backend/app/routers/goals.py
+++ b/backend/app/routers/goals.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select
 from uuid import UUID
@@ -24,11 +24,17 @@ async def _get_owned_goal(goal_id: UUID, user: User, db: AsyncSession, for_updat
 
 @router.get("/", response_model=list[GoalResponse])
 async def list_goals(
+    limit: int = Query(100, ge=1, le=500),
+    offset: int = Query(0, ge=0),
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
     goals = (await db.execute(
-        select(Goal).where(Goal.user_id == current_user.id).order_by(Goal.created_at.desc())
+        select(Goal)
+        .where(Goal.user_id == current_user.id)
+        .order_by(Goal.created_at.desc())
+        .limit(limit)
+        .offset(offset)
     )).scalars().all()
     return [await build_goal_response(db, g) for g in goals]
 

--- a/backend/app/routers/recurring.py
+++ b/backend/app/routers/recurring.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select
 from uuid import UUID
@@ -13,6 +13,8 @@ router = APIRouter(prefix="/recurring", tags=["Recurring"])
 
 @router.get("/", response_model=list[RecurringResponse])
 async def list_recurring(
+    limit: int = Query(100, ge=1, le=500),
+    offset: int = Query(0, ge=0),
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
@@ -20,6 +22,8 @@ async def list_recurring(
         select(RecurringTransaction)
         .where(RecurringTransaction.user_id == current_user.id)
         .order_by(RecurringTransaction.next_run_date.asc())
+        .limit(limit)
+        .offset(offset)
     )
     return result.scalars().all()
 

--- a/backend/app/routers/transactions.py
+++ b/backend/app/routers/transactions.py
@@ -54,6 +54,8 @@ async def list_transactions(
     type: Optional[TransactionType] = Query(None),
     month: Optional[int] = Query(None, ge=1, le=12),
     year: Optional[int] = Query(None),
+    limit: int = Query(200, ge=1, le=500),
+    offset: int = Query(0, ge=0),
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
@@ -71,8 +73,9 @@ async def list_transactions(
     result = await db.execute(
         select(Transaction)
         .where(*filters)
-        .order_by(Transaction.date.desc())
-        .limit(200)
+        .order_by(Transaction.date.desc(), Transaction.created_at.desc())
+        .limit(limit)
+        .offset(offset)
     )
     return result.scalars().all()
 

--- a/backend/app/routers/wallets.py
+++ b/backend/app/routers/wallets.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select
 from uuid import UUID
@@ -10,10 +10,18 @@ router = APIRouter(prefix="/wallets", tags=["Wallets"])
 
 @router.get("/", response_model=list[WalletResponse]) 
 async def list_wallets( # Retorna a lista de carteiras do usuário
+    limit: int = Query(100, ge=1, le=500),
+    offset: int = Query(0, ge=0),
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
-    result = await db.execute(select(Wallet).where(Wallet.user_id == current_user.id))
+    result = await db.execute(
+        select(Wallet)
+        .where(Wallet.user_id == current_user.id)
+        .order_by(Wallet.created_at.desc())
+        .limit(limit)
+        .offset(offset)
+    )
     return result.scalars().all()
 
 @router.post("/", response_model=WalletResponse, status_code=status.HTTP_201_CREATED)

--- a/backend/app/schemas/ai.py
+++ b/backend/app/schemas/ai.py
@@ -1,0 +1,24 @@
+from datetime import datetime
+
+from pydantic import BaseModel
+
+
+class InsightResponse(BaseModel):
+    # score/summary_text/suggested_action no caminho normal; error preenchido
+    # apenas na degradação graciosa (IA indisponível). response_model também
+    # filtra os campos internos do doc cacheado (user_id, reference_month, etc.).
+    score: float | None = None
+    summary_text: str = ""
+    suggested_action: str | None = None
+    error: str | None = None
+
+
+class ChatResponse(BaseModel):
+    response: str
+    session_id: str
+
+
+class ChatSessionSummary(BaseModel):
+    session_id: str
+    updated_at: datetime | None = None
+    first_message: str = ""

--- a/backend/app/schemas/recurring.py
+++ b/backend/app/schemas/recurring.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 from uuid import UUID
 from datetime import datetime
 from decimal import Decimal
@@ -49,5 +49,4 @@ class RecurringResponse(BaseModel):
     active: bool
     created_at: datetime
 
-    class Config:
-        from_attributes = True
+    model_config = ConfigDict(from_attributes=True)

--- a/backend/app/schemas/transaction.py
+++ b/backend/app/schemas/transaction.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 from uuid import UUID
 import datetime  # via módulo: o campo `date` colide com o tipo `date` se importado direto
 from decimal import Decimal
@@ -30,5 +30,4 @@ class TransactionResponse(BaseModel):
     date: datetime.date
     created_at: datetime.datetime
 
-    class Config:
-        from_attributes = True
+    model_config = ConfigDict(from_attributes=True)

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -1,6 +1,6 @@
 import re
 
-from pydantic import BaseModel, EmailStr, Field, field_validator
+from pydantic import BaseModel, ConfigDict, EmailStr, Field, field_validator
 from uuid import UUID
 from datetime import datetime
 
@@ -30,10 +30,9 @@ class UserResponse(BaseModel):
     name: str
     email: str
     created_at: datetime
-    
-    class Config:
-        from_attributes = True
-        
+
+    model_config = ConfigDict(from_attributes=True)
+
 class Token(BaseModel):
     access_token: str
     refresh_token: str

--- a/backend/app/schemas/wallet.py
+++ b/backend/app/schemas/wallet.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 from uuid import UUID
 from datetime import datetime
 from decimal import Decimal
@@ -16,6 +16,5 @@ class WalletResponse(BaseModel):
     name: str
     balance: Decimal
     created_at: datetime
-    
-    class Config:
-        from_attributes = True
+
+    model_config = ConfigDict(from_attributes=True)

--- a/backend/app/services/ai_service.py
+++ b/backend/app/services/ai_service.py
@@ -13,6 +13,9 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+# Nº de mensagens recentes enviadas como contexto ao Gemini (evita estourar o limite).
+MAX_CHAT_HISTORY_MESSAGES = 10
+
 settings = get_settings()
 genai.configure(api_key=settings.gemini_api_key)
 model = genai.GenerativeModel("models/gemini-2.5-flash")
@@ -150,7 +153,7 @@ async def chat_with_ai(db: AsyncSession, user_id: str, message: str, history: li
     # Monta histórico no formato do Gemini. Usa .get() porque um doc antigo ou
     # malformado no Mongo (sem role/content) não deve derrubar o chat inteiro.
     chat_history = []
-    for msg in history[-10:]: # Últimas 10 mensagens para não estourar contexto
+    for msg in history[-MAX_CHAT_HISTORY_MESSAGES:]:
         content = msg.get("content")
         if not content:
             continue

--- a/backend/tests/test_ai_contract.py
+++ b/backend/tests/test_ai_contract.py
@@ -1,0 +1,30 @@
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_ai_routes_expose_response_models_in_openapi(client):
+    spec = (await client.get("/openapi.json")).json()
+    schemas = spec["components"]["schemas"]
+
+    def resp_schema(path, method="get"):
+        return spec["paths"][path][method]["responses"]["200"]["content"]["application/json"]["schema"]
+
+    # /ai/insight → InsightResponse
+    assert resp_schema("/ai/insight").get("$ref", "").endswith("/InsightResponse")
+    assert "InsightResponse" in schemas
+
+    # /ai/chat → ChatResponse
+    assert resp_schema("/ai/chat", "post").get("$ref", "").endswith("/ChatResponse")
+    assert "ChatResponse" in schemas
+
+    # /ai/chat/sessions → list[ChatSessionSummary]
+    sessions = resp_schema("/ai/chat/sessions")
+    assert sessions.get("type") == "array"
+    assert sessions["items"].get("$ref", "").endswith("/ChatSessionSummary")
+    assert "ChatSessionSummary" in schemas
+
+
+@pytest.mark.asyncio
+async def test_ai_chat_documents_503_in_openapi(client):
+    spec = (await client.get("/openapi.json")).json()
+    assert "503" in spec["paths"]["/ai/chat"]["post"]["responses"]

--- a/backend/tests/test_observability.py
+++ b/backend/tests/test_observability.py
@@ -1,0 +1,34 @@
+import pytest
+
+from app.main import app
+
+
+# Rota de teste que estoura, para exercitar o handler global de exceção.
+@app.get("/_boom_test", include_in_schema=False)
+async def _boom_test():
+    raise RuntimeError("boom")
+
+
+@pytest.mark.asyncio
+async def test_unhandled_exception_returns_generic_500_with_request_id(client):
+    res = await client.get("/_boom_test", headers={"Origin": "http://localhost:5173"})
+    assert res.status_code == 500
+    assert res.json() == {"detail": "Erro interno do servidor"}
+    assert res.headers.get("x-request-id")
+    # CORS preservado no 500 (senão o navegador mascara como erro de CORS).
+    assert res.headers.get("access-control-allow-origin") == "http://localhost:5173"
+
+
+@pytest.mark.asyncio
+async def test_response_carries_request_id_header(client):
+    # Toda resposta deve trazer um X-Request-ID para correlacionar logs.
+    res = await client.get("/health")
+    assert res.status_code == 200
+    assert res.headers.get("x-request-id")
+
+
+@pytest.mark.asyncio
+async def test_request_id_is_echoed_when_provided(client):
+    # Se o cliente mandar um X-Request-ID, ele é preservado na resposta.
+    res = await client.get("/health", headers={"X-Request-ID": "abc-123"})
+    assert res.headers.get("x-request-id") == "abc-123"

--- a/backend/tests/test_transactions.py
+++ b/backend/tests/test_transactions.py
@@ -115,6 +115,21 @@ async def test_concurrent_transactions_do_not_lose_wallet_balance_updates(make_a
 
 
 @pytest.mark.asyncio
+async def test_list_respects_limit_and_offset(make_auth_client):
+    ac = await make_auth_client("Alice")
+    w = await make_wallet(ac, balance=1000)
+    for i in range(5):
+        await ac.post("/transactions/", json=tx_payload(w["id"], amount="10.00", date=f"2026-06-0{i+1}"))
+
+    page1 = (await ac.get("/transactions/?limit=2&offset=0")).json()
+    page2 = (await ac.get("/transactions/?limit=2&offset=2")).json()
+    assert len(page1) == 2
+    assert len(page2) == 2
+    # Páginas consecutivas não se sobrepõem.
+    assert {t["id"] for t in page1}.isdisjoint({t["id"] for t in page2})
+
+
+@pytest.mark.asyncio
 async def test_list_is_scoped_to_user(make_auth_client):
     alice = await make_auth_client("Alice")
     bob = await make_auth_client("Bob")

--- a/backend/tests/test_wallets.py
+++ b/backend/tests/test_wallets.py
@@ -1,0 +1,63 @@
+import pytest
+
+
+async def make_wallet(ac, name="Main", balance="100.00"):
+    res = await ac.post("/wallets/", json={"name": name, "balance": balance})
+    assert res.status_code == 201, res.text
+    return res.json()
+
+
+@pytest.mark.asyncio
+async def test_create_wallet_returns_fields(make_auth_client):
+    ac = await make_auth_client("Alice")
+    w = await make_wallet(ac, name="Nubank", balance="250.00")
+    assert w["name"] == "Nubank"
+    assert float(w["balance"]) == 250.0
+    assert "id" in w and "created_at" in w
+
+
+@pytest.mark.asyncio
+async def test_list_is_scoped_to_user(make_auth_client):
+    alice = await make_auth_client("Alice")
+    bob = await make_auth_client("Bob")
+    await make_wallet(alice, name="Alice Wallet")
+    assert len((await alice.get("/wallets/")).json()) == 1
+    assert len((await bob.get("/wallets/")).json()) == 0
+
+
+@pytest.mark.asyncio
+async def test_update_own_wallet_name(make_auth_client):
+    ac = await make_auth_client("Alice")
+    w = await make_wallet(ac)
+    res = await ac.put(f"/wallets/{w['id']}", json={"name": "Renomeada"})
+    assert res.status_code == 200
+    assert res.json()["name"] == "Renomeada"
+
+
+@pytest.mark.asyncio
+async def test_user_cannot_update_other_users_wallet(make_auth_client):
+    alice = await make_auth_client("Alice")
+    bob = await make_auth_client("Bob")
+    w = await make_wallet(alice)
+    res = await bob.put(f"/wallets/{w['id']}", json={"name": "Hijack"})
+    assert res.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_user_cannot_delete_other_users_wallet(make_auth_client):
+    alice = await make_auth_client("Alice")
+    bob = await make_auth_client("Bob")
+    w = await make_wallet(alice)
+    res = await bob.delete(f"/wallets/{w['id']}")
+    assert res.status_code == 404
+    # A carteira da Alice continua lá.
+    assert len((await alice.get("/wallets/")).json()) == 1
+
+
+@pytest.mark.asyncio
+async def test_delete_own_wallet(make_auth_client):
+    ac = await make_auth_client("Alice")
+    w = await make_wallet(ac)
+    res = await ac.delete(f"/wallets/{w['id']}")
+    assert res.status_code == 204
+    assert len((await ac.get("/wallets/")).json()) == 0

--- a/backend/tests/test_wallets.py
+++ b/backend/tests/test_wallets.py
@@ -26,6 +26,16 @@ async def test_list_is_scoped_to_user(make_auth_client):
 
 
 @pytest.mark.asyncio
+async def test_list_respects_limit(make_auth_client):
+    # A listagem de carteiras (antes ilimitada) passa a respeitar limit/offset.
+    ac = await make_auth_client("Alice")
+    for i in range(4):
+        await make_wallet(ac, name=f"W{i}")
+    assert len((await ac.get("/wallets/?limit=2")).json()) == 2
+    assert len((await ac.get("/wallets/?limit=2&offset=2")).json()) == 2
+
+
+@pytest.mark.asyncio
 async def test_update_own_wallet_name(make_auth_client):
     ac = await make_auth_client("Alice")
     w = await make_wallet(ac)

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -24,6 +24,19 @@ export default defineConfig([
     },
     rules: {
       'no-unused-vars': ['error', { varsIgnorePattern: '^[A-Z_]' }],
+      // Permite exportar constantes (ex.: as variantes cva do shadcn) junto do componente.
+      'react-refresh/only-export-components': ['error', { allowConstantExport: true }],
     },
+  },
+  {
+    // Arquivos de configuração rodam no Node (têm __dirname, process, etc.).
+    files: ['*.config.js'],
+    languageOptions: { globals: globals.node },
+  },
+  {
+    // Primitivos gerados pelo shadcn: exportar as variantes cva junto do
+    // componente é intencional; a regra de fast-refresh não se aplica aqui.
+    files: ['src/components/ui/**'],
+    rules: { 'react-refresh/only-export-components': 'off' },
   },
 ])

--- a/frontend/src/components/shared/AmountPromptDialog.jsx
+++ b/frontend/src/components/shared/AmountPromptDialog.jsx
@@ -1,0 +1,106 @@
+import { useId, useState } from "react";
+
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { inputCls } from "@/lib/utils";
+
+/**
+ * Diálogo com um input de valor validado (R$), no lugar de `prompt()`.
+ *
+ * Aceita valores negativos (ex.: corrigir um aporte) mas rejeita zero/entrada
+ * inválida. Erros da API do `onSubmit` aparecem inline, sem fechar o diálogo.
+ */
+export function AmountPromptDialog({
+  trigger,
+  title,
+  description,
+  submitLabel = "Confirmar",
+  errorFallback = "Não foi possível concluir a ação.",
+  onSubmit,
+}) {
+  const inputId = useId();
+  const [open, setOpen] = useState(false);
+  const [value, setValue] = useState("");
+  const [error, setError] = useState(null);
+  const [loading, setLoading] = useState(false);
+
+  function handleOpenChange(v) {
+    setOpen(v);
+    if (!v) {
+      setValue("");
+      setError(null);
+    }
+  }
+
+  async function handleSubmit(e) {
+    e.preventDefault();
+    const amount = Number(value);
+    if (value.trim() === "" || Number.isNaN(amount) || amount === 0) {
+      setError("Informe um valor diferente de zero.");
+      return;
+    }
+    setError(null);
+    setLoading(true);
+    try {
+      await onSubmit(amount);
+      handleOpenChange(false);
+    } catch (err) {
+      setError(err?.response?.data?.detail || errorFallback);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogTrigger render={trigger} />
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          {description && <DialogDescription>{description}</DialogDescription>}
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit} className="space-y-3">
+          <div className="space-y-1">
+            <label htmlFor={inputId} className="text-xs text-norby-ivory/60">
+              Valor
+            </label>
+            <input
+              id={inputId}
+              type="number"
+              step="0.01"
+              inputMode="decimal"
+              value={value}
+              onChange={(e) => setValue(e.target.value)}
+              className={inputCls}
+            />
+          </div>
+
+          {error && <p className="text-norby-danger text-xs">{error}</p>}
+
+          <DialogFooter>
+            <DialogClose render={<Button type="button" variant="outline" />}>
+              Cancelar
+            </DialogClose>
+            <Button
+              type="submit"
+              disabled={loading}
+              className="bg-norby-teal hover:bg-norby-teal-soft text-norby-night font-medium disabled:opacity-40"
+            >
+              {loading ? "..." : submitLabel}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/shared/AmountPromptDialog.test.jsx
+++ b/frontend/src/components/shared/AmountPromptDialog.test.jsx
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { AmountPromptDialog } from "./AmountPromptDialog";
+
+function open(name = "abrir") {
+  fireEvent.click(screen.getByRole("button", { name }));
+}
+
+describe("AmountPromptDialog", () => {
+  it("submits a valid amount (accepts negative) and closes on success", async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    render(
+      <AmountPromptDialog
+        trigger={<button>abrir</button>}
+        title="Aporte"
+        submitLabel="Adicionar"
+        onSubmit={onSubmit}
+      />,
+    );
+    open();
+    fireEvent.change(await screen.findByLabelText("Valor"), { target: { value: "-150.5" } });
+    fireEvent.click(screen.getByRole("button", { name: "Adicionar" }));
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledWith(-150.5));
+  });
+
+  it("rejects zero without calling onSubmit", async () => {
+    const onSubmit = vi.fn();
+    render(
+      <AmountPromptDialog
+        trigger={<button>abrir</button>}
+        title="Aporte"
+        submitLabel="Adicionar"
+        onSubmit={onSubmit}
+      />,
+    );
+    open();
+    fireEvent.change(await screen.findByLabelText("Valor"), { target: { value: "0" } });
+    fireEvent.click(screen.getByRole("button", { name: "Adicionar" }));
+    expect(await screen.findByText(/diferente de zero/i)).toBeInTheDocument();
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("shows the API error inline when onSubmit rejects", async () => {
+    const onSubmit = vi
+      .fn()
+      .mockRejectedValue({ response: { data: { detail: "Erro do servidor" } } });
+    render(
+      <AmountPromptDialog
+        trigger={<button>abrir</button>}
+        title="Aporte"
+        submitLabel="Adicionar"
+        onSubmit={onSubmit}
+      />,
+    );
+    open();
+    fireEvent.change(await screen.findByLabelText("Valor"), { target: { value: "100" } });
+    fireEvent.click(screen.getByRole("button", { name: "Adicionar" }));
+    expect(await screen.findByText("Erro do servidor")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/shared/ConfirmDialog.jsx
+++ b/frontend/src/components/shared/ConfirmDialog.jsx
@@ -1,0 +1,77 @@
+import { useState } from "react";
+
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+
+/**
+ * Diálogo de confirmação reutilizável para ações destrutivas.
+ *
+ * Substitui `confirm()` + `alert()` nativos: confirma a ação e, se o `onConfirm`
+ * (async) falhar, mostra a mensagem de erro da API inline sem fechar o diálogo.
+ */
+export function ConfirmDialog({
+  trigger,
+  title,
+  description,
+  confirmLabel = "Confirmar",
+  cancelLabel = "Cancelar",
+  errorFallback = "Não foi possível concluir a ação.",
+  onConfirm,
+}) {
+  const [open, setOpen] = useState(false);
+  const [error, setError] = useState(null);
+  const [loading, setLoading] = useState(false);
+
+  function handleOpenChange(v) {
+    setOpen(v);
+    if (!v) setError(null); // limpa o erro ao fechar
+  }
+
+  async function handleConfirm() {
+    setError(null);
+    setLoading(true);
+    try {
+      await onConfirm();
+      setOpen(false);
+    } catch (err) {
+      setError(err?.response?.data?.detail || errorFallback);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogTrigger render={trigger} />
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          {description && <DialogDescription>{description}</DialogDescription>}
+        </DialogHeader>
+
+        {error && <p className="text-norby-danger text-xs">{error}</p>}
+
+        <DialogFooter>
+          <DialogClose render={<Button variant="outline" />}>{cancelLabel}</DialogClose>
+          <Button
+            type="button"
+            onClick={handleConfirm}
+            disabled={loading}
+            className="bg-norby-danger hover:bg-norby-danger/80 text-norby-ivory disabled:opacity-40"
+          >
+            {loading ? "..." : confirmLabel}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/shared/ConfirmDialog.test.jsx
+++ b/frontend/src/components/shared/ConfirmDialog.test.jsx
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { ConfirmDialog } from "./ConfirmDialog";
+
+describe("ConfirmDialog", () => {
+  it("opens from the trigger, confirms, and closes on success", async () => {
+    const onConfirm = vi.fn().mockResolvedValue(undefined);
+    render(
+      <ConfirmDialog
+        trigger={<button>abrir</button>}
+        title="Remover esta meta?"
+        confirmLabel="Remover"
+        onConfirm={onConfirm}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "abrir" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Remover" }));
+
+    await waitFor(() => expect(onConfirm).toHaveBeenCalledTimes(1));
+    await waitFor(() =>
+      expect(screen.queryByText("Remover esta meta?")).not.toBeInTheDocument(),
+    );
+  });
+
+  it("shows the API error inline and stays open when onConfirm rejects", async () => {
+    const onConfirm = vi
+      .fn()
+      .mockRejectedValue({ response: { data: { detail: "Falhou no servidor" } } });
+    render(
+      <ConfirmDialog
+        trigger={<button>abrir</button>}
+        title="Remover?"
+        confirmLabel="Remover"
+        onConfirm={onConfirm}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "abrir" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Remover" }));
+
+    expect(await screen.findByText("Falhou no servidor")).toBeInTheDocument();
+    // Continua aberto (o título segue visível).
+    expect(screen.getByText("Remover?")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/lib/utils.js
+++ b/frontend/src/lib/utils.js
@@ -49,3 +49,14 @@ export function todayInput() {
   const day = String(d.getDate()).padStart(2, "0");
   return `${year}-${month}-${day}`;
 }
+
+/** Formata um valor (número ou string decimal) como moeda pt-BR: "R$ 1.234,56". */
+export const formatBRL = (v) =>
+  `R$ ${Number(v).toLocaleString("pt-BR", { minimumFractionDigits: 2 })}`;
+
+/**
+ * Classe base dos inputs "cheios" dos formulários (input nativo, não o <Input>
+ * do shadcn, que tem estilo próprio). Compartilhada por Goals/Recurring/Transactions.
+ */
+export const inputCls =
+  "w-full h-10 px-3 rounded-lg bg-white/5 border border-white/10 text-norby-ivory text-sm placeholder:text-norby-ivory/40 focus:outline-none focus:ring-2 focus:ring-norby-teal/40 transition";

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -29,7 +29,7 @@ import { aiApi } from "@/api/ai";
 import { recurringApi } from "@/api/recurring";
 import { dashboardApi } from "@/api/dashboard";
 import { Button } from "@/components/ui/button";
-import { formatDateBR } from "@/lib/utils";
+import { formatDateBR, formatBRL } from "@/lib/utils";
 
 // Rótulo curto pt-BR de uma chave ano-mês ("2026-07" → "jul"), em horário local.
 const monthLabel = (ym) => {
@@ -61,8 +61,6 @@ const EXPENSE_COLOR = "#E0725C";
 
 const axisTick = { fill: "rgba(239,250,248,0.40)", fontSize: 11 };
 
-const fmt = (v) =>
-  `R$ ${Number(v).toLocaleString("pt-BR", { minimumFractionDigits: 2 })}`;
 const fmtShort = (v) =>
   Number(v) >= 1000 ? `${(v / 1000).toFixed(1)}k` : `${v}`;
 
@@ -84,7 +82,7 @@ function ChartTooltip({ active, payload, label }) {
           />
           <span className="text-norby-ivory/70">{p.name}</span>
           <span className="ml-auto font-semibold text-norby-ivory tnum">
-            {fmt(p.value)}
+            {formatBRL(p.value)}
           </span>
         </div>
       ))}
@@ -178,16 +176,16 @@ export default function Dashboard() {
 
       {/* KPI Cards */}
       <div className="grid grid-cols-4 gap-4">
-        <KpiCard title="Saldo atual" value={fmt(totalBalance)} icon={DollarSign} />
+        <KpiCard title="Saldo atual" value={formatBRL(totalBalance)} icon={DollarSign} />
         <KpiCard
           title="Receitas do mês"
-          value={fmt(monthIncome)}
+          value={formatBRL(monthIncome)}
           change={incomeChange}
           icon={TrendingUp}
         />
         <KpiCard
           title="Gastos do mês"
-          value={fmt(monthExpenses)}
+          value={formatBRL(monthExpenses)}
           change={expensesChange}
           changeInverted
           icon={CreditCard}
@@ -379,7 +377,7 @@ export default function Dashboard() {
                     Total
                   </span>
                   <span className="text-lg font-bold text-norby-ivory tnum">
-                    {fmt(categoryTotal)}
+                    {formatBRL(categoryTotal)}
                   </span>
                 </div>
               </div>
@@ -403,7 +401,7 @@ export default function Dashboard() {
                         {c.name}
                       </span>
                       <span className="text-sm font-semibold text-norby-ivory tnum">
-                        {fmt(c.value)}
+                        {formatBRL(c.value)}
                       </span>
                       <span className="text-xs text-norby-ivory/40 tnum w-9 text-right">
                         {pct.toFixed(0)}%
@@ -467,7 +465,7 @@ export default function Dashboard() {
                         isIncome ? "text-norby-income" : "text-norby-ivory"
                       }`}
                     >
-                      {isIncome ? "+" : "−"} {fmt(parseFloat(t.amount))}
+                      {isIncome ? "+" : "−"} {formatBRL(parseFloat(t.amount))}
                     </p>
                   </div>
                 );
@@ -488,7 +486,7 @@ export default function Dashboard() {
                 ) : (
                   <TrendingDown size={13} />
                 )}
-                {fmt(monthNet)}
+                {formatBRL(monthNet)}
               </p>
             </div>
             <div className="p-3 rounded-xl bg-norby-teal/10 border border-norby-teal/20">

--- a/frontend/src/pages/Goals.jsx
+++ b/frontend/src/pages/Goals.jsx
@@ -7,6 +7,8 @@ import { goalsApi } from "@/api/goals";
 import { CATEGORIES } from "@/lib/categories";
 import { goalSchema } from "@/lib/schemas";
 import { formatBRL, inputCls } from "@/lib/utils";
+import { ConfirmDialog } from "@/components/shared/ConfirmDialog";
+import { AmountPromptDialog } from "@/components/shared/AmountPromptDialog";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -90,27 +92,15 @@ export default function Goals() {
     }
   }
 
-  async function handleContribute(goal) {
-    const raw = prompt(`Adicionar aporte em "${goal.name}" (use negativo para corrigir):`);
-    if (raw === null) return;
-    const amount = Number(raw);
-    if (!amount) return;
-    try {
-      await goalsApi.contribute(goal.id, amount);
-      load();
-    } catch (err) {
-      alert(err.response?.data?.detail || "Não foi possível salvar o aporte.");
-    }
+  // Os diálogos tratam validação e erro da API; aqui só a chamada + reload.
+  async function contribute(goalId, amount) {
+    await goalsApi.contribute(goalId, amount);
+    await load();
   }
 
-  async function handleDelete(id) {
-    if (!confirm("Remover esta meta?")) return;
-    try {
-      await goalsApi.delete(id);
-      load();
-    } catch (err) {
-      alert(err.response?.data?.detail || "Não foi possível remover a meta.");
-    }
+  async function deleteGoal(id) {
+    await goalsApi.delete(id);
+    await load();
   }
 
   return (
@@ -263,22 +253,37 @@ export default function Goals() {
                 </div>
                 <div className="flex gap-1">
                   {g.type === "SAVINGS" && (
-                    <button
-                      type="button"
-                      onClick={() => handleContribute(g)}
-                      className="p-2 rounded-lg text-norby-ivory/40 hover:text-norby-teal hover:bg-white/5"
-                      title="Adicionar aporte"
-                    >
-                      <Plus size={14} />
-                    </button>
+                    <AmountPromptDialog
+                      title={`Aporte em "${g.name}"`}
+                      description="Use um valor negativo para corrigir um aporte."
+                      submitLabel="Adicionar"
+                      errorFallback="Não foi possível salvar o aporte."
+                      onSubmit={(amount) => contribute(g.id, amount)}
+                      trigger={
+                        <button
+                          type="button"
+                          className="p-2 rounded-lg text-norby-ivory/40 hover:text-norby-teal hover:bg-white/5"
+                          title="Adicionar aporte"
+                        >
+                          <Plus size={14} />
+                        </button>
+                      }
+                    />
                   )}
-                  <button
-                    type="button"
-                    onClick={() => handleDelete(g.id)}
-                    className="p-2 rounded-lg text-norby-ivory/40 hover:text-norby-danger hover:bg-white/5"
-                  >
-                    <Trash2 size={14} />
-                  </button>
+                  <ConfirmDialog
+                    title="Remover esta meta?"
+                    confirmLabel="Remover"
+                    errorFallback="Não foi possível remover a meta."
+                    onConfirm={() => deleteGoal(g.id)}
+                    trigger={
+                      <button
+                        type="button"
+                        className="p-2 rounded-lg text-norby-ivory/40 hover:text-norby-danger hover:bg-white/5"
+                      >
+                        <Trash2 size={14} />
+                      </button>
+                    }
+                  />
                 </div>
               </div>
 

--- a/frontend/src/pages/Goals.jsx
+++ b/frontend/src/pages/Goals.jsx
@@ -6,6 +6,7 @@ import { Plus, Trash2, Target, PiggyBank } from "lucide-react";
 import { goalsApi } from "@/api/goals";
 import { CATEGORIES } from "@/lib/categories";
 import { goalSchema } from "@/lib/schemas";
+import { formatBRL, inputCls } from "@/lib/utils";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -22,12 +23,6 @@ const TYPE_OPTIONS = [
 ];
 
 const CATEGORY_OPTIONS = CATEGORIES.map((c) => ({ value: c, label: c }));
-
-const inputCls =
-  "w-full h-10 px-3 rounded-lg bg-white/5 border border-white/10 text-norby-ivory text-sm placeholder:text-norby-ivory/40 focus:outline-none focus:ring-2 focus:ring-norby-teal/40 transition";
-
-const fmt = (v) =>
-  `R$ ${parseFloat(v).toLocaleString("pt-BR", { minimumFractionDigits: 2 })}`;
 
 export default function Goals() {
   const [goals, setGoals] = useState([]);
@@ -292,7 +287,7 @@ export default function Goals() {
               </div>
               <div className="flex items-center justify-between text-xs">
                 <span className="text-norby-ivory/60 tnum">
-                  {fmt(g.current_amount)} / {fmt(g.target_amount)}
+                  {formatBRL(g.current_amount)} / {formatBRL(g.target_amount)}
                 </span>
                 <span className={over ? "text-norby-danger" : "text-norby-ivory/40"}>
                   {g.progress_pct}%

--- a/frontend/src/pages/Goals.jsx
+++ b/frontend/src/pages/Goals.jsx
@@ -26,6 +26,14 @@ const TYPE_OPTIONS = [
 
 const CATEGORY_OPTIONS = CATEGORIES.map((c) => ({ value: c, label: c }));
 
+const EMPTY_FORM = {
+  name: "",
+  type: "SAVINGS",
+  target_amount: "",
+  current_amount: "",
+  category: "",
+};
+
 export default function Goals() {
   const [goals, setGoals] = useState([]);
   const [open, setOpen] = useState(false);
@@ -39,16 +47,10 @@ export default function Goals() {
     formState: { errors, isSubmitting },
   } = useForm({
     resolver: zodResolver(goalSchema),
-    defaultValues: {
-      name: "",
-      type: "SAVINGS",
-      target_amount: "",
-      current_amount: "",
-      category: "",
-    },
+    defaultValues: EMPTY_FORM,
   });
 
-  // Watch type to toggle conditional fields and label
+  // Observa o type para alternar campos condicionais e o rótulo.
   const type = useWatch({ control, name: "type" });
 
   async function load() {
@@ -63,13 +65,7 @@ export default function Goals() {
     setOpen(v);
     if (!v) {
       setServerError(null);
-      reset({
-        name: "",
-        type: "SAVINGS",
-        target_amount: "",
-        current_amount: "",
-        category: "",
-      });
+      reset(EMPTY_FORM);
     }
   }
 

--- a/frontend/src/pages/Recurring.jsx
+++ b/frontend/src/pages/Recurring.jsx
@@ -47,6 +47,17 @@ const TYPE_OPTIONS = [
 
 const CATEGORY_OPTIONS = CATEGORIES.map((c) => ({ value: c, label: c }));
 
+// Valores iniciais do formulário de recorrência.
+const emptyForm = () => ({
+  wallet_id: "",
+  type: "EXPENSE",
+  amount: "",
+  category: CATEGORIES[0],
+  frequency: "MONTHLY",
+  day_of_month: 1,
+  weekday: undefined,
+});
+
 export default function Recurring() {
   const [items, setItems] = useState([]);
   const [wallets, setWallets] = useState([]);
@@ -58,18 +69,11 @@ export default function Recurring() {
     handleSubmit,
     control,
     reset,
+    getValues,
     formState: { errors, isSubmitting },
   } = useForm({
     resolver: zodResolver(recurringSchema),
-    defaultValues: {
-      wallet_id: "",
-      type: "EXPENSE",
-      amount: "",
-      category: CATEGORIES[0],
-      frequency: "MONTHLY",
-      day_of_month: 1,
-      weekday: undefined,
-    },
+    defaultValues: emptyForm(),
   });
 
   async function load() {
@@ -82,17 +86,16 @@ export default function Recurring() {
     load(); // eslint-disable-line react-hooks/set-state-in-effect
   }, []);
 
-  // Build wallet options
   const walletOptions = wallets.map((w) => ({ value: w.id, label: w.name }));
 
-  // Auto-select the sole wallet when wallets load
+  // Auto-seleciona a única carteira, sem sobrescrever uma escolha já feita.
   useEffect(() => {
-    if (wallets.length === 1) {
+    if (wallets.length === 1 && !getValues("wallet_id")) {
       reset((prev) => ({ ...prev, wallet_id: wallets[0].id }));
     }
-  }, [wallets]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [wallets, reset, getValues]);
 
-  // Watch frequency to conditionally show day_of_month or weekday field
+  // Observa a frequência para alternar entre os campos day_of_month e weekday.
   const frequency = useWatch({ control, name: "frequency" });
 
   function handleOpenChange(v) {
@@ -100,13 +103,8 @@ export default function Recurring() {
     if (!v) {
       setServerError(null);
       reset({
+        ...emptyForm(),
         wallet_id: wallets.length === 1 ? wallets[0].id : "",
-        type: "EXPENSE",
-        amount: "",
-        category: CATEGORIES[0],
-        frequency: "MONTHLY",
-        day_of_month: 1,
-        weekday: undefined,
       });
     }
   }

--- a/frontend/src/pages/Recurring.jsx
+++ b/frontend/src/pages/Recurring.jsx
@@ -7,7 +7,7 @@ import { recurringApi } from "@/api/recurring";
 import { walletsApi } from "@/api/wallets";
 import { CATEGORIES } from "@/lib/categories";
 import { recurringSchema } from "@/lib/schemas";
-import { formatDateBR } from "@/lib/utils";
+import { formatDateBR, formatBRL, inputCls } from "@/lib/utils";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -45,9 +45,6 @@ const TYPE_OPTIONS = [
 ];
 
 const CATEGORY_OPTIONS = CATEGORIES.map((c) => ({ value: c, label: c }));
-
-const inputCls =
-  "w-full h-10 px-3 rounded-lg bg-white/5 border border-white/10 text-norby-ivory text-sm placeholder:text-norby-ivory/40 focus:outline-none focus:ring-2 focus:ring-norby-teal/40 transition";
 
 export default function Recurring() {
   const [items, setItems] = useState([]);
@@ -147,8 +144,6 @@ export default function Recurring() {
     load();
   }
 
-  const fmt = (v) =>
-    `R$ ${parseFloat(v).toLocaleString("pt-BR", { minimumFractionDigits: 2 })}`;
   const cadence = (it) =>
     it.frequency === "MONTHLY"
       ? `Mensal · dia ${it.day_of_month}`
@@ -350,7 +345,7 @@ export default function Recurring() {
                       : "text-norby-ivory/50"
                   }
                 >
-                  · {it.type === "INCOME" ? "+" : "−"} {fmt(it.amount)}
+                  · {it.type === "INCOME" ? "+" : "−"} {formatBRL(it.amount)}
                 </span>
               </p>
               <p className="text-xs text-norby-ivory/40">

--- a/frontend/src/pages/Recurring.jsx
+++ b/frontend/src/pages/Recurring.jsx
@@ -8,6 +8,7 @@ import { walletsApi } from "@/api/wallets";
 import { CATEGORIES } from "@/lib/categories";
 import { recurringSchema } from "@/lib/schemas";
 import { formatDateBR, formatBRL, inputCls } from "@/lib/utils";
+import { ConfirmDialog } from "@/components/shared/ConfirmDialog";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -138,8 +139,7 @@ export default function Recurring() {
     load();
   }
 
-  async function handleDelete(id) {
-    if (!confirm("Remover esta recorrência?")) return;
+  async function deleteRecurring(id) {
     await recurringApi.delete(id);
     load();
   }
@@ -361,12 +361,19 @@ export default function Recurring() {
             >
               {it.active ? <Pause size={14} /> : <Play size={14} />}
             </button>
-            <button
-              onClick={() => handleDelete(it.id)}
-              className="p-2 rounded-lg text-norby-ivory/40 hover:text-norby-danger hover:bg-white/5"
-            >
-              <Trash2 size={14} />
-            </button>
+            <ConfirmDialog
+              title="Remover esta recorrência?"
+              confirmLabel="Remover"
+              errorFallback="Não foi possível remover a recorrência."
+              onConfirm={() => deleteRecurring(it.id)}
+              trigger={
+                <button
+                  className="p-2 rounded-lg text-norby-ivory/40 hover:text-norby-danger hover:bg-white/5"
+                >
+                  <Trash2 size={14} />
+                </button>
+              }
+            />
           </div>
         ))}
       </div>

--- a/frontend/src/pages/Transactions.jsx
+++ b/frontend/src/pages/Transactions.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { useForm, Controller, useWatch } from "react-hook-form";
+import { useForm, Controller } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Plus, Search, Trash2, Pencil } from "lucide-react";
 
@@ -32,6 +32,16 @@ const TYPE_OPTIONS = [
 
 const CATEGORY_OPTIONS = CATEGORIES.map((c) => ({ value: c, label: c }));
 
+// Valores iniciais do formulário (date sempre fresca → função).
+const emptyForm = () => ({
+  wallet_id: "",
+  type: "EXPENSE",
+  amount: "",
+  category: CATEGORIES[0],
+  description: "",
+  date: todayInput(),
+});
+
 
 export default function Transactions() {
   const [transactions, setTransactions] = useState([]);
@@ -47,21 +57,12 @@ export default function Transactions() {
     handleSubmit,
     control,
     reset,
+    getValues,
     formState: { errors, isSubmitting },
   } = useForm({
     resolver: zodResolver(transactionSchema),
-    defaultValues: {
-      wallet_id: "",
-      type: "EXPENSE",
-      amount: "",
-      category: CATEGORIES[0],
-      description: "",
-      date: todayInput(),
-    },
+    defaultValues: emptyForm(),
   });
-
-  // Watch type for Segmented (not strictly needed in render, but kept for consistency)
-  useWatch({ control, name: "type" });
 
   async function load(params = {}) {
     await recurringApi.run().catch(() => {});
@@ -84,12 +85,13 @@ export default function Transactions() {
     return () => clearTimeout(timer);
   }, [filterType]);
 
-  // Auto-select the sole wallet only when NOT editing
+  // Auto-seleciona a única carteira, sem sobrescrever uma escolha já feita nem
+  // atrapalhar a edição.
   useEffect(() => {
-    if (wallets.length === 1 && !editing) {
+    if (wallets.length === 1 && !editing && !getValues("wallet_id")) {
       reset((prev) => ({ ...prev, wallet_id: wallets[0].id }));
     }
-  }, [wallets]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [wallets, editing, reset, getValues]);
 
   const reload = () => load(filterType ? { type: filterType } : {});
 
@@ -99,12 +101,8 @@ export default function Transactions() {
     setEditing(null);
     setServerError(null);
     reset({
+      ...emptyForm(),
       wallet_id: wallets.length === 1 ? wallets[0].id : "",
-      type: "EXPENSE",
-      amount: "",
-      category: CATEGORIES[0],
-      description: "",
-      date: todayInput(),
     });
     setOpen(true);
   }

--- a/frontend/src/pages/Transactions.jsx
+++ b/frontend/src/pages/Transactions.jsx
@@ -8,7 +8,7 @@ import { walletsApi } from "@/api/wallets";
 import { recurringApi } from "@/api/recurring";
 import { CATEGORIES } from "@/lib/categories";
 import { transactionSchema } from "@/lib/schemas";
-import { formatDateBR, toDateInput, todayInput } from "@/lib/utils";
+import { formatDateBR, formatBRL, inputCls, toDateInput, todayInput } from "@/lib/utils";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -30,9 +30,6 @@ const TYPE_OPTIONS = [
 ];
 
 const CATEGORY_OPTIONS = CATEGORIES.map((c) => ({ value: c, label: c }));
-
-const inputCls =
-  "w-full h-10 px-3 rounded-lg bg-white/5 border border-white/10 text-norby-ivory text-sm placeholder:text-norby-ivory/40 focus:outline-none focus:ring-2 focus:ring-norby-teal/40 transition";
 
 
 export default function Transactions() {
@@ -170,9 +167,6 @@ export default function Transactions() {
       );
     }
   }
-
-  const fmt = (v) =>
-    `R$ ${parseFloat(v).toLocaleString("pt-BR", { minimumFractionDigits: 2 })}`;
 
   const filtered = transactions.filter(
     (t) =>
@@ -403,7 +397,7 @@ export default function Transactions() {
                   }`}
                 >
                   {t.type === "INCOME" ? "+" : "-"}
-                  {fmt(t.amount)}
+                  {formatBRL(t.amount)}
                 </td>
                 <td className="px-4 py-3 text-sm text-norby-ivory/60">
                   {formatDateBR(t.date)}

--- a/frontend/src/pages/Transactions.jsx
+++ b/frontend/src/pages/Transactions.jsx
@@ -9,6 +9,7 @@ import { recurringApi } from "@/api/recurring";
 import { CATEGORIES } from "@/lib/categories";
 import { transactionSchema } from "@/lib/schemas";
 import { formatDateBR, formatBRL, inputCls, toDateInput, todayInput } from "@/lib/utils";
+import { ConfirmDialog } from "@/components/shared/ConfirmDialog";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -156,16 +157,9 @@ export default function Transactions() {
     }
   }
 
-  async function handleDelete(id) {
-    if (!confirm("Remover esta transação?")) return;
-    try {
-      await transactionsApi.delete(id);
-      reload();
-    } catch (err) {
-      alert(
-        err.response?.data?.detail || "Não foi possível remover a transação.",
-      );
-    }
+  async function deleteTransaction(id) {
+    await transactionsApi.delete(id);
+    reload();
   }
 
   const filtered = transactions.filter(
@@ -411,13 +405,20 @@ export default function Transactions() {
                     >
                       <Pencil size={16} />
                     </button>
-                    <button
-                      type="button"
-                      onClick={() => handleDelete(t.id)}
-                      className="text-norby-ivory/50 hover:text-norby-danger transition-colors"
-                    >
-                      <Trash2 size={16} />
-                    </button>
+                    <ConfirmDialog
+                      title="Remover esta transação?"
+                      confirmLabel="Remover"
+                      errorFallback="Não foi possível remover a transação."
+                      onConfirm={() => deleteTransaction(t.id)}
+                      trigger={
+                        <button
+                          type="button"
+                          className="text-norby-ivory/50 hover:text-norby-danger transition-colors"
+                        >
+                          <Trash2 size={16} />
+                        </button>
+                      }
+                    />
                   </div>
                 </td>
               </tr>

--- a/frontend/src/pages/Wallets.jsx
+++ b/frontend/src/pages/Wallets.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { Plus, Pencil, Trash2, Wallet } from "lucide-react";
 import { walletsApi } from "@/api/wallets";
 import { formatBRL } from "@/lib/utils";
+import { ConfirmDialog } from "@/components/shared/ConfirmDialog";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import {
@@ -56,16 +57,9 @@ export default function Wallets() {
     }
   }
 
-  async function handleDelete(id) {
-    if (!confirm("Remover esta carteira e todas as transações?")) return;
-    try {
-      await walletsApi.delete(id);
-      load();
-    } catch (err) {
-      alert(
-        err.response?.data?.detail || "Não foi possível remover a carteira.",
-      );
-    }
+  async function deleteWallet(id) {
+    await walletsApi.delete(id);
+    load();
   }
 
   function openEdit(wallet) {
@@ -166,12 +160,20 @@ export default function Wallets() {
                 >
                   <Pencil size={14} />
                 </button>
-                <button
-                  onClick={() => handleDelete(w.id)}
-                  className="m-1 p-2 rounded-lg text-norby-ivory/40 hover:text-norby-danger hover:bg-white/5"
-                >
-                  <Trash2 size={14} />
-                </button>
+                <ConfirmDialog
+                  title="Remover esta carteira?"
+                  description="A carteira e todas as suas transações serão removidas."
+                  confirmLabel="Remover"
+                  errorFallback="Não foi possível remover a carteira."
+                  onConfirm={() => deleteWallet(w.id)}
+                  trigger={
+                    <button
+                      className="m-1 p-2 rounded-lg text-norby-ivory/40 hover:text-norby-danger hover:bg-white/5"
+                    >
+                      <Trash2 size={14} />
+                    </button>
+                  }
+                />
               </div>
             </div>
             <div>

--- a/frontend/src/pages/Wallets.jsx
+++ b/frontend/src/pages/Wallets.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { Plus, Pencil, Trash2, Wallet } from "lucide-react";
 import { walletsApi } from "@/api/wallets";
+import { formatBRL } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import {
@@ -73,9 +74,6 @@ export default function Wallets() {
     setError(null);
     setOpen(true);
   }
-
-  const fmt = (v) =>
-    `R$ ${parseFloat(v).toLocaleString("pt-BR", { minimumFractionDigits: 2 })}`;
 
   const inputCls =
     "bg-white/5 border-white/10 text-norby-ivory placeholder:text-norby-ivory/30";
@@ -179,7 +177,7 @@ export default function Wallets() {
             <div>
               <p className="text-norby-ivory/70">{w.name}</p>
               <p className="text-xl font-bold text-norby-ivory mt-1 tnum">
-                {fmt(w.balance)}
+                {formatBRL(w.balance)}
               </p>
             </div>
             <p className="text-xs text-norby-ivory/40">

--- a/frontend/vitest.config.js
+++ b/frontend/vitest.config.js
@@ -12,4 +12,7 @@ export default defineConfig({
     globals: true,
     setupFiles: "./src/test/setup.js",
   },
+  // O transform de teste usa o runtime clássico de JSX; injeta o React para os
+  // componentes (.jsx) não precisarem importá-lo explicitamente.
+  esbuild: { jsxInject: `import React from 'react'` },
 });


### PR DESCRIPTION
## Verificação
- Backend: `pytest` no container → **79 passed**.
- Frontend: `vitest` → **20 passed** (5 de componente com RTL); `npm run lint`
  **100% verde**; `npm run build` ok.
- TDD: cada correção de dados acompanha um teste que falha sem o fix.
- Dashboard conferido visualmente na staging (sem erros de console).

## Correção de dados
- **A** — timezone shift na agregação do Dashboard (`parseDateOnly`).
- **B** — race no saldo da carteira: lock `with_for_update` nos writes.
- **C** — Dashboard agregava só as 200 txns mais recentes → novo
  `GET /dashboard/summary` agrega no Postgres sobre todas.
- **D** — hash de senha (bcrypt) fora do event loop (`asyncio.to_thread`).

## Arquitetura
- **E** — `transaction_service` centraliza a regra de saldo (fim da duplicação).
- **F/G** — `current_month_range` retorna `date` (fim do cast de timezone em metas
  BUDGET); month range consolidado num único helper.
- **H** — `ai_service` recebe `db` via injeção (Depends), fora do ciclo próprio.
- **I** — `build_goal_response` retorna `GoalResponse`; `chat_with_ai` valida o
  histórico do Mongo com `.get()`.

## Contrato de API / prontidão de produção
- **J** — `response_model` nas rotas `/ai/*` (para de vazar campos internos do
  insight) + 503 do chat documentado no OpenAPI.
- **K** — logging com request-id (`X-Request-ID`) + handler global de exceção
  (500 genérico, por dentro do CORS).
- **L** — `limit/offset` nos endpoints de lista; limita goals/recurring/wallets
  antes ilimitados (resposta segue array puro, front inalterado).

## Qualidade
- **P** — Pydantic `class Config` → `ConfigDict` (fim dos warnings de deprecação).
- **R** — `test_wallets.py` (ownership da carteira).
- **O** — `formatBRL` + `inputCls` compartilhados (fim das cópias).
- **M** — `ConfirmDialog` e `AmountPromptDialog` validados no lugar de
  prompt/confirm/alert; erro da API inline.
- **N** — `emptyForm`/`EMPTY_FORM` nos forms + guard no auto-select de carteira.
- **Q** — typos, magic numbers nomeados, comentários pt-BR, código morto; `npm run
  lint` 100% verde (allowConstantExport + node globals nos configs).

## Deploy
Merge dispara auto-deploy: Render (backend) + Vercel (frontend). **Nenhuma
migration nova** (nada altera schema). Backend no Render tem cold start ~50s; dar
F5 no front da Vercel após o rebuild.