### PR TITLE
Release: redesign da UI + categorias por tipo + IA (score determinístico, histórico de chat, Leitura por fingerprint)

### DIFF
--- a/.impeccable/config.json
+++ b/.impeccable/config.json
@@ -1,0 +1,14 @@
+{
+  "detector": {
+    "ignoreRules": [],
+    "ignoreFiles": [],
+    "ignoreValues": [
+      {
+        "rule": "overused-font",
+        "value": "inter",
+        "reason": "Inter e identidade fechada do brand book Norby (docs/design-workflow.md + DESIGN.md)",
+        "createdAt": "2026-07-02T03:43:18.297Z"
+      }
+    ]
+  }
+}

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,82 @@
+# Design — Norby "Petróleo Confiável"
+
+Tema dark único (não há modo claro). Cena física: uso desktop à noite; o app é
+um painel de instrumentos calmo sob pouca luz ambiente.
+
+## Color
+
+Paleta fechada — hex imutáveis, definidos em `frontend/tailwind.config.js`
+(namespace Tailwind `norby-*`). Variações só por opacidade (`/70`, `/15`…).
+
+| Token | Hex | Papel |
+|---|---|---|
+| `norby-night` | `#07100F` | Fundo do body |
+| `norby-surface` | `#0E1B19` | Cards e sidebar |
+| `norby-surface2` | `#152624` | Superfície elevada (tooltip, hover, dialog) |
+| `norby-teal` | `#2DB5A3` | Accent: ação primária, seleção, presença da IA |
+| `norby-teal-soft` | `#6FD4C6` | Accent claro: valores em destaque, hover do accent |
+| `norby-ivory` | `#EFFAF8` | Texto principal |
+| `norby-income` | `#5FBF7E` | Semântico: receita/positivo |
+| `norby-expense` | `#8A8580` | Semântico: neutro de despesa |
+| `norby-danger` | `#E06A4A` | Semântico: gasto/negativo/destrutivo |
+
+- Estratégia: **Restrained** — neutros escuros + teal ≤10% da superfície.
+- Texto secundário: `ivory/60` mínimo para corpo; `ivory/40` só para labels grandes/uppercase.
+- Cores categóricas de gráfico (donut): `#2DB5A3`, `#5B8DEF`, `#E0B341`, `#E0725C`, `#7BD88F`, `#6FD4C6` — uso exclusivo em data-viz.
+- Fundo Aurora teal (`components/Aurora.jsx`) atrás de overlay `night/60`: o glow é ambiente, nunca compete com dado.
+
+## Typography
+
+- **Família única: Inter** (identidade fechada do brand book). Sem display font.
+- Escala fixa em rem, ratio ~1.2: `text-[11px]` labels uppercase `tracking-widest` · `text-xs` meta · `text-sm` corpo de UI · `text-base` prosa · `text-xl` título de card · `text-3xl` título de página/saudação · `text-4xl` valor-herói (saldo).
+- Números monetários e tabelas: `font-variant-numeric: tabular-nums` (classe `.tnum`), `tracking-tight` em valores grandes.
+- Centavos de valores-herói em tamanho menor e `ivory/50` (padrão do rascunho aprovado).
+
+## Signature
+
+**A estrela-norte de 4 pontas** (path do monograma em `components/shared/Logo.jsx`)
+é o marcador de posição do app — e só isso:
+
+1. Indicador do item ativo da sidebar.
+2. Orbe da IA: gradiente radial `teal → teal-soft → transparente` com a estrela
+   no centro (card Leitura da IA, chat, hero do dashboard).
+3. Loading: estrela pulsando no lugar de spinner genérico.
+
+O monograma (N + estrela) é intocável: nenhum path/stroke muda.
+
+## Components
+
+- **Card:** `bg-norby-surface/70 border border-white/[0.06] rounded-3xl` +
+  `backdrop-blur-xl` (classe `.glass-card`). Hover: borda `white/[0.14]`.
+  Sem nested cards; blocos internos usam `bg-white/[0.03] rounded-2xl`.
+- **Botão primário:** pill (`rounded-full`), `bg-norby-teal text-norby-night`,
+  h-10, hover `bg-norby-teal-soft`, `active:scale-[0.98]`. Glow teal só aqui.
+- **Botão secundário:** pill outline `border-white/10 text-norby-ivory hover:bg-white/5`.
+- **Chip de tendência:** pill `bg-norby-income/15 text-norby-income` (ou danger)
+  com seta; nunca texto solto.
+- **Inputs:** `bg-white/5 border-white/10 rounded-xl`, foco `ring-norby-teal`.
+- **Estados obrigatórios:** default, hover, focus-visible, active, disabled,
+  loading, empty (que ensina a agir), error.
+- Ícones: **lucide-react** exclusivamente.
+
+## Layout
+
+- Shell: sidebar 16rem fixa + conteúdo `max-w-7xl` com `p-8`.
+- Bento grid no dashboard: `gap-5`, cards de proporções variadas; densidade
+  cresce para baixo (hero → widgets → tabelas).
+- Padding interno de card: `p-6` (compacto `p-5`).
+
+## Motion
+
+- 150–250ms, `ease-out`; nada de bounce/elastic.
+- Motion comunica estado (hover, seleção, feedback, loading) — sem coreografia
+  de page-load; entrada máxima: fade único e rápido.
+- Orbe da IA: pulso lento e sutil (opacity/scale ≤3%), o único motion ambiente.
+- `@media (prefers-reduced-motion: reduce)` desativa tudo, sempre.
+
+## Anti-padrões (deste projeto)
+
+- Âmbar/dourado/laranja como accent (era Lumea) — proibido.
+- `#000` puro; bloco teal chapado em navegação (compete com o CTA).
+- Side-stripe borders, gradient text, eyebrow uppercase em toda seção.
+- Spinner circular genérico (usar a estrela).

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,0 +1,54 @@
+# Product
+
+## Register
+
+product
+
+## Users
+
+Pessoas físicas organizando as próprias finanças (o desenvolvedor é também o
+usuário primário). Contexto: uso desktop, geralmente à noite, em sessões curtas
+de conferência ("como estou este mês?") ou de lançamento de transações. O
+trabalho a ser feito: registrar receitas/despesas, acompanhar saldo, metas e
+recorrências, e receber leitura de IA sobre o próprio comportamento financeiro.
+
+## Product Purpose
+
+Norby é um organizador financeiro pessoal com IA ("seu norte financeiro"):
+carteiras, transações, recorrências, metas (SAVINGS/BUDGET) e um analista IA
+(Gemini) que gera score, insights e chat. Sucesso = o usuário confia nos
+números à primeira vista e volta todo dia sem fricção.
+
+## Brand Personality
+
+Confiável, calmo, preciso. Um instrumento de navegação noturna: painel escuro,
+dados nítidos, um único brilho teal orientando a atenção. Voz em pt-BR, direta
+e sem jargão bancário; a IA fala como um copiloto, não como um consultor pomposo.
+
+## Anti-references
+
+- A paleta âmbar antiga (era Lumea) — nunca reintroduzir dourado/laranja como accent.
+- Gradiente roxo-azul genérico de SaaS/fintech.
+- Dashboard-template: hero-metric com gradiente, cards idênticos em grade, glassmorphism decorativo.
+- Banco digital que "vende" (upsell, badges, confete). Norby organiza, não vende.
+
+## Design Principles
+
+1. **Números primeiro.** Todo layout existe para deixar um número legível em 1s.
+   Figuras tabulares, hierarquia por escala, ruído zero ao redor do dado.
+2. **Um brilho só.** O teal marca ação primária, seleção e a presença da IA.
+   Nunca decoração. Estados inativos ficam em neutros.
+3. **A estrela orienta.** O motivo estrela-norte (do monograma) é o marcador de
+   posição do app: item ativo, presença da IA, loading. Em nenhum outro lugar.
+4. **Familiaridade ganha de surpresa.** Padrões de produto consagrados
+   (sidebar, tabelas, dialogs); a personalidade vive no acabamento, não em
+   affordances inventadas.
+5. **Funcionalidade é sagrada.** Redesign nunca remove, esconde ou altera
+   comportamento — só aparência e ergonomia.
+
+## Accessibility & Inclusion
+
+- Contraste mínimo WCAG AA (4.5:1 corpo, 3:1 texto grande) sobre os fundos escuros.
+- `prefers-reduced-motion` respeitado em toda animação.
+- Semântica de cor nunca é o único canal (setas/sinais acompanham verde/vermelho).
+- Interface em pt-BR; valores em BRL com `tabular-nums`.

--- a/backend/app/routers/ai.py
+++ b/backend/app/routers/ai.py
@@ -6,7 +6,12 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.dependencies import get_db, get_current_user
 from app.models.sql_models import User
 from app.services.ai_service import get_or_generate_insight, chat_with_ai
-from app.schemas.ai import InsightResponse, ChatResponse, ChatSessionSummary
+from app.schemas.ai import (
+    InsightResponse,
+    ChatResponse,
+    ChatSessionSummary,
+    ChatSessionDetail,
+)
 from app.database import chat_history_collection
 import logging
 
@@ -109,4 +114,23 @@ async def list_sessions(current_user: User = Depends(get_current_user)): # Lista
             "first_message": doc["messages"][0]["content"] if doc.get("messages") else "",
         })
     return sessions
-        
+
+
+@router.get("/chat/sessions/{session_id}", response_model=ChatSessionDetail)
+async def get_session(
+    session_id: str,
+    current_user: User = Depends(get_current_user),
+):  # Mensagens de uma sessão do próprio usuário
+    doc = await chat_history_collection.find_one(
+        {"user_id": str(current_user.id), "session_id": session_id}
+    )
+    if not doc:
+        raise HTTPException(status_code=404, detail="Conversa não encontrada")
+
+    # .get() defensivo: mensagens malformadas (sem content) são ignoradas.
+    messages = [
+        {"role": m.get("role"), "content": m.get("content")}
+        for m in doc.get("messages", [])
+        if m.get("content")
+    ]
+    return {"session_id": session_id, "messages": messages}

--- a/backend/app/routers/ai.py
+++ b/backend/app/routers/ai.py
@@ -127,10 +127,10 @@ async def get_session(
     if not doc:
         raise HTTPException(status_code=404, detail="Conversa não encontrada")
 
-    # .get() defensivo: mensagens malformadas (sem content) são ignoradas.
+    # .get() defensivo: mensagens malformadas (sem content ou sem role) são ignoradas.
     messages = [
         {"role": m.get("role"), "content": m.get("content")}
         for m in doc.get("messages", [])
-        if m.get("content")
+        if m.get("content") and m.get("role")
     ]
     return {"session_id": session_id, "messages": messages}

--- a/backend/app/schemas/ai.py
+++ b/backend/app/schemas/ai.py
@@ -22,3 +22,13 @@ class ChatSessionSummary(BaseModel):
     session_id: str
     updated_at: datetime | None = None
     first_message: str = ""
+
+
+class ChatMessageOut(BaseModel):
+    role: str
+    content: str
+
+
+class ChatSessionDetail(BaseModel):
+    session_id: str
+    messages: list[ChatMessageOut]

--- a/backend/app/services/ai_service.py
+++ b/backend/app/services/ai_service.py
@@ -169,7 +169,10 @@ async def get_or_generate_insight(db: AsyncSession, user_id: str, month: int, ye
                 "suggested_action": suggested_action,
                 "data_fingerprint": fingerprint,
                 "generated_at": generated_at,
-            }
+            },
+            # Score é sempre recalculado, nunca servido do cache — não deixar um
+            # score antigo (do código legado) persistir e ser lido por engano.
+            "$unset": {"score": ""},
         },
         upsert=True,
     )

--- a/backend/app/services/ai_service.py
+++ b/backend/app/services/ai_service.py
@@ -115,13 +115,20 @@ async def get_or_generate_insight(db: AsyncSession, user_id: str, month: int, ye
         data = json.loads(raw)
         summary_text = data["summary_text"]
         suggested_action = data["suggested_action"]
-    except (AttributeError, ValueError, KeyError, TypeError) as e:
+    except (AttributeError, ValueError, KeyError, TypeError):
         raw_text = getattr(response, "text", None)
         logger.exception(
             "Resposta da IA inválida ao gerar insight (user=%s). Texto cru: %r",
             user_id, raw_text,
         )
-        raise ValueError("Resposta da IA em formato inesperado") from e
+        # O texto da IA falhou, mas o score é determinístico — devolve o score real.
+        # Não cacheia (retorna sem passar por insert_one), para tentar de novo na próxima chamada.
+        return {
+            "score": score,
+            "summary_text": "",
+            "suggested_action": None,
+            "error": "Não foi possível gerar a leitura da IA",
+        }
 
     # Cacheia só o texto no MongoDB (score fica fora do cache).
     insight = {

--- a/backend/app/services/ai_service.py
+++ b/backend/app/services/ai_service.py
@@ -8,6 +8,7 @@ from app.services.goal_service import current_month_range
 from app.services.score_service import compute_financial_score
 from app.config import get_settings
 import asyncio
+import hashlib
 import json
 import re
 import logging
@@ -72,6 +73,25 @@ async def _get_user_financial_summary(db: AsyncSession, user_id: str) -> dict:
         "top_categories": categories,
     }
     
+def _summary_fingerprint(summary: dict) -> str:
+    """Impressão digital dos dados que embasam o texto da IA.
+
+    Se qualquer número/categoria muda, o fingerprint muda e o texto é
+    regenerado — evita a 'Leitura da IA' congelada quando as transações do mês
+    mudam, sem precisar chamar o Gemini a cada carga do dashboard.
+    """
+    payload = json.dumps(
+        {
+            "income": summary.get("total_income"),
+            "expenses": summary.get("total_expenses"),
+            "categories": summary.get("top_categories"),
+        },
+        sort_keys=True,
+        default=str,
+    )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
 async def get_or_generate_insight(db: AsyncSession, user_id: str, month: int, year: int) -> dict:
     reference = f"{year}-{month:02d}"
 
@@ -79,12 +99,15 @@ async def get_or_generate_insight(db: AsyncSession, user_id: str, month: int, ye
     # para não congelar quando as transações do mês mudam.
     summary = await _get_user_financial_summary(db, user_id)
     score = compute_financial_score(summary)
+    fingerprint = _summary_fingerprint(summary)
 
-    # Texto (summary_text/suggested_action) pode vir do cache mensal.
+    # Texto (summary_text/suggested_action) é cacheado por mês, mas só
+    # reaproveitado se os dados que o embasam não mudaram (fingerprint bate).
+    # Assim a leitura nunca contradiz os números do dashboard.
     cached = await ai_insights_collection.find_one(
         {"user_id": user_id, "reference_month": reference}
     )
-    if cached:
+    if cached and cached.get("data_fingerprint") == fingerprint:
         cached.pop("_id", None)
         cached["score"] = score
         return cached
@@ -132,18 +155,30 @@ async def get_or_generate_insight(db: AsyncSession, user_id: str, month: int, ye
             "error": "Não foi possível gerar a leitura da IA",
         }
 
-    # Cacheia só o texto no MongoDB (score fica fora do cache).
-    insight = {
-        "user_id": user_id,
-        "reference_month": reference,
+    # Cacheia só o texto + o fingerprint dos dados (score fica fora do cache).
+    # upsert em (user_id, reference_month) → sempre 1 doc por usuário/mês:
+    # sobrescreve o texto velho e não cria duplicados sob concorrência.
+    generated_at = datetime.now(timezone.utc).isoformat()
+    await ai_insights_collection.update_one(
+        {"user_id": user_id, "reference_month": reference},
+        {
+            "$set": {
+                "user_id": user_id,
+                "reference_month": reference,
+                "summary_text": summary_text,
+                "suggested_action": suggested_action,
+                "data_fingerprint": fingerprint,
+                "generated_at": generated_at,
+            }
+        },
+        upsert=True,
+    )
+    return {
+        "score": score,
         "summary_text": summary_text,
         "suggested_action": suggested_action,
-        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "generated_at": generated_at,
     }
-    await ai_insights_collection.insert_one(insight)
-    insight.pop("_id", None)
-    insight["score"] = score
-    return insight
 
 async def chat_with_ai(db: AsyncSession, user_id: str, message: str, history: list) -> str:
     """ Chat contextualizado com dados financeiros do usuário """

--- a/backend/app/services/ai_service.py
+++ b/backend/app/services/ai_service.py
@@ -105,17 +105,19 @@ async def get_or_generate_insight(db: AsyncSession, user_id: str, month: int, ye
     }}
     """
 
-    # Chamada bloqueante do SDK -> offload p/ thread pra não travar o event loop
-    response = await asyncio.to_thread(model.generate_content, prompt)
-
-    # A IA pode devolver texto não-JSON, vazio ou ser bloqueada por safety filter.
+    # A IA pode falhar na chamada (API/rede/quota) ou devolver texto não-JSON,
+    # vazio ou bloqueado por safety filter — qualquer uma dessas falhas não
+    # pode derrubar o score determinístico já calculado.
+    response = None
     try:
+        # Chamada bloqueante do SDK -> offload p/ thread pra não travar o event loop
+        response = await asyncio.to_thread(model.generate_content, prompt)
         raw = response.text.strip()
         raw = re.sub(r"```json|```", "", raw).strip()  # Tira formatação markdown
         data = json.loads(raw)
         summary_text = data["summary_text"]
         suggested_action = data["suggested_action"]
-    except (AttributeError, ValueError, KeyError, TypeError):
+    except Exception:
         raw_text = getattr(response, "text", None)
         logger.exception(
             "Resposta da IA inválida ao gerar insight (user=%s). Texto cru: %r",

--- a/backend/app/services/ai_service.py
+++ b/backend/app/services/ai_service.py
@@ -5,6 +5,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.database import ai_insights_collection
 from app.models.sql_models import Transaction, TransactionType
 from app.services.goal_service import current_month_range
+from app.services.score_service import compute_financial_score
 from app.config import get_settings
 import asyncio
 import json
@@ -74,18 +75,21 @@ async def _get_user_financial_summary(db: AsyncSession, user_id: str) -> dict:
 async def get_or_generate_insight(db: AsyncSession, user_id: str, month: int, year: int) -> dict:
     reference = f"{year}-{month:02d}"
 
-    # Verifica cache
+    # Score é sempre recalculado (determinístico) — nunca servido do cache,
+    # para não congelar quando as transações do mês mudam.
+    summary = await _get_user_financial_summary(db, user_id)
+    score = compute_financial_score(summary)
+
+    # Texto (summary_text/suggested_action) pode vir do cache mensal.
     cached = await ai_insights_collection.find_one(
         {"user_id": user_id, "reference_month": reference}
     )
     if cached:
         cached.pop("_id", None)
+        cached["score"] = score
         return cached
 
-    # Busca dados financeiros
-    summary = await _get_user_financial_summary(db, user_id)
-
-    # Chama o Gemini
+    # Chama o Gemini só para o texto (o número não vem mais do LLM).
     prompt = f"""
     Você é um consultor financeiro pessoal. Analise os dados abaixo e responda em português (pt-BR).
     Dados do usuário em {summary['month']}:
@@ -93,25 +97,22 @@ async def get_or_generate_insight(db: AsyncSession, user_id: str, month: int, ye
     - Despesas totais: R$ {summary['total_expenses']:.2f}
     - Saldo: R$ {summary['balance']:.2f}
     - Maiores categorias de gasto: {summary['top_categories']}
-    
+
     responda APENAS em JSON com este formato (sem markdown):
     {{
-        "score": <número de 0 a 100 representando saúde financeira>,
         "summary_text": "<3 insights curtos separados por | sobre o comportamento financeiro>",
         "suggested_action": "<uma sugestão prática e específica>"
     }}
     """
-    
+
     # Chamada bloqueante do SDK -> offload p/ thread pra não travar o event loop
     response = await asyncio.to_thread(model.generate_content, prompt)
 
     # A IA pode devolver texto não-JSON, vazio ou ser bloqueada por safety filter.
-    # Parsing isolado: se falhar, loga o texto cru e propaga pro router tratar.
     try:
         raw = response.text.strip()
         raw = re.sub(r"```json|```", "", raw).strip()  # Tira formatação markdown
         data = json.loads(raw)
-        score = data["score"]
         summary_text = data["summary_text"]
         suggested_action = data["suggested_action"]
     except (AttributeError, ValueError, KeyError, TypeError) as e:
@@ -122,17 +123,17 @@ async def get_or_generate_insight(db: AsyncSession, user_id: str, month: int, ye
         )
         raise ValueError("Resposta da IA em formato inesperado") from e
 
-    # Salva no cache do MongoDB
+    # Cacheia só o texto no MongoDB (score fica fora do cache).
     insight = {
         "user_id": user_id,
         "reference_month": reference,
-        "score": score,
         "summary_text": summary_text,
         "suggested_action": suggested_action,
         "generated_at": datetime.now(timezone.utc).isoformat(),
     }
     await ai_insights_collection.insert_one(insight)
     insight.pop("_id", None)
+    insight["score"] = score
     return insight
 
 async def chat_with_ai(db: AsyncSession, user_id: str, message: str, history: list) -> str:

--- a/backend/app/services/score_service.py
+++ b/backend/app/services/score_service.py
@@ -1,0 +1,37 @@
+"""Score de saúde financeira determinístico (0-100).
+
+Calculado por regras a partir do resumo mensal do usuário, em vez de ser
+inventado por um LLM: previsível, testável e instantâneo. Baseado na taxa de
+poupança do mês corrente: s = (receita - despesa) / receita.
+"""
+
+
+def compute_financial_score(summary: dict) -> float | None:
+    income = float(summary.get("total_income") or 0)
+    expenses = float(summary.get("total_expenses") or 0)
+
+    # Sem nenhum dado no mês → sem score (dashboard mostra "—").
+    if income == 0 and expenses == 0:
+        return None
+
+    # Gastou sem nenhuma receita registrada: pior cenário com dados.
+    if income == 0:
+        return 10
+
+    savings_rate = (income - expenses) / income
+
+    if savings_rate >= 0.5:
+        score = 100
+    elif savings_rate >= 0.3:
+        # 0.3 -> 90 ; 0.5 -> 100
+        score = 90 + (savings_rate - 0.3) / 0.2 * 10
+    elif savings_rate >= 0:
+        # 0 -> 50 ; 0.3 -> 90
+        score = 50 + savings_rate / 0.3 * 40
+    elif savings_rate > -0.5:
+        # 0 -> 50 ; -0.5 -> 0
+        score = (savings_rate + 0.5) / 0.5 * 50
+    else:
+        score = 0
+
+    return round(score)

--- a/backend/scripts/dedupe_ai_insights.py
+++ b/backend/scripts/dedupe_ai_insights.py
@@ -1,0 +1,49 @@
+"""Manutenção one-off: remove insights de IA duplicados por
+(user_id, reference_month) e cria um índice único que impede novas duplicatas.
+
+Contexto: o insight do dashboard passou a usar upsert em (user_id,
+reference_month), mas o código antigo fazia insert_one sem índice único, o que
+permitiu duplicatas sob concorrência (duas cargas simultâneas do dashboard).
+Este script limpa o passivo e blinda o futuro.
+
+Idempotente — seguro rodar mais de uma vez. Rodar UMA vez por ambiente:
+    docker exec norby_backend python scripts/dedupe_ai_insights.py   # dev
+(em produção, rodar contra o Mongo do ambiente uma única vez.)
+"""
+import asyncio
+import os
+import sys
+from collections import defaultdict
+
+# Permite rodar o arquivo diretamente (python scripts/dedupe_ai_insights.py):
+# garante que a raiz do backend (que contém o pacote `app`) esteja no path.
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from app.database import ai_insights_collection  # noqa: E402
+
+
+async def main() -> None:
+    groups: dict[tuple, list] = defaultdict(list)
+    async for doc in ai_insights_collection.find({}):
+        groups[(doc.get("user_id"), doc.get("reference_month"))].append(doc)
+
+    removed = 0
+    for docs in groups.values():
+        if len(docs) <= 1:
+            continue
+        # Mantém o mais recente por generated_at (docs sem data vão pro fim).
+        docs.sort(key=lambda d: d.get("generated_at") or "", reverse=True)
+        for stale in docs[1:]:
+            await ai_insights_collection.delete_one({"_id": stale["_id"]})
+            removed += 1
+
+    await ai_insights_collection.create_index(
+        [("user_id", 1), ("reference_month", 1)],
+        unique=True,
+        name="uniq_user_month",
+    )
+    print(f"duplicados removidos: {removed}; índice único 'uniq_user_month' garantido.")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/backend/scripts/dedupe_ai_insights.py
+++ b/backend/scripts/dedupe_ai_insights.py
@@ -37,12 +37,21 @@ async def main() -> None:
             await ai_insights_collection.delete_one({"_id": stale["_id"]})
             removed += 1
 
+    # Score nunca deve viver no cache (é sempre recalculado). Remove qualquer
+    # score legado deixado pelo código antigo, para ninguém servir um valor velho.
+    cleaned = await ai_insights_collection.update_many(
+        {"score": {"$exists": True}}, {"$unset": {"score": ""}}
+    )
+
     await ai_insights_collection.create_index(
         [("user_id", 1), ("reference_month", 1)],
         unique=True,
         name="uniq_user_month",
     )
-    print(f"duplicados removidos: {removed}; índice único 'uniq_user_month' garantido.")
+    print(
+        f"duplicados removidos: {removed}; scores legados limpos: "
+        f"{cleaned.modified_count}; índice único 'uniq_user_month' garantido."
+    )
 
 
 if __name__ == "__main__":

--- a/backend/tests/test_ai.py
+++ b/backend/tests/test_ai.py
@@ -38,6 +38,9 @@ class _FakeInsights:
     async def insert_one(self, *_a, **_k):
         return None
 
+    async def update_one(self, *_a, **_k):
+        return None
+
 
 @pytest.mark.asyncio
 async def test_insight_score_is_deterministic_not_from_llm(db_session, monkeypatch):
@@ -126,15 +129,20 @@ async def test_insight_returns_score_when_llm_call_raises(db_session, monkeypatc
 
 
 class _FakeInsightsCacheHit:
+    # Cache com fingerprint que BATE com o summary atual → texto é reaproveitado.
+    def __init__(self, fingerprint):
+        self._fp = fingerprint
+
     async def find_one(self, *_a, **_k):
         return {
             "score": 5,  # score em cache está desatualizado (stale)
             "summary_text": "cached text",
             "suggested_action": "x",
+            "data_fingerprint": self._fp,
         }
 
-    async def insert_one(self, *_a, **_k):
-        return None
+    async def update_one(self, *_a, **_k):
+        raise AssertionError("não deve regenerar quando o fingerprint bate")
 
 
 @pytest.mark.asyncio
@@ -152,8 +160,64 @@ async def test_insight_recomputes_score_on_cache_hit(db_session, monkeypatch):
         return summary
 
     monkeypatch.setattr(ai, "_get_user_financial_summary", _fake_summary)
-    monkeypatch.setattr(ai, "ai_insights_collection", _FakeInsightsCacheHit())
+    monkeypatch.setattr(
+        ai, "ai_insights_collection", _FakeInsightsCacheHit(ai._summary_fingerprint(summary))
+    )
+    # Se reaproveitar o cache, o Gemini nem é chamado.
+    def _boom(_p):
+        raise AssertionError("não deve chamar o Gemini quando o fingerprint bate")
+
+    monkeypatch.setattr(ai.model, "generate_content", _boom)
 
     result = await ai.get_or_generate_insight(db_session, "user-1", 7, 2026)
     assert result["score"] == 90
     assert result["summary_text"] == "cached text"
+
+
+class _FakeInsightsStale:
+    # Cache com fingerprint ANTIGO → dados mudaram → texto deve ser regenerado.
+    def __init__(self):
+        self.updated = False
+
+    async def find_one(self, *_a, **_k):
+        return {
+            "score": 5,
+            "summary_text": "texto velho e errado",
+            "suggested_action": "ação antiga",
+            "data_fingerprint": "fingerprint-antigo",
+        }
+
+    async def update_one(self, *_a, **_k):
+        self.updated = True
+        return None
+
+
+@pytest.mark.asyncio
+async def test_insight_regenerates_text_when_data_changes(db_session, monkeypatch):
+    # Regressão do bug real: a Leitura da IA ficava congelada mesmo com os dados
+    # do mês mudando. Com o fingerprint diferente, o texto tem que ser regenerado.
+    summary = {
+        "month": "July 2026",
+        "total_income": 4050.0,
+        "total_expenses": 230.0,  # s alto -> score 100
+        "balance": 3820.0,
+        "top_categories": [{"category": "Outros", "total": 100.0}],
+    }
+
+    async def _fake_summary(_db, _uid):
+        return summary
+
+    fake = _FakeInsightsStale()
+    monkeypatch.setattr(ai, "_get_user_financial_summary", _fake_summary)
+    monkeypatch.setattr(ai, "ai_insights_collection", fake)
+
+    class _Resp:
+        text = '{"summary_text": "novo|texto|fresco", "suggested_action": "nova ação"}'
+
+    monkeypatch.setattr(ai.model, "generate_content", lambda _p: _Resp())
+
+    result = await ai.get_or_generate_insight(db_session, "user-1", 7, 2026)
+    assert result["score"] == 100
+    assert result["summary_text"] == "novo|texto|fresco"  # regenerado, não o velho
+    assert result["suggested_action"] == "nova ação"
+    assert fake.updated is True  # cache foi sobrescrito (upsert)

--- a/backend/tests/test_ai.py
+++ b/backend/tests/test_ai.py
@@ -29,3 +29,39 @@ async def test_chat_survives_malformed_history_message(db_session, monkeypatch):
     history = [{"foo": "bar"}, {"role": "user", "content": "oi"}]  # 1ª é malformada
     resp = await ai.chat_with_ai(db_session, str(user.id), "olá", history)
     assert resp == "resposta ok"
+
+
+class _FakeInsights:
+    async def find_one(self, *_a, **_k):
+        return None
+
+    async def insert_one(self, *_a, **_k):
+        return None
+
+
+@pytest.mark.asyncio
+async def test_insight_score_is_deterministic_not_from_llm(db_session, monkeypatch):
+    # O score vem do cálculo, não do texto do LLM (que aqui nem traz score).
+    summary = {
+        "month": "July 2026",
+        "total_income": 1000.0,
+        "total_expenses": 700.0,  # s=0.3 -> 90
+        "balance": 300.0,
+        "top_categories": [],
+    }
+
+    async def _fake_summary(_db, _uid):
+        return summary
+
+    monkeypatch.setattr(ai, "_get_user_financial_summary", _fake_summary)
+    monkeypatch.setattr(ai, "ai_insights_collection", _FakeInsights())
+
+    class _Resp:
+        text = '{"summary_text": "a|b|c", "suggested_action": "faça X"}'
+
+    monkeypatch.setattr(ai.model, "generate_content", lambda _p: _Resp())
+
+    result = await ai.get_or_generate_insight(db_session, "user-1", 7, 2026)
+    assert result["score"] == 90
+    assert result["summary_text"] == "a|b|c"
+    assert result["suggested_action"] == "faça X"

--- a/backend/tests/test_ai.py
+++ b/backend/tests/test_ai.py
@@ -65,3 +65,66 @@ async def test_insight_score_is_deterministic_not_from_llm(db_session, monkeypat
     assert result["score"] == 90
     assert result["summary_text"] == "a|b|c"
     assert result["suggested_action"] == "faça X"
+
+
+@pytest.mark.asyncio
+async def test_insight_returns_score_when_llm_text_fails(db_session, monkeypatch):
+    # Mesmo se o texto da IA vier quebrado, o score (determinístico) deve ser
+    # retornado normalmente — só o texto degrada.
+    summary = {
+        "month": "July 2026",
+        "total_income": 1000.0,
+        "total_expenses": 700.0,  # s=0.3 -> 90
+        "balance": 300.0,
+        "top_categories": [],
+    }
+
+    async def _fake_summary(_db, _uid):
+        return summary
+
+    monkeypatch.setattr(ai, "_get_user_financial_summary", _fake_summary)
+    monkeypatch.setattr(ai, "ai_insights_collection", _FakeInsights())
+
+    class _BadResp:
+        text = "desculpe, não consegui"
+
+    monkeypatch.setattr(ai.model, "generate_content", lambda _p: _BadResp())
+
+    result = await ai.get_or_generate_insight(db_session, "user-1", 7, 2026)
+    assert result["score"] == 90
+    assert result["summary_text"] == ""
+    assert result.get("error")
+
+
+class _FakeInsightsCacheHit:
+    async def find_one(self, *_a, **_k):
+        return {
+            "score": 5,  # score em cache está desatualizado (stale)
+            "summary_text": "cached text",
+            "suggested_action": "x",
+        }
+
+    async def insert_one(self, *_a, **_k):
+        return None
+
+
+@pytest.mark.asyncio
+async def test_insight_recomputes_score_on_cache_hit(db_session, monkeypatch):
+    # O texto pode vir do cache mensal, mas o score é sempre recalculado.
+    summary = {
+        "month": "July 2026",
+        "total_income": 1000.0,
+        "total_expenses": 700.0,  # s=0.3 -> 90
+        "balance": 300.0,
+        "top_categories": [],
+    }
+
+    async def _fake_summary(_db, _uid):
+        return summary
+
+    monkeypatch.setattr(ai, "_get_user_financial_summary", _fake_summary)
+    monkeypatch.setattr(ai, "ai_insights_collection", _FakeInsightsCacheHit())
+
+    result = await ai.get_or_generate_insight(db_session, "user-1", 7, 2026)
+    assert result["score"] == 90
+    assert result["summary_text"] == "cached text"

--- a/backend/tests/test_ai.py
+++ b/backend/tests/test_ai.py
@@ -178,6 +178,7 @@ class _FakeInsightsStale:
     # Cache com fingerprint ANTIGO → dados mudaram → texto deve ser regenerado.
     def __init__(self):
         self.updated = False
+        self.update = None
 
     async def find_one(self, *_a, **_k):
         return {
@@ -187,8 +188,9 @@ class _FakeInsightsStale:
             "data_fingerprint": "fingerprint-antigo",
         }
 
-    async def update_one(self, *_a, **_k):
+    async def update_one(self, _filter, update, **_k):
         self.updated = True
+        self.update = update
         return None
 
 
@@ -221,3 +223,5 @@ async def test_insight_regenerates_text_when_data_changes(db_session, monkeypatc
     assert result["summary_text"] == "novo|texto|fresco"  # regenerado, não o velho
     assert result["suggested_action"] == "nova ação"
     assert fake.updated is True  # cache foi sobrescrito (upsert)
+    # score nunca vive no cache: o upsert deve REMOVER qualquer score persistido.
+    assert "score" in fake.update.get("$unset", {})

--- a/backend/tests/test_ai.py
+++ b/backend/tests/test_ai.py
@@ -96,6 +96,35 @@ async def test_insight_returns_score_when_llm_text_fails(db_session, monkeypatch
     assert result.get("error")
 
 
+@pytest.mark.asyncio
+async def test_insight_returns_score_when_llm_call_raises(db_session, monkeypatch):
+    # Erro de API/rede/quota do Gemini (não só parse) também deve degradar
+    # com elegância e devolver o score determinístico já calculado.
+    summary = {
+        "month": "July 2026",
+        "total_income": 1000.0,
+        "total_expenses": 700.0,  # s=0.3 -> 90
+        "balance": 300.0,
+        "top_categories": [],
+    }
+
+    async def _fake_summary(_db, _uid):
+        return summary
+
+    monkeypatch.setattr(ai, "_get_user_financial_summary", _fake_summary)
+    monkeypatch.setattr(ai, "ai_insights_collection", _FakeInsights())
+
+    def _boom(_p):
+        raise RuntimeError("gemini down")
+
+    monkeypatch.setattr(ai.model, "generate_content", _boom)
+
+    result = await ai.get_or_generate_insight(db_session, "user-1", 7, 2026)
+    assert result["score"] == 90
+    assert result["summary_text"] == ""
+    assert result.get("error")
+
+
 class _FakeInsightsCacheHit:
     async def find_one(self, *_a, **_k):
         return {

--- a/backend/tests/test_ai_history.py
+++ b/backend/tests/test_ai_history.py
@@ -30,6 +30,7 @@ async def test_get_session_returns_messages(client, monkeypatch):
             {"role": "user", "content": "oi"},
             {"role": "assistant", "content": "olá"},
             {"role": "user"},  # malformada (sem content) → ignorada
+            {"content": "sem role"},  # malformada (sem role) → ignorada
         ],
     }]
     monkeypatch.setattr(ai_router, "chat_history_collection", _FakeChatHistory(docs))

--- a/backend/tests/test_ai_history.py
+++ b/backend/tests/test_ai_history.py
@@ -1,0 +1,66 @@
+import types
+
+import pytest
+
+from app.main import app
+from app.dependencies import get_current_user
+import app.routers.ai as ai_router
+
+
+class _FakeChatHistory:
+    """Coleção falsa que honra o filtro user_id/session_id do find_one."""
+
+    def __init__(self, docs):
+        self._docs = docs
+
+    async def find_one(self, query, *_a, **_k):
+        for d in self._docs:
+            if all(d.get(k) == v for k, v in query.items()):
+                return d
+        return None
+
+
+@pytest.mark.asyncio
+async def test_get_session_returns_messages(client, monkeypatch):
+    app.dependency_overrides[get_current_user] = lambda: types.SimpleNamespace(id="user-A")
+    docs = [{
+        "user_id": "user-A",
+        "session_id": "s1",
+        "messages": [
+            {"role": "user", "content": "oi"},
+            {"role": "assistant", "content": "olá"},
+            {"role": "user"},  # malformada (sem content) → ignorada
+        ],
+    }]
+    monkeypatch.setattr(ai_router, "chat_history_collection", _FakeChatHistory(docs))
+
+    res = await client.get("/ai/chat/sessions/s1")
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert body["session_id"] == "s1"
+    assert body["messages"] == [
+        {"role": "user", "content": "oi"},
+        {"role": "assistant", "content": "olá"},
+    ]
+    app.dependency_overrides.pop(get_current_user, None)
+
+
+@pytest.mark.asyncio
+async def test_get_session_404_for_other_user(client, monkeypatch):
+    # user-B não pode ver a sessão de user-A.
+    app.dependency_overrides[get_current_user] = lambda: types.SimpleNamespace(id="user-B")
+    docs = [{"user_id": "user-A", "session_id": "s1", "messages": []}]
+    monkeypatch.setattr(ai_router, "chat_history_collection", _FakeChatHistory(docs))
+
+    res = await client.get("/ai/chat/sessions/s1")
+    assert res.status_code == 404
+    app.dependency_overrides.pop(get_current_user, None)
+
+
+@pytest.mark.asyncio
+async def test_session_detail_route_in_openapi(client):
+    spec = (await client.get("/openapi.json")).json()
+    path = spec["paths"]["/ai/chat/sessions/{session_id}"]["get"]
+    ref = path["responses"]["200"]["content"]["application/json"]["schema"].get("$ref", "")
+    assert ref.endswith("/ChatSessionDetail")
+    assert "ChatSessionDetail" in spec["components"]["schemas"]

--- a/backend/tests/test_score.py
+++ b/backend/tests/test_score.py
@@ -1,0 +1,25 @@
+import pytest
+
+from app.services.score_service import compute_financial_score
+
+
+@pytest.mark.parametrize(
+    "income,expenses,expected",
+    [
+        (0, 0, None),      # sem dados
+        (0, 500, 10),      # só gastos, sem receita
+        (1000, 0, 100),    # poupou tudo
+        (1000, 400, 100),  # s=0.6 -> 100
+        (1000, 600, 95),   # s=0.4 -> 95
+        (1000, 700, 90),   # s=0.3 -> 90 (borda)
+        (1000, 850, 70),   # s=0.15 -> 70
+        (1000, 1000, 50),  # s=0 -> 50 (borda)
+        (1000, 1200, 30),  # s=-0.2 -> 30
+        (1000, 1400, 10),  # s=-0.4 -> 10
+        (1000, 1500, 0),   # s=-0.5 -> 0 (borda)
+        (1000, 3000, 0),   # déficit extremo -> 0
+    ],
+)
+def test_compute_financial_score(income, expenses, expected):
+    summary = {"total_income": income, "total_expenses": expenses}
+    assert compute_financial_score(summary) == expected

--- a/frontend/src/api/ai.js
+++ b/frontend/src/api/ai.js
@@ -4,5 +4,5 @@ export const aiApi = {
   getInsight: () => api.get("/ai/insight"),
   chat: (data) => api.post("/ai/chat", data),
   getSessions: () => api.get("/ai/chat/sessions"),
-  getSession: (id) => api.get(`/ai/chat/sessions/${id}`),
+  getSession: (id) => api.get(`/ai/chat/sessions/${encodeURIComponent(id)}`),
 };

--- a/frontend/src/api/ai.js
+++ b/frontend/src/api/ai.js
@@ -4,4 +4,5 @@ export const aiApi = {
   getInsight: () => api.get("/ai/insight"),
   chat: (data) => api.post("/ai/chat", data),
   getSessions: () => api.get("/ai/chat/sessions"),
+  getSession: (id) => api.get(`/ai/chat/sessions/${id}`),
 };

--- a/frontend/src/components/layout/AppLayout.jsx
+++ b/frontend/src/components/layout/AppLayout.jsx
@@ -20,10 +20,8 @@ export default function AppLayout() {
       <div className="relative z-10 flex h-screen">
         <Sidebar />
         
-        <main className="flex-1 overflow-y-auto p-8">
-          <div className="max-w-7xl mx-auto">
-            <Outlet />
-          </div>
+        <main className="flex-1 overflow-y-auto px-8 py-6">
+          <Outlet />
         </main>
       </div>
     </div>

--- a/frontend/src/components/layout/Sidebar.jsx
+++ b/frontend/src/components/layout/Sidebar.jsx
@@ -30,7 +30,8 @@ const prefItems = [
 
 // Item de navegação: ativo = estrela-norte teal + texto ivory sobre fundo
 // sutil (o teal chapado fica reservado ao CTA primário — ver DESIGN.md).
-function NavItem({ to, icon: Icon, label }) {
+function NavItem({ to, icon, label }) {
+  const Icon = icon;
   return (
     <NavLink
       to={to}

--- a/frontend/src/components/layout/Sidebar.jsx
+++ b/frontend/src/components/layout/Sidebar.jsx
@@ -12,16 +12,48 @@ import {
   Target,
 } from "lucide-react";
 import NorbyMark from "../shared/Logo";
+import NorthStar from "../shared/NorthStar";
+import AiOrb from "../shared/AiOrb";
 
-const navItems = [
+const mainItems = [
   { to: "/dashboard", icon: LayoutDashboard, label: "Dashboard" },
   { to: "/wallets", icon: Wallet, label: "Carteiras" },
   { to: "/transactions", icon: FileText, label: "Relatórios" },
   { to: "/recurring", icon: Repeat, label: "Recorrências" },
   { to: "/goals", icon: Target, label: "Metas" },
   { to: "/ai", icon: BrainCircuit, label: "IA Analista" },
+];
+
+const prefItems = [
   { to: "/settings", icon: Settings, label: "Configurações" },
 ];
+
+// Item de navegação: ativo = estrela-norte teal + texto ivory sobre fundo
+// sutil (o teal chapado fica reservado ao CTA primário — ver DESIGN.md).
+function NavItem({ to, icon: Icon, label }) {
+  return (
+    <NavLink
+      to={to}
+      className={({ isActive }) =>
+        `group relative flex items-center gap-3 px-3 py-2.5 rounded-xl text-sm font-medium transition-colors duration-200 ${
+          isActive
+            ? "bg-white/[0.06] text-norby-ivory"
+            : "text-norby-ivory/50 hover:text-norby-ivory hover:bg-white/[0.03]"
+        }`
+      }
+    >
+      {({ isActive }) => (
+        <>
+          <Icon size={18} className={isActive ? "text-norby-teal" : ""} />
+          {label}
+          {isActive && (
+            <NorthStar size={12} className="ml-auto text-norby-teal" />
+          )}
+        </>
+      )}
+    </NavLink>
+  );
+}
 
 export default function Sidebar() {
   const { user } = useAuthStore();
@@ -33,9 +65,9 @@ export default function Sidebar() {
   }
 
   return (
-    <aside className="w-64 h-screen bg-norby-surface/60 backdrop-blur-xl border-r border-white/10 flex flex-col px-4 py-6 shrink-0">
+    <aside className="w-64 h-screen bg-norby-surface/60 backdrop-blur-xl border-r border-white/[0.06] flex flex-col px-4 py-6 shrink-0">
       {/* Logo */}
-      <div className="flex items-center gap-3 mb-10 px-2">
+      <div className="flex items-center gap-3 mb-8 px-2">
         <div className="w-9 h-9 rounded-xl bg-norby-teal flex items-center justify-center shadow-md shadow-norby-teal/20">
           <NorbyMark size={20} color="#07100F" />
         </div>
@@ -46,38 +78,34 @@ export default function Sidebar() {
       </div>
 
       {/* Nav */}
-      <nav className="flex-1 flex flex-col gap-1">
-        {navItems.map((item) => (
-          <NavLink
-            key={item.to}
-            to={item.to}
-            className={({ isActive }) =>
-              `flex items-center gap-3 px-3 py-2.5 rounded-xl text-sm font-medium transition-all duration-200 ${
-                isActive
-                  ? "bg-norby-teal text-norby-night shadow-lg shadow-norby-teal/20"
-                  : "text-norby-ivory/50 hover:text-norby-ivory hover:bg-white/5"
-              }`
-            }
-          >
-            <item.icon size={18} />
-            {item.label}
-          </NavLink>
+      <nav className="flex-1 flex flex-col gap-1 overflow-y-auto">
+        <p className="microlabel px-3 mb-1.5">Menu principal</p>
+        {mainItems.map((item) => (
+          <NavItem key={item.to} {...item} />
+        ))}
+
+        <p className="microlabel px-3 mt-6 mb-1.5">Preferências</p>
+        {prefItems.map((item) => (
+          <NavItem key={item.to} {...item} />
         ))}
       </nav>
 
-      {/* IA do Mês — destaque */}
-      <div className="p-4 mb-4 bg-norby-teal/10 backdrop-blur-sm border border-norby-teal/20 rounded-2xl">
-        <div className="flex items-center gap-2 mb-1">
-          <BrainCircuit size={14} className="text-norby-teal" />
-          <span className="text-xs font-semibold text-norby-teal">IA do Mês</span>
+      {/* IA do Mês — atalho para o analista */}
+      <NavLink
+        to="/ai"
+        className="group flex items-center gap-3 p-3.5 mb-4 bg-norby-teal/[0.08] border border-norby-teal/20 rounded-2xl transition-colors hover:bg-norby-teal/[0.14]"
+      >
+        <AiOrb size={34} pulse={false} />
+        <div className="min-w-0">
+          <p className="text-xs font-semibold text-norby-teal">IA do Mês</p>
+          <p className="text-[11px] text-norby-ivory/55 leading-snug mt-0.5">
+            Análises personalizadas do seu perfil financeiro
+          </p>
         </div>
-        <p className="text-xs text-norby-ivory/60">
-          Acesse análises personalizadas do seu perfil financeiro.
-        </p>
-      </div>
+      </NavLink>
 
       {/* User */}
-      <div className="flex items-center gap-3 pt-4 border-t border-white/10 px-1">
+      <div className="flex items-center gap-3 pt-4 border-t border-white/[0.06] px-1">
         <div className="w-8 h-8 rounded-full bg-norby-teal flex items-center justify-center text-xs font-bold text-norby-night shadow-sm">
           {user?.name?.[0]?.toUpperCase() || "U"}
         </div>
@@ -89,9 +117,11 @@ export default function Sidebar() {
         </div>
         <button
           onClick={handleLogout}
-          className="text-norby-ivory/40 hover:text-norby-ivory transition-colors"
+          title="Sair"
+          className="p-1.5 rounded-lg text-norby-ivory/40 hover:text-norby-ivory hover:bg-white/5 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-norby-teal/50"
         >
           <LogOut size={16} />
+          <span className="sr-only">Sair da conta</span>
         </button>
       </div>
     </aside>

--- a/frontend/src/components/shared/AiOrb.jsx
+++ b/frontend/src/components/shared/AiOrb.jsx
@@ -1,0 +1,24 @@
+import NorthStar from "./NorthStar";
+
+// Orbe da IA: a presença visual do assistente (DESIGN.md › Signature).
+// Gradiente radial teal com a estrela-norte no centro; pulso lento é o
+// único motion ambiente permitido no app. `pulse=false` para contextos
+// estáticos (listas, avatares de mensagem).
+export default function AiOrb({ size = 40, pulse = true, className = "" }) {
+  return (
+    <div
+      aria-hidden="true"
+      className={`relative shrink-0 rounded-full flex items-center justify-center shadow-lg shadow-norby-teal/25 ${
+        pulse ? "animate-orb-pulse" : ""
+      } ${className}`}
+      style={{
+        width: size,
+        height: size,
+        background:
+          "radial-gradient(circle at 32% 28%, #6FD4C6 0%, #2DB5A3 55%, #156358 100%)",
+      }}
+    >
+      <NorthStar size={Math.round(size * 0.5)} color="#07100F" />
+    </div>
+  );
+}

--- a/frontend/src/components/shared/NorthStar.jsx
+++ b/frontend/src/components/shared/NorthStar.jsx
@@ -1,0 +1,18 @@
+// Estrela-norte de 4 pontas — o mesmo desenho da estrela do monograma
+// (Logo.jsx), isolada e centralizada. É o marcador de posição do app:
+// item ativo da sidebar, presença da IA (orbe) e loading. Não usar como
+// decoração fora desses papéis (ver DESIGN.md › Signature).
+export default function NorthStar({ size = 12, color = "currentColor", className }) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 14 14"
+      fill="none"
+      className={className}
+      aria-hidden="true"
+    >
+      <path d="M7 2 L8 6 L10.5 7 L8 8 L7 12 L6 8 L3.5 7 L6 6 Z" fill={color} />
+    </svg>
+  );
+}

--- a/frontend/src/components/ui/button.jsx
+++ b/frontend/src/components/ui/button.jsx
@@ -4,11 +4,11 @@ import { cva } from "class-variance-authority";
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "group/button inline-flex shrink-0 items-center justify-center rounded-lg border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  "group/button inline-flex shrink-0 items-center justify-center rounded-full border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:scale-[0.98] disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
   {
     variants: {
       variant: {
-        default: "bg-primary text-primary-foreground [a]:hover:bg-primary/80",
+        default: "bg-primary text-primary-foreground hover:bg-norby-teal-soft [a]:hover:bg-norby-teal-soft",
         outline:
           "border-border bg-background hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50",
         secondary:
@@ -21,15 +21,13 @@ const buttonVariants = cva(
       },
       size: {
         default:
-          "h-8 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
-        xs: "h-6 gap-1 rounded-[min(var(--radius-md),10px)] px-2 text-xs in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3",
-        sm: "h-7 gap-1 rounded-[min(var(--radius-md),12px)] px-2.5 text-[0.8rem] in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3.5",
-        lg: "h-9 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
+          "h-9 gap-1.5 px-4 has-data-[icon=inline-end]:pr-3 has-data-[icon=inline-start]:pl-3",
+        xs: "h-6 gap-1 px-2.5 text-xs has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2 [&_svg:not([class*='size-'])]:size-3",
+        sm: "h-7 gap-1 px-3 text-[0.8rem] has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2 [&_svg:not([class*='size-'])]:size-3.5",
+        lg: "h-10 gap-1.5 px-5 has-data-[icon=inline-end]:pr-4 has-data-[icon=inline-start]:pl-4",
         icon: "size-8",
-        "icon-xs":
-          "size-6 rounded-[min(var(--radius-md),10px)] in-data-[slot=button-group]:rounded-lg [&_svg:not([class*='size-'])]:size-3",
-        "icon-sm":
-          "size-7 rounded-[min(var(--radius-md),12px)] in-data-[slot=button-group]:rounded-lg",
+        "icon-xs": "size-6 [&_svg:not([class*='size-'])]:size-3",
+        "icon-sm": "size-7",
         "icon-lg": "size-9",
       },
     },

--- a/frontend/src/components/ui/dialog.jsx
+++ b/frontend/src/components/ui/dialog.jsx
@@ -39,7 +39,7 @@ function DialogOverlay({
     <DialogPrimitive.Backdrop
       data-slot="dialog-overlay"
       className={cn(
-        "fixed inset-0 isolate z-50 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
+        "fixed inset-0 isolate z-50 bg-norby-night/70 duration-100 supports-backdrop-filter:backdrop-blur-sm data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
         className
       )}
       {...props} />
@@ -58,7 +58,7 @@ function DialogContent({
       <DialogPrimitive.Popup
         data-slot="dialog-content"
         className={cn(
-          "fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl bg-popover p-4 text-sm text-popover-foreground ring-1 ring-foreground/10 duration-100 outline-none sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          "fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-2xl bg-popover p-6 text-sm text-popover-foreground ring-1 ring-foreground/10 duration-100 outline-none sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
           className
         )}
         {...props}>

--- a/frontend/src/components/ui/input.jsx
+++ b/frontend/src/components/ui/input.jsx
@@ -13,7 +13,7 @@ function Input({
       type={type}
       data-slot="input"
       className={cn(
-        "h-8 w-full min-w-0 rounded-lg border border-input bg-transparent px-2.5 py-1 text-base transition-colors outline-none file:inline-flex file:h-6 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
+        "h-10 w-full min-w-0 rounded-xl border border-input bg-white/5 px-3 py-1 text-base transition-colors outline-none file:inline-flex file:h-6 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
         className
       )}
       {...props} />

--- a/frontend/src/components/ui/segmented.jsx
+++ b/frontend/src/components/ui/segmented.jsx
@@ -24,7 +24,7 @@ export function Segmented({ value, onChange, options, className }) {
             type="button"
             onClick={() => onChange(opt.value)}
             className={cn(
-              "rounded-lg py-2 text-sm font-medium transition-all",
+              "rounded-xl py-2 text-sm font-medium transition-all",
               isActive
                 ? (opt.activeClass ?? "bg-norby-teal text-norby-night")
                 : "bg-white/5 text-norby-ivory/70 hover:text-norby-ivory"

--- a/frontend/src/components/ui/select.jsx
+++ b/frontend/src/components/ui/select.jsx
@@ -4,7 +4,7 @@ import { ChevronDown, Check } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 const fieldBase =
-  "w-full h-10 px-3 rounded-lg bg-white/5 border border-white/10 text-norby-ivory text-sm placeholder:text-norby-ivory/40 focus:outline-none focus:ring-2 focus:ring-norby-teal/40 transition";
+  "w-full h-10 px-3 rounded-xl bg-white/5 border border-white/10 text-norby-ivory text-sm placeholder:text-norby-ivory/40 focus:outline-none focus:ring-2 focus:ring-norby-teal/40 transition";
 
 /**
  * Themed dropdown built on @base-ui/react Select.
@@ -61,7 +61,7 @@ export function Select({ id, value, placeholder, options, onChange, disabled }) 
         >
           <SelectPrimitive.Popup
             data-slot="select-popup"
-            className="bg-norby-surface border border-white/10 rounded-lg shadow-xl p-1 min-w-[var(--anchor-width)] origin-[var(--transform-origin)] outline-none data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 duration-100"
+            className="bg-norby-surface border border-white/10 rounded-xl shadow-xl p-1 min-w-[var(--anchor-width)] origin-[var(--transform-origin)] outline-none data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 duration-100"
           >
             <SelectPrimitive.List>
               {options?.map((opt) => (

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -14,14 +14,42 @@
   /* Card dark "Petróleo Confiável": superfície sólida o bastante p/ ler dados,
      borda sutil, leve blur deixando o glow teal vazar por trás. */
   .glass-card {
-    @apply bg-norby-surface/70 backdrop-blur-xl border border-white/[0.06] rounded-2xl;
+    @apply bg-norby-surface/70 backdrop-blur-xl border border-white/[0.06] rounded-3xl;
   }
   .glass-card-hover {
     @apply glass-card transition-colors duration-200 hover:border-white/[0.14];
+  }
+
+  /* Chip de tendência (pílula): variação % nunca fica como texto solto */
+  .chip {
+    @apply inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-semibold tnum;
+  }
+  .chip-pos { @apply chip bg-norby-income/15 text-norby-income; }
+  .chip-neg { @apply chip bg-norby-danger/15 text-norby-danger; }
+  .chip-neutral { @apply chip bg-white/[0.06] text-norby-ivory/60; }
+
+  /* Label micro em uppercase: padrão único de rótulo de dado */
+  .microlabel {
+    @apply text-[11px] font-medium text-norby-ivory/40 uppercase tracking-widest;
   }
 }
 
 @layer base {
   /* Números monetários/tabela: figuras tabulares (precisão, sem layout shift) */
   .tnum { font-variant-numeric: tabular-nums; }
+}
+
+/* Estrela-norte pulsando: substituto de spinner genérico (assinatura da marca) */
+@keyframes star-pulse {
+  0%, 100% { opacity: 0.35; transform: scale(0.92); }
+  50% { opacity: 1; transform: scale(1); }
+}
+.star-loading { animation: star-pulse 1.4s ease-in-out infinite; }
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
 }

--- a/frontend/src/lib/categories.js
+++ b/frontend/src/lib/categories.js
@@ -1,9 +1,35 @@
-export const CATEGORIES = [
+export const EXPENSE_CATEGORIES = [
   "Alimentação",
-  "Educação",
   "Moradia",
   "Transporte",
   "Saúde",
+  "Educação",
   "Lazer",
+  "Compras",
+  "Contas & Serviços",
   "Outros",
 ];
+
+export const INCOME_CATEGORIES = [
+  "Salário",
+  "Freelance/Extra",
+  "Investimentos",
+  "Reembolso",
+  "Presente",
+  "Outros",
+];
+
+// Alias de compatibilidade: consumidores sem tipo (ex.: orçamento de metas)
+// usam categorias de despesa.
+export const CATEGORIES = EXPENSE_CATEGORIES;
+
+// Lista de categorias válidas para o tipo de lançamento.
+export function categoriesFor(type) {
+  return type === "INCOME" ? INCOME_CATEGORIES : EXPENSE_CATEGORIES;
+}
+
+// Mantém a categoria se ela for válida para o tipo; senão cai na 1ª da lista.
+export function reconcileCategory(type, current) {
+  const list = categoriesFor(type);
+  return list.includes(current) ? current : list[0];
+}

--- a/frontend/src/lib/categories.test.js
+++ b/frontend/src/lib/categories.test.js
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+import {
+  categoriesFor,
+  reconcileCategory,
+  EXPENSE_CATEGORIES,
+  INCOME_CATEGORIES,
+} from "./categories";
+
+describe("categoriesFor", () => {
+  it("returns income categories for INCOME", () => {
+    expect(categoriesFor("INCOME")).toBe(INCOME_CATEGORIES);
+  });
+  it("returns expense categories for EXPENSE", () => {
+    expect(categoriesFor("EXPENSE")).toBe(EXPENSE_CATEGORIES);
+  });
+});
+
+describe("reconcileCategory", () => {
+  it("keeps the category when valid for the type", () => {
+    expect(reconcileCategory("EXPENSE", "Lazer")).toBe("Lazer");
+  });
+  it("falls back to the first of the new list when invalid", () => {
+    // "Lazer" não existe em receitas → cai na 1ª de receita (Salário)
+    expect(reconcileCategory("INCOME", "Lazer")).toBe(INCOME_CATEGORIES[0]);
+  });
+});

--- a/frontend/src/lib/utils.js
+++ b/frontend/src/lib/utils.js
@@ -59,4 +59,4 @@ export const formatBRL = (v) =>
  * do shadcn, que tem estilo próprio). Compartilhada por Goals/Recurring/Transactions.
  */
 export const inputCls =
-  "w-full h-10 px-3 rounded-lg bg-white/5 border border-white/10 text-norby-ivory text-sm placeholder:text-norby-ivory/40 focus:outline-none focus:ring-2 focus:ring-norby-teal/40 transition";
+  "w-full h-10 px-3 rounded-xl bg-white/5 border border-white/10 text-norby-ivory text-sm placeholder:text-norby-ivory/40 focus:outline-none focus:ring-2 focus:ring-norby-teal/40 transition";

--- a/frontend/src/pages/AIAnalyst.jsx
+++ b/frontend/src/pages/AIAnalyst.jsx
@@ -1,9 +1,10 @@
 import { useState, useRef, useEffect } from "react";
-import { BrainCircuit, Send, Plus } from "lucide-react";
+import { Send, Plus } from "lucide-react";
 import { aiApi } from "@/api/ai";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import NorbyMark from "@/components/shared/Logo";
+import AiOrb from "@/components/shared/AiOrb";
 
 export default function AIAnalyst() {
   const [messages, setMessages] = useState([]);
@@ -108,15 +109,25 @@ export default function AIAnalyst() {
 
         {/* Messages */}
         <div className="flex-1 overflow-y-auto p-4 space-y-4">
+          {messages.length === 0 && !loading && (
+            <div className="h-full flex flex-col items-center justify-center gap-3 text-center">
+              <AiOrb size={56} />
+              <p className="text-sm font-medium text-norby-ivory mt-1">
+                No que posso ajudar?
+              </p>
+              <p className="text-xs text-norby-ivory/50 max-w-xs leading-relaxed">
+                Pergunte sobre seus gastos, suas metas ou peça dicas de
+                economia — a Norby responde com base nos seus dados.
+              </p>
+            </div>
+          )}
           {messages.map((msg, i) => (
             <div
               key={i}
               className={`flex ${msg.role === "user" ? "justify-end" : "justify-start"}`}
             >
               {msg.role === "assistant" && (
-                <div className="w-7 h-7 rounded-lg bg-norby-teal/15 flex items-center justify-center shrink-0 mr-2 mt-0.5">
-                  <BrainCircuit size={18} className="text-norby-teal" />
-                </div>
+                <AiOrb size={28} pulse={false} className="mr-2 mt-0.5" />
               )}
               <div
                 className={`max-w-[70%] px-4 py-3 rounded-2xl text-sm leading-relaxed ${
@@ -131,15 +142,13 @@ export default function AIAnalyst() {
           ))}
           {loading && (
             <div className="flex items-center gap-2">
-              <div className="w-7 h-7 rounded-lg bg-norby-teal/15 flex items-center justify-center">
-                <BrainCircuit size={13} className="text-norby-teal" />
-              </div>
+              <AiOrb size={28} />
               <div className="glass-card px-4 py-3 flex gap-1.5">
                 {[0, 1, 2].map((i) => (
                   <span
                     key={i}
-                    className="w-1.5 h-1.5 rounded-full bg-norby-ivory/30 animate-bounce"
-                    style={{ animationDelay: `${i * 0.15}s` }}
+                    className="w-1.5 h-1.5 rounded-full bg-norby-ivory/40 animate-pulse"
+                    style={{ animationDelay: `${i * 0.2}s` }}
                   />
                 ))}
               </div>

--- a/frontend/src/pages/AIAnalyst.jsx
+++ b/frontend/src/pages/AIAnalyst.jsx
@@ -40,6 +40,7 @@ export default function AIAnalyst() {
     try {
       const res = await aiApi.chat({ message: input, session_id: sessionId });
       setSessionId(res.data.session_id);
+      aiApi.getSessions().then((r) => setSessions(r.data)).catch(() => {});
       setMessages((prev) => [
         ...prev,
         { role: "assistant", content: res.data.response },
@@ -51,6 +52,22 @@ export default function AIAnalyst() {
           role: "assistant",
           content: "Erro ao conectar com a IA. Tente novamente.",
         },
+      ]);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function openSession(id) {
+    if (id === sessionId || loading) return;
+    setLoading(true);
+    try {
+      const res = await aiApi.getSession(id);
+      setMessages(res.data.messages);
+      setSessionId(id);
+    } catch {
+      setMessages([
+        { role: "assistant", content: "Não foi possível carregar esta conversa." },
       ]);
     } finally {
       setLoading(false);
@@ -77,7 +94,7 @@ export default function AIAnalyst() {
           {sessions.map((s) => (
             <button
               key={s.session_id}
-              onClick={() => setSessionId(s.session_id)}
+              onClick={() => openSession(s.session_id)}
               className={`text-left p-2.5 rounded-xl text-xs transition-colors truncate ${
                 sessionId === s.session_id
                   ? "bg-white/10 text-norby-ivory"

--- a/frontend/src/pages/Auth.jsx
+++ b/frontend/src/pages/Auth.jsx
@@ -102,12 +102,12 @@ export default function Auth() {
         {/* Card */}
         <div className="glass-card p-8">
           {/* Tabs */}
-          <div className="flex gap-1 p-1 rounded-xl bg-white/5 mb-6">
+          <div className="flex gap-1 p-1 rounded-full bg-white/5 mb-6">
             {["login", "register"].map((m) => (
               <button
                 key={m}
                 onClick={() => setMode(m)}
-                className={`flex-1 py-2 rounded-lg text-sm font-medium transition-all ${
+                className={`flex-1 py-2 rounded-full text-sm font-medium transition-all ${
                   mode === m
                     ? "bg-norby-teal text-norby-night"
                     : "text-norby-ivory/50 hover:text-norby-ivory"
@@ -197,7 +197,7 @@ export default function Auth() {
             )}
 
             {error && (
-              <div className="p-3 rounded-lg bg-norby-danger/10 border border-norby-danger/20 text-norby-danger text-sm">
+              <div className="p-3 rounded-xl bg-norby-danger/10 border border-norby-danger/20 text-norby-danger text-sm">
                 {error}
               </div>
             )}

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -1,14 +1,15 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import {
-  DollarSign,
-  CreditCard,
   TrendingUp,
   TrendingDown,
   Plus,
-  BrainCircuit,
+  Minus,
+  ArrowRight,
   ArrowUpRight,
   ArrowDownRight,
+  Flame,
+  Target,
 } from "lucide-react";
 import {
   AreaChart,
@@ -22,13 +23,17 @@ import {
   Cell,
   CartesianGrid,
 } from "recharts";
-import KpiCard from "@/components/shared/KpiCard";
 import { transactionsApi } from "@/api/transactions";
 import { walletsApi } from "@/api/wallets";
 import { aiApi } from "@/api/ai";
+import { goalsApi } from "@/api/goals";
 import { recurringApi } from "@/api/recurring";
 import { dashboardApi } from "@/api/dashboard";
 import { Button } from "@/components/ui/button";
+import { Select } from "@/components/ui/select";
+import NorthStar from "@/components/shared/NorthStar";
+import AiOrb from "@/components/shared/AiOrb";
+import { useAuthStore } from "@/store/authStore";
 import { formatDateBR, formatBRL } from "@/lib/utils";
 
 // Rótulo curto pt-BR de uma chave ano-mês ("2026-07" → "jul"), em horário local.
@@ -64,6 +69,26 @@ const axisTick = { fill: "rgba(239,250,248,0.40)", fontSize: 11 };
 const fmtShort = (v) =>
   Number(v) >= 1000 ? `${(v / 1000).toFixed(1)}k` : `${v}`;
 
+// Janela do heatmap "Ritmo financeiro" (dias, terminando hoje)
+const STREAK_DAYS = 42;
+
+const pad2 = (n) => String(n).padStart(2, "0");
+const dayKey = (d) =>
+  `${d.getFullYear()}-${pad2(d.getMonth() + 1)}-${pad2(d.getDate())}`;
+
+// Meses (1-12/ano) que a janela de N dias terminando hoje atravessa.
+function monthsForWindow(days) {
+  const end = new Date();
+  const start = new Date(end.getFullYear(), end.getMonth(), end.getDate() - (days - 1));
+  const months = [];
+  const cursor = new Date(start.getFullYear(), start.getMonth(), 1);
+  while (cursor <= end) {
+    months.push({ month: cursor.getMonth() + 1, year: cursor.getFullYear() });
+    cursor.setMonth(cursor.getMonth() + 1);
+  }
+  return months;
+}
+
 // Tooltip escuro reutilizável, formatado em R$
 function ChartTooltip({ active, payload, label }) {
   if (!active || !payload?.length) return null;
@@ -90,28 +115,60 @@ function ChartTooltip({ active, payload, label }) {
   );
 }
 
+// Valor monetário grande com centavos rebaixados ("R$ 8.240" + ",50")
+function MoneyHero({ value }) {
+  const formatted = formatBRL(value);
+  const idx = formatted.lastIndexOf(",");
+  return (
+    <span className="tnum tracking-tight">
+      <span className="text-4xl font-semibold text-norby-ivory">
+        {formatted.slice(0, idx)}
+      </span>
+      <span className="text-2xl font-semibold text-norby-ivory/50">
+        {formatted.slice(idx)}
+      </span>
+    </span>
+  );
+}
+
 export default function Dashboard() {
   const [wallets, setWallets] = useState([]);
   const [transactions, setTransactions] = useState([]);
   const [summary, setSummary] = useState(null);
   const [insight, setInsight] = useState(null);
+  const [goals, setGoals] = useState([]);
+  const [streakTx, setStreakTx] = useState([]);
+  const [selectedWallet, setSelectedWallet] = useState("all");
   const [loading, setLoading] = useState(true);
   const navigate = useNavigate();
+  const { user } = useAuthStore();
 
   useEffect(() => {
     async function loadData() {
       await recurringApi.run().catch(() => {}); // materializa recorrências vencidas
-      // allSettled: falha da IA (insight) não derruba os demais painéis
-      const [wRes, tRes, sRes, iRes] = await Promise.allSettled([
-        walletsApi.list(),
-        transactionsApi.list(),
-        dashboardApi.summary(),
-        aiApi.getInsight(),
-      ]);
+      const streakMonths = monthsForWindow(STREAK_DAYS);
+      // allSettled: falha de um painel (ex.: IA) não derruba os demais
+      const [wRes, tRes, sRes, iRes, gRes, ...streakRes] =
+        await Promise.allSettled([
+          walletsApi.list(),
+          transactionsApi.list(),
+          dashboardApi.summary(),
+          aiApi.getInsight(),
+          goalsApi.list(),
+          ...streakMonths.map((m) =>
+            transactionsApi.list({ month: m.month, year: m.year, limit: 500 }),
+          ),
+        ]);
       if (wRes.status === "fulfilled") setWallets(wRes.value.data);
       if (tRes.status === "fulfilled") setTransactions(tRes.value.data);
       if (sRes.status === "fulfilled") setSummary(sRes.value.data);
       if (iRes.status === "fulfilled") setInsight(iRes.value.data);
+      if (gRes.status === "fulfilled") setGoals(gRes.value.data);
+      setStreakTx(
+        streakRes
+          .filter((r) => r.status === "fulfilled")
+          .flatMap((r) => r.value.data),
+      );
       setLoading(false);
     }
     loadData();
@@ -120,17 +177,25 @@ export default function Dashboard() {
   const pctChange = (curr, prev) =>
     prev > 0 ? ((curr - prev) / prev) * 100 : undefined;
 
-  // Saldo atual = soma das carteiras (estado real, não recorte de mês)
+  // Saldo = soma das carteiras (estado real) ou da carteira filtrada
   const totalBalance = wallets.reduce((s, w) => s + parseFloat(w.balance), 0);
+  const shownBalance =
+    selectedWallet === "all"
+      ? totalBalance
+      : parseFloat(wallets.find((w) => w.id === selectedWallet)?.balance ?? 0);
 
   // KPIs, fluxo e categorias vêm agregados do backend (sobre TODAS as transações,
   // sem o cap de 200 da listagem). O front só formata para os gráficos.
   const s = summary || EMPTY_SUMMARY;
   const monthIncome = parseFloat(s.month_income);
   const monthExpenses = parseFloat(s.month_expenses);
-  const incomeChange = pctChange(monthIncome, parseFloat(s.prev_month_income));
-  const expensesChange = pctChange(monthExpenses, parseFloat(s.prev_month_expenses));
   const monthNet = monthIncome - monthExpenses;
+
+  // Variação do saldo total vs. fim do mês anterior (derivável do resultado do
+  // mês corrente). Só faz sentido na visão "todas as carteiras".
+  const prevBalance = totalBalance - monthNet;
+  const balanceChange =
+    selectedWallet === "all" ? pctChange(totalBalance, prevBalance) : undefined;
 
   const cashFlowData = s.cash_flow.map((p) => ({
     key: p.month,
@@ -143,65 +208,414 @@ export default function Dashboard() {
     name: c.category,
     value: parseFloat(c.total),
   }));
-
   const categoryTotal = categoryData.reduce((sum, c) => sum + c.value, 0);
+  const topCategoryPct = categoryTotal
+    ? Math.round((categoryData[0]?.value / categoryTotal) * 100)
+    : 0;
+
+  // ── Ritmo financeiro: 42 dias, "no azul" = receitas ≥ despesas no dia ──
+  const { streakCells, streakCount, hasStreakActivity } = useMemo(() => {
+    const byDay = new Map();
+    for (const t of streakTx) {
+      const key = String(t.date).slice(0, 10);
+      const amt = parseFloat(t.amount);
+      byDay.set(key, (byDay.get(key) || 0) + (t.type === "INCOME" ? amt : -amt));
+    }
+    const today = new Date();
+    const cells = [];
+    for (let i = STREAK_DAYS - 1; i >= 0; i--) {
+      const d = new Date(today.getFullYear(), today.getMonth(), today.getDate() - i);
+      const key = dayKey(d);
+      const net = byDay.get(key) ?? 0;
+      cells.push({ key, net, active: byDay.has(key), blue: net >= 0 });
+    }
+    let count = 0;
+    for (let i = cells.length - 1; i >= 0 && cells[i].blue; i--) count++;
+    return {
+      streakCells: cells,
+      streakCount: count,
+      hasStreakActivity: byDay.size > 0,
+    };
+  }, [streakTx]);
+
+  const maxPositiveNet = Math.max(
+    1,
+    ...streakCells.filter((c) => c.net > 0).map((c) => c.net),
+  );
+
+  // Intensidade do heatmap: teal escala com o resultado do dia; vermelho = dia
+  // negativo; neutro = dia sem lançamento (conta como azul para a sequência).
+  function cellClass(cell) {
+    if (!cell.active) return "bg-white/[0.06]";
+    if (!cell.blue) return "bg-norby-danger/60";
+    const ratio = cell.net / maxPositiveNet;
+    if (ratio > 0.66) return "bg-norby-teal";
+    if (ratio > 0.33) return "bg-norby-teal/70";
+    if (cell.net > 0) return "bg-norby-teal/40";
+    return "bg-norby-teal/20"; // dia ativo com resultado zero
+  }
+
+  // ── Meta em destaque: a SAVINGS mais próxima de concluir ──
+  const featuredGoal = goals
+    .filter((g) => g.type === "SAVINGS")
+    .sort((a, b) => b.progress_pct - a.progress_pct)[0];
+  const goalPct = featuredGoal
+    ? Math.min(100, Math.round(featuredGoal.progress_pct))
+    : 0;
+
+  const firstName = user?.name?.split(" ")[0] || "";
+  const todayLabel = new Date()
+    .toLocaleDateString("pt-BR", { weekday: "short", day: "2-digit", month: "long" })
+    .replace(".", "");
 
   if (loading) {
     return (
       <div className="flex items-center justify-center h-full">
-        <div className="w-8 h-8 border-2 border-norby-teal border-t-transparent rounded-full animate-spin" />
+        <NorthStar size={32} className="text-norby-teal star-loading" />
       </div>
     );
   }
 
   const insightItems = insight?.summary_text?.split("|") || [];
 
+  const walletOptions = [
+    { value: "all", label: "Todas as carteiras" },
+    ...wallets.map((w) => ({ value: w.id, label: w.name })),
+  ];
+
+  // Atalho: abre o form de Relatórios já com o tipo pré-selecionado
+  const newTransaction = (type) =>
+    navigate("/transactions", { state: { newType: type } });
+
   return (
     <div className="space-y-5">
-      {/* Header */}
-      <div className="flex items-start justify-between">
-        <div>
-          <p className="text-norby-ivory/50 text-sm">Bem-vindo de volta</p>
-          <h1 className="text-2xl font-bold text-norby-ivory mt-0.5 tracking-tight">
-            Dashboard
-          </h1>
-        </div>
-        <Button
-          onClick={() => navigate("/transactions")}
-          className="bg-norby-teal hover:bg-norby-teal-soft text-norby-night font-medium shadow-lg shadow-norby-teal/20"
+      {/* ── Linha 1: hero + saldo total ─────────────────────────────── */}
+      <div className="grid grid-cols-2 gap-5">
+        {/* Hero: saudação + convite à IA */}
+        <div
+          className="relative overflow-hidden rounded-3xl p-7 flex flex-col animate-fade-up"
+          style={{
+            background:
+              "linear-gradient(130deg, #156358 0%, #2DB5A3 48%, #6FD4C6 115%)",
+          }}
         >
-          <Plus size={16} /> Novo Lançamento
-        </Button>
+          {/* Círculos decorativos, como no rascunho aprovado */}
+          <div className="absolute -right-16 -top-24 w-72 h-72 rounded-full bg-white/[0.08] pointer-events-none" />
+          <div className="absolute right-20 bottom-[-70px] w-44 h-44 rounded-full bg-norby-night/[0.08] pointer-events-none" />
+
+          <span className="relative inline-flex items-center gap-1.5 w-fit rounded-full bg-norby-night/20 px-3 py-1 text-[11px] font-semibold text-norby-night uppercase tracking-widest">
+            <span className="w-1.5 h-1.5 rounded-full bg-norby-night/70" />
+            {todayLabel}
+          </span>
+
+          <h1 className="relative text-3xl font-bold text-norby-night mt-4 tracking-tight">
+            Olá, {firstName} 👋
+          </h1>
+          <p className="relative text-sm text-norby-night/70 mt-1.5 max-w-xs leading-relaxed">
+            Pergunte qualquer coisa sobre suas finanças — a Norby está pronta.
+          </p>
+
+          <div className="relative mt-auto pt-6">
+            <Button
+              onClick={() => navigate("/ai")}
+              className="bg-norby-night text-norby-ivory hover:bg-norby-night/85"
+            >
+              Falar com a Norby <ArrowRight size={15} />
+            </Button>
+          </div>
+        </div>
+
+        {/* Saldo total */}
+        <div className="glass-card p-6 flex flex-col gap-4 animate-fade-up">
+          <div className="flex items-center justify-between gap-3">
+            <span className="microlabel">Saldo total</span>
+            {wallets.length > 1 && (
+              <div className="w-48 shrink-0">
+                <Select
+                  id="wallet-filter"
+                  value={selectedWallet}
+                  options={walletOptions}
+                  onChange={(v) => setSelectedWallet(v || "all")}
+                />
+              </div>
+            )}
+          </div>
+
+          <div>
+            <div className="flex items-baseline gap-2">
+              <MoneyHero value={shownBalance} />
+              <span className="text-xs font-medium text-norby-ivory/40">BRL</span>
+            </div>
+            {balanceChange !== undefined && (
+              <div className="flex items-center gap-2 mt-2">
+                <span className={balanceChange >= 0 ? "chip-pos" : "chip-neg"}>
+                  {balanceChange >= 0 ? (
+                    <ArrowUpRight size={12} />
+                  ) : (
+                    <ArrowDownRight size={12} />
+                  )}
+                  {Math.abs(balanceChange).toFixed(1)}%
+                </span>
+                <span className="text-xs text-norby-ivory/40">
+                  vs. mês passado
+                </span>
+              </div>
+            )}
+          </div>
+
+          <div className="flex gap-2">
+            <Button
+              onClick={() => newTransaction("INCOME")}
+              className="flex-1 bg-norby-teal text-norby-night hover:bg-norby-teal-soft font-medium shadow-lg shadow-norby-teal/20"
+            >
+              <Plus size={15} /> Receita
+            </Button>
+            <Button
+              onClick={() => newTransaction("EXPENSE")}
+              variant="outline"
+              className="flex-1 border-white/10 bg-white/[0.03] text-norby-ivory hover:bg-white/[0.08]"
+            >
+              <Minus size={15} /> Despesa
+            </Button>
+          </div>
+
+          <div className="grid grid-cols-3 divide-x divide-white/[0.06] border-t border-white/[0.06] pt-4 mt-auto">
+            <div className="pr-3">
+              <p className="microlabel">Receitas</p>
+              <p className="text-sm font-semibold text-norby-income tnum mt-1">
+                {formatBRL(monthIncome)}
+              </p>
+            </div>
+            <div className="px-3">
+              <p className="microlabel">Despesas</p>
+              <p className="text-sm font-semibold text-norby-ivory tnum mt-1">
+                {formatBRL(monthExpenses)}
+              </p>
+            </div>
+            <div className="pl-3">
+              <p className="microlabel">Score IA</p>
+              <p className="text-sm font-semibold text-norby-teal-soft tnum mt-1">
+                {insight?.score ?? "—"}/100
+              </p>
+            </div>
+          </div>
+        </div>
       </div>
 
-      {/* KPI Cards */}
-      <div className="grid grid-cols-4 gap-4">
-        <KpiCard title="Saldo atual" value={formatBRL(totalBalance)} icon={DollarSign} />
-        <KpiCard
-          title="Receitas do mês"
-          value={formatBRL(monthIncome)}
-          change={incomeChange}
-          icon={TrendingUp}
-        />
-        <KpiCard
-          title="Gastos do mês"
-          value={formatBRL(monthExpenses)}
-          change={expensesChange}
-          changeInverted
-          icon={CreditCard}
-        />
-        <KpiCard
-          title="Score da IA"
-          value={`${insight?.score ?? "—"}`}
-          suffix="/100"
-          icon={BrainCircuit}
-          accent="bg-norby-teal-soft/15 text-norby-teal-soft"
-        />
+      {/* ── Linha 2: categorias + ritmo + meta ──────────────────────── */}
+      <div className="grid grid-cols-3 gap-5">
+        {/* Onde vai seu dinheiro */}
+        <div className="glass-card p-6">
+          <div className="flex items-start justify-between gap-2">
+            <div>
+              <h2 className="font-semibold text-norby-ivory">
+                Onde vai seu dinheiro
+              </h2>
+              <p className="text-xs text-norby-ivory/50 mt-0.5 capitalize">
+                {new Date().toLocaleDateString("pt-BR", { month: "long" })}
+                {categoryTotal > 0 && (
+                  <span className="tnum"> · {formatBRL(categoryTotal)}</span>
+                )}
+              </p>
+            </div>
+          </div>
+
+          {categoryData.length === 0 ? (
+            <div className="flex items-center justify-center h-[170px] text-norby-ivory/40 text-xs text-center px-4">
+              Registre despesas para ver a distribuição por categoria
+            </div>
+          ) : (
+            <div className="flex items-center gap-5 mt-4">
+              <div className="relative w-[128px] h-[128px] shrink-0">
+                <ResponsiveContainer width="100%" height="100%">
+                  <PieChart>
+                    <Pie
+                      data={categoryData}
+                      dataKey="value"
+                      nameKey="name"
+                      cx="50%"
+                      cy="50%"
+                      innerRadius={44}
+                      outerRadius={62}
+                      paddingAngle={categoryData.length > 1 ? 3 : 0}
+                      cornerRadius={4}
+                      startAngle={90}
+                      endAngle={-270}
+                      stroke="none"
+                    >
+                      {categoryData.map((_, i) => (
+                        <Cell
+                          key={i}
+                          fill={CATEGORY_COLORS[i % CATEGORY_COLORS.length]}
+                        />
+                      ))}
+                    </Pie>
+                    <Tooltip content={<ChartTooltip />} cursor={false} />
+                  </PieChart>
+                </ResponsiveContainer>
+                <div className="absolute inset-0 flex flex-col items-center justify-center pointer-events-none">
+                  <span className="text-[10px] text-norby-ivory/40 uppercase tracking-wider">
+                    Maior
+                  </span>
+                  <span className="text-lg font-bold text-norby-ivory tnum">
+                    {topCategoryPct}%
+                  </span>
+                </div>
+              </div>
+
+              {/* Legenda: cor + categoria + % (valor no tooltip do donut) */}
+              <div className="flex-1 flex flex-col gap-2 min-w-0">
+                {categoryData.map((c, i) => {
+                  const pct = categoryTotal
+                    ? Math.round((c.value / categoryTotal) * 100)
+                    : 0;
+                  return (
+                    <div key={c.name} className="flex items-center gap-2.5">
+                      <span
+                        className="w-2 h-2 rounded-full shrink-0"
+                        style={{
+                          background: CATEGORY_COLORS[i % CATEGORY_COLORS.length],
+                        }}
+                      />
+                      <span className="text-xs text-norby-ivory/80 flex-1 truncate">
+                        {c.name}
+                      </span>
+                      <span className="text-xs font-semibold text-norby-ivory tnum">
+                        {pct}%
+                      </span>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          )}
+        </div>
+
+        {/* Ritmo financeiro (streak de dias no azul) */}
+        <div className="glass-card p-6 flex flex-col">
+          <div className="flex items-start justify-between gap-2">
+            <div>
+              <h2 className="font-semibold text-norby-ivory">Ritmo financeiro</h2>
+              <p className="text-xs text-norby-ivory/50 mt-0.5">
+                {hasStreakActivity
+                  ? `${streakCount} ${streakCount === 1 ? "dia" : "dias"} no azul seguidos`
+                  : "Registre lançamentos para acompanhar seu ritmo"}
+              </p>
+            </div>
+            {hasStreakActivity && streakCount > 0 && (
+              <span className="chip bg-norby-teal/15 text-norby-teal">
+                <Flame size={12} /> {streakCount}
+              </span>
+            )}
+          </div>
+
+          <div
+            className="grid gap-1.5 mt-5"
+            style={{ gridTemplateColumns: "repeat(14, minmax(0, 1fr))" }}
+          >
+            {streakCells.map((cell) => (
+              <div
+                key={cell.key}
+                title={`${formatDateBR(cell.key)} · ${
+                  cell.active ? formatBRL(cell.net) : "sem lançamentos"
+                }`}
+                className={`aspect-square rounded-[4px] ${cellClass(cell)}`}
+              />
+            ))}
+          </div>
+
+          <div className="flex items-center justify-between mt-auto pt-4">
+            <span className="text-[11px] text-norby-ivory/40">
+              Últimos {STREAK_DAYS} dias
+            </span>
+            <span className="flex items-center gap-1 text-[11px] text-norby-ivory/40">
+              Menos
+              <span className="w-2.5 h-2.5 rounded-[3px] bg-norby-teal/20" />
+              <span className="w-2.5 h-2.5 rounded-[3px] bg-norby-teal/40" />
+              <span className="w-2.5 h-2.5 rounded-[3px] bg-norby-teal/70" />
+              <span className="w-2.5 h-2.5 rounded-[3px] bg-norby-teal" />
+              Mais
+            </span>
+          </div>
+        </div>
+
+        {/* Meta em destaque */}
+        <div className="glass-card p-6 flex flex-col">
+          {featuredGoal ? (
+            <>
+              <div className="flex items-center gap-3">
+                <div className="w-9 h-9 rounded-xl bg-norby-income/15 text-norby-income flex items-center justify-center shrink-0">
+                  <Target size={17} />
+                </div>
+                <div className="min-w-0">
+                  <h2 className="font-semibold text-norby-ivory truncate">
+                    {featuredGoal.name}
+                  </h2>
+                  <p className="text-xs text-norby-ivory/50">meta ativa</p>
+                </div>
+              </div>
+
+              <div className="mt-5">
+                <p className="tnum tracking-tight">
+                  <span className="text-2xl font-semibold text-norby-ivory">
+                    {formatBRL(featuredGoal.current_amount)}
+                  </span>
+                  <span className="text-sm font-medium text-norby-ivory/40">
+                    {" "}/ {formatBRL(featuredGoal.target_amount)}
+                  </span>
+                </p>
+                <div
+                  role="progressbar"
+                  aria-valuenow={goalPct}
+                  aria-valuemin={0}
+                  aria-valuemax={100}
+                  className="h-2 rounded-full bg-white/[0.06] mt-3 overflow-hidden"
+                >
+                  <div
+                    className="h-full rounded-full bg-norby-income transition-all duration-500"
+                    style={{ width: `${goalPct}%` }}
+                  />
+                </div>
+                <p className="text-xs text-norby-ivory/50 mt-2 tnum">
+                  {goalPct}% concluído
+                </p>
+              </div>
+
+              <Button
+                onClick={() => navigate("/goals")}
+                variant="outline"
+                className="mt-auto w-full border-norby-income/25 bg-transparent text-norby-income hover:bg-norby-income/10"
+              >
+                Ver todas as metas <ArrowRight size={14} />
+              </Button>
+            </>
+          ) : (
+            <>
+              <div className="flex items-center gap-3">
+                <div className="w-9 h-9 rounded-xl bg-norby-income/15 text-norby-income flex items-center justify-center shrink-0">
+                  <Target size={17} />
+                </div>
+                <h2 className="font-semibold text-norby-ivory">Metas</h2>
+              </div>
+              <p className="text-xs text-norby-ivory/50 leading-relaxed mt-4 flex-1">
+                Crie uma meta de reserva para acompanhar o progresso dela aqui
+                no painel.
+              </p>
+              <Button
+                onClick={() => navigate("/goals")}
+                variant="outline"
+                className="mt-4 w-full border-norby-income/25 bg-transparent text-norby-income hover:bg-norby-income/10"
+              >
+                Criar uma meta <ArrowRight size={14} />
+              </Button>
+            </>
+          )}
+        </div>
       </div>
 
-      {/* Fluxo de Caixa + Leitura da IA */}
-      <div className="grid grid-cols-3 gap-4">
-        <div className="glass-card p-5 col-span-2">
+      {/* ── Linha 3: fluxo de caixa + leitura da IA ─────────────────── */}
+      <div className="grid grid-cols-3 gap-5">
+        <div className="glass-card p-6 col-span-2">
           <div className="flex items-start justify-between mb-4">
             <div>
               <h2 className="font-semibold text-norby-ivory">Fluxo de Caixa</h2>
@@ -293,12 +707,15 @@ export default function Dashboard() {
         </div>
 
         {/* Leitura da IA */}
-        <div className="glass-card p-5 flex flex-col gap-3">
-          <div>
-            <h2 className="font-semibold text-norby-ivory">Leitura da IA</h2>
-            <p className="text-xs text-norby-ivory/50">
-              Resumo do seu comportamento financeiro
-            </p>
+        <div className="glass-card p-6 flex flex-col gap-3">
+          <div className="flex items-center gap-3">
+            <AiOrb size={34} />
+            <div>
+              <h2 className="font-semibold text-norby-ivory">Leitura da IA</h2>
+              <p className="text-xs text-norby-ivory/50">
+                Resumo do seu comportamento financeiro
+              </p>
+            </div>
           </div>
           {insightItems.length === 0 ? (
             <div className="flex-1 flex items-center justify-center text-norby-ivory/40 text-xs text-center">
@@ -330,91 +747,9 @@ export default function Dashboard() {
         </div>
       </div>
 
-      {/* Gastos por categoria + Movimentações Recentes */}
-      <div className="grid grid-cols-3 gap-4">
-        <div className="glass-card p-5 col-span-2">
-          <h2 className="font-semibold text-norby-ivory">Gastos por categoria</h2>
-          <p className="text-xs text-norby-ivory/50 mb-4">
-            Distribuição das despesas do mês
-          </p>
-
-          {categoryData.length === 0 ? (
-            <div className="flex items-center justify-center h-[200px] text-norby-ivory/40 text-sm">
-              Nenhuma despesa registrada ainda
-            </div>
-          ) : (
-            <div className="flex items-center gap-8">
-              {/* Donut com total no centro */}
-              <div className="relative w-[200px] h-[200px] shrink-0">
-                <ResponsiveContainer width="100%" height="100%">
-                  <PieChart>
-                    <Pie
-                      data={categoryData}
-                      dataKey="value"
-                      nameKey="name"
-                      cx="50%"
-                      cy="50%"
-                      innerRadius={66}
-                      outerRadius={92}
-                      paddingAngle={categoryData.length > 1 ? 3 : 0}
-                      cornerRadius={4}
-                      startAngle={90}
-                      endAngle={-270}
-                      stroke="none"
-                    >
-                      {categoryData.map((_, i) => (
-                        <Cell key={i} fill={CATEGORY_COLORS[i % CATEGORY_COLORS.length]} />
-                      ))}
-                    </Pie>
-                    <Tooltip
-                      content={<ChartTooltip />}
-                      cursor={false}
-                    />
-                  </PieChart>
-                </ResponsiveContainer>
-                <div className="absolute inset-0 flex flex-col items-center justify-center pointer-events-none">
-                  <span className="text-[11px] text-norby-ivory/40 uppercase tracking-wider">
-                    Total
-                  </span>
-                  <span className="text-lg font-bold text-norby-ivory tnum">
-                    {formatBRL(categoryTotal)}
-                  </span>
-                </div>
-              </div>
-
-              {/* Legenda-lista: cor + categoria + valor + % (fallback de acessibilidade) */}
-              <div className="flex-1 flex flex-col gap-2.5">
-                {categoryData.map((c, i) => {
-                  const pct = categoryTotal
-                    ? (c.value / categoryTotal) * 100
-                    : 0;
-                  return (
-                    <div key={c.name} className="flex items-center gap-3">
-                      <span
-                        className="w-2.5 h-2.5 rounded-full shrink-0"
-                        style={{
-                          background:
-                            CATEGORY_COLORS[i % CATEGORY_COLORS.length],
-                        }}
-                      />
-                      <span className="text-sm text-norby-ivory/80 flex-1 truncate">
-                        {c.name}
-                      </span>
-                      <span className="text-sm font-semibold text-norby-ivory tnum">
-                        {formatBRL(c.value)}
-                      </span>
-                      <span className="text-xs text-norby-ivory/40 tnum w-9 text-right">
-                        {pct.toFixed(0)}%
-                      </span>
-                    </div>
-                  );
-                })}
-              </div>
-            </div>
-          )}
-        </div>
-
-        <div className="glass-card p-5 flex flex-col gap-3">
+      {/* ── Linha 4: movimentações recentes + resumo do mês ─────────── */}
+      <div className="glass-card p-6">
+        <div className="flex items-center justify-between mb-3">
           <div>
             <h2 className="font-semibold text-norby-ivory">
               Movimentações Recentes
@@ -423,14 +758,25 @@ export default function Dashboard() {
               Últimos lançamentos registrados
             </p>
           </div>
+          <Button
+            onClick={() => navigate("/transactions")}
+            variant="ghost"
+            size="sm"
+            className="text-norby-ivory/60 hover:text-norby-ivory hover:bg-white/5"
+          >
+            Ver todas <ArrowRight size={13} />
+          </Button>
+        </div>
 
-          <div className="flex flex-col gap-1 flex-1">
+        <div className="flex gap-6">
+          <div className="flex-1 flex flex-col min-w-0">
             {transactions.length === 0 ? (
-              <div className="flex-1 flex items-center justify-center text-norby-ivory/40 text-xs text-center">
-                Nenhuma movimentação ainda
+              <div className="flex-1 flex items-center justify-center text-norby-ivory/40 text-xs text-center py-8">
+                Nenhuma movimentação ainda — use “+ Receita” ou “− Despesa” para
+                começar
               </div>
             ) : (
-              transactions.slice(0, 4).map((t) => {
+              transactions.slice(0, 5).map((t) => {
                 const isIncome = t.type === "INCOME";
                 return (
                   <div
@@ -473,8 +819,8 @@ export default function Dashboard() {
             )}
           </div>
 
-          <div className="grid grid-cols-2 gap-2">
-            <div className="p-3 rounded-xl bg-white/[0.03]">
+          <div className="w-60 shrink-0 flex flex-col gap-2">
+            <div className="p-4 rounded-2xl bg-white/[0.03]">
               <p className="text-xs text-norby-ivory/40">Saldo do mês</p>
               <p
                 className={`text-sm font-bold mt-1 tnum flex items-center gap-1 ${
@@ -489,7 +835,7 @@ export default function Dashboard() {
                 {formatBRL(monthNet)}
               </p>
             </div>
-            <div className="p-3 rounded-xl bg-norby-teal/10 border border-norby-teal/20">
+            <div className="p-4 rounded-2xl bg-norby-teal/10 border border-norby-teal/20">
               <p className="text-xs text-norby-teal">Maior gasto</p>
               <p className="text-sm font-bold text-norby-ivory mt-1 truncate">
                 {categoryData[0]?.name || "—"}

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -1,21 +1,19 @@
 import { useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import {
-  TrendingUp,
-  TrendingDown,
   Plus,
   Minus,
   ArrowRight,
   ArrowUpRight,
   ArrowDownRight,
-  Flame,
-  Target,
+  AlertTriangle,
+  Check,
+  Sparkles,
 } from "lucide-react";
 import {
   AreaChart,
   Area,
   XAxis,
-  YAxis,
   Tooltip,
   ResponsiveContainer,
   PieChart,
@@ -34,7 +32,7 @@ import { Select } from "@/components/ui/select";
 import NorthStar from "@/components/shared/NorthStar";
 import AiOrb from "@/components/shared/AiOrb";
 import { useAuthStore } from "@/store/authStore";
-import { formatDateBR, formatBRL } from "@/lib/utils";
+import { formatDateBR, formatBRL, parseDateOnly } from "@/lib/utils";
 
 // Rótulo curto pt-BR de uma chave ano-mês ("2026-07" → "jul"), em horário local.
 const monthLabel = (ym) => {
@@ -66,8 +64,47 @@ const EXPENSE_COLOR = "#E0725C";
 
 const axisTick = { fill: "rgba(239,250,248,0.40)", fontSize: 11 };
 
-const fmtShort = (v) =>
-  Number(v) >= 1000 ? `${(v / 1000).toFixed(1)}k` : `${v}`;
+// Emoji por categoria (rascunho aprovado): chip visual das movimentações.
+const CATEGORY_EMOJI = {
+  "Alimentação": "🍔",
+  "Moradia": "🏠",
+  "Transporte": "🚇",
+  "Saúde": "💊",
+  "Educação": "📚",
+  "Lazer": "🎬",
+  "Compras": "🛍️",
+  "Contas & Serviços": "🧾",
+  "Salário": "💼",
+  "Freelance/Extra": "💰",
+  "Investimentos": "📈",
+  "Reembolso": "↩️",
+  "Presente": "🎁",
+};
+const emojiFor = (t) =>
+  CATEGORY_EMOJI[t.category] ?? (t.type === "INCOME" ? "🪙" : "💸");
+
+// "Hoje" / "Ontem" / "N dias atrás" / dd/mm/aaaa — para as movimentações.
+function relativeDay(value) {
+  const d = parseDateOnly(value);
+  if (!d) return "";
+  const today = new Date();
+  const startOfToday = new Date(today.getFullYear(), today.getMonth(), today.getDate());
+  const diff = Math.round((startOfToday - d) / 86_400_000);
+  if (diff <= 0) return "Hoje";
+  if (diff === 1) return "Ontem";
+  if (diff < 7) return `${diff} dias atrás`;
+  return formatDateBR(value);
+}
+
+// Ícone contextual dos insights da IA (heurística simples em pt-BR).
+function insightStyle(text) {
+  const t = text.toLowerCase();
+  if (/(caminho certo|parab|bom |ótimo|no azul|guarda|econom|caíram|caiu|reduz)/.test(t))
+    return { Icon: Check, chip: "bg-norby-income/15 text-norby-income", bg: "bg-norby-income/[0.07]" };
+  if (/(crítico|urgente|déficit|acima|estour|exced|negativ|cuidado|risco|falta|imped|ausência|não )/.test(t))
+    return { Icon: AlertTriangle, chip: "bg-norby-danger/15 text-norby-danger", bg: "bg-norby-danger/[0.07]" };
+  return { Icon: Sparkles, chip: "bg-norby-teal/15 text-norby-teal", bg: "bg-white/[0.03]" };
+}
 
 // Janela do heatmap "Ritmo financeiro" (dias, terminando hoje)
 const STREAK_DAYS = 42;
@@ -115,7 +152,7 @@ function ChartTooltip({ active, payload, label }) {
   );
 }
 
-// Valor monetário grande com centavos rebaixados ("R$ 8.240" + ",50")
+// Valor monetário grande com centavos em teal-soft ("R$ 8.240" + ",50")
 function MoneyHero({ value }) {
   const formatted = formatBRL(value);
   const idx = formatted.lastIndexOf(",");
@@ -124,7 +161,7 @@ function MoneyHero({ value }) {
       <span className="text-4xl font-semibold text-norby-ivory">
         {formatted.slice(0, idx)}
       </span>
-      <span className="text-2xl font-semibold text-norby-ivory/50">
+      <span className="text-2xl font-semibold text-norby-teal-soft">
         {formatted.slice(idx)}
       </span>
     </span>
@@ -209,9 +246,27 @@ export default function Dashboard() {
     value: parseFloat(c.total),
   }));
   const categoryTotal = categoryData.reduce((sum, c) => sum + c.value, 0);
+  const categoryMax = Math.max(1, ...categoryData.map((c) => c.value));
   const topCategoryPct = categoryTotal
     ? Math.round((categoryData[0]?.value / categoryTotal) * 100)
     : 0;
+
+  // Ponto de fim de linha do fluxo de caixa (detalhe do rascunho aprovado)
+  const endDot = (color) =>
+    function EndDot({ cx, cy, index }) {
+      if (index !== cashFlowData.length - 1) return <g key={index} />;
+      return (
+        <circle
+          key={index}
+          cx={cx}
+          cy={cy}
+          r={4.5}
+          fill="#0E1B19"
+          stroke={color}
+          strokeWidth={2.5}
+        />
+      );
+    };
 
   // ── Ritmo financeiro: 42 dias, "no azul" = receitas ≥ despesas no dia ──
   const { streakCells, streakCount, hasStreakActivity } = useMemo(() => {
@@ -267,6 +322,13 @@ export default function Dashboard() {
   const todayLabel = new Date()
     .toLocaleDateString("pt-BR", { weekday: "short", day: "2-digit", month: "long" })
     .replace(".", "");
+  // "julho de 2026" → "Julho de 2026" (capitalize do CSS pegaria o "De" também)
+  const rawMonthYear = new Date().toLocaleDateString("pt-BR", {
+    month: "long",
+    year: "numeric",
+  });
+  const monthYearLabel =
+    rawMonthYear.charAt(0).toUpperCase() + rawMonthYear.slice(1);
 
   if (loading) {
     return (
@@ -288,9 +350,9 @@ export default function Dashboard() {
     navigate("/transactions", { state: { newType: type } });
 
   return (
-    <div className="space-y-5">
+    <div className="space-y-4">
       {/* ── Linha 1: hero + saldo total ─────────────────────────────── */}
-      <div className="grid grid-cols-2 gap-5">
+      <div className="grid grid-cols-[1.15fr_1fr] gap-4">
         {/* Hero: saudação + convite à IA */}
         <div
           className="relative overflow-hidden rounded-3xl p-7 flex flex-col animate-fade-up"
@@ -300,25 +362,25 @@ export default function Dashboard() {
           }}
         >
           {/* Círculos decorativos, como no rascunho aprovado */}
-          <div className="absolute -right-16 -top-24 w-72 h-72 rounded-full bg-white/[0.08] pointer-events-none" />
-          <div className="absolute right-20 bottom-[-70px] w-44 h-44 rounded-full bg-norby-night/[0.08] pointer-events-none" />
+          <div className="absolute -right-10 -top-10 w-56 h-56 rounded-full bg-white/[0.08] pointer-events-none" />
+          <div className="absolute right-5 -bottom-16 w-40 h-40 rounded-full bg-norby-night/[0.16] pointer-events-none" />
 
-          <span className="relative inline-flex items-center gap-1.5 w-fit rounded-full bg-norby-night/20 px-3 py-1 text-[11px] font-semibold text-norby-night uppercase tracking-widest">
+          <span className="relative inline-flex items-center gap-1.5 w-fit rounded-full bg-white/25 px-3 py-1 text-[11px] font-semibold text-norby-night/80 uppercase tracking-widest">
             <span className="w-1.5 h-1.5 rounded-full bg-norby-night/70" />
             {todayLabel}
           </span>
 
-          <h1 className="relative text-3xl font-bold text-norby-night mt-4 tracking-tight">
+          <h1 className="relative text-3xl font-bold text-norby-night mt-3.5 tracking-tight">
             Olá, {firstName} 👋
           </h1>
-          <p className="relative text-sm text-norby-night/70 mt-1.5 max-w-xs leading-relaxed">
+          <p className="relative text-sm text-norby-night/70 mt-1.5 max-w-sm leading-relaxed">
             Pergunte qualquer coisa sobre suas finanças — a Norby está pronta.
           </p>
 
-          <div className="relative mt-auto pt-6">
+          <div className="relative mt-auto pt-5">
             <Button
               onClick={() => navigate("/ai")}
-              className="bg-norby-night text-norby-ivory hover:bg-norby-night/85"
+              className="bg-norby-night text-norby-teal-soft hover:bg-norby-night/85"
             >
               Falar com a Norby <ArrowRight size={15} />
             </Button>
@@ -326,8 +388,15 @@ export default function Dashboard() {
         </div>
 
         {/* Saldo total */}
-        <div className="glass-card p-6 flex flex-col gap-4 animate-fade-up">
-          <div className="flex items-center justify-between gap-3">
+        <div className="relative overflow-hidden glass-card border-norby-teal/20 p-6 flex flex-col gap-4 animate-fade-up">
+          <div
+            className="absolute inset-0 pointer-events-none"
+            style={{
+              background:
+                "radial-gradient(circle at 90% 12%, rgba(45,181,163,0.14), transparent 55%)",
+            }}
+          />
+          <div className="relative flex items-center justify-between gap-3">
             <span className="microlabel">Saldo total</span>
             {wallets.length > 1 && (
               <div className="w-48 shrink-0">
@@ -341,7 +410,7 @@ export default function Dashboard() {
             )}
           </div>
 
-          <div>
+          <div className="relative">
             <div className="flex items-baseline gap-2">
               <MoneyHero value={shownBalance} />
               <span className="text-xs font-medium text-norby-ivory/40">BRL</span>
@@ -363,7 +432,7 @@ export default function Dashboard() {
             )}
           </div>
 
-          <div className="flex gap-2">
+          <div className="relative flex gap-2">
             <Button
               onClick={() => newTransaction("INCOME")}
               className="flex-1 bg-norby-teal text-norby-night hover:bg-norby-teal-soft font-medium shadow-lg shadow-norby-teal/20"
@@ -373,13 +442,13 @@ export default function Dashboard() {
             <Button
               onClick={() => newTransaction("EXPENSE")}
               variant="outline"
-              className="flex-1 border-white/10 bg-white/[0.03] text-norby-ivory hover:bg-white/[0.08]"
+              className="flex-1 border-norby-teal/25 bg-norby-teal/[0.08] text-norby-teal hover:bg-norby-teal/[0.15]"
             >
               <Minus size={15} /> Despesa
             </Button>
           </div>
 
-          <div className="grid grid-cols-3 divide-x divide-white/[0.06] border-t border-white/[0.06] pt-4 mt-auto">
+          <div className="relative grid grid-cols-3 divide-x divide-white/[0.06] border-t border-dashed border-white/10 pt-4 mt-auto">
             <div className="pr-3">
               <p className="microlabel">Receitas</p>
               <p className="text-sm font-semibold text-norby-income tnum mt-1">
@@ -403,25 +472,25 @@ export default function Dashboard() {
       </div>
 
       {/* ── Linha 2: categorias + ritmo + meta ──────────────────────── */}
-      <div className="grid grid-cols-3 gap-5">
+      <div className="grid grid-cols-[1.1fr_1fr_1fr] gap-4">
         {/* Onde vai seu dinheiro */}
         <div className="glass-card p-6">
-          <div className="flex items-start justify-between gap-2">
-            <div>
-              <h2 className="font-semibold text-norby-ivory">
-                Onde vai seu dinheiro
-              </h2>
-              <p className="text-xs text-norby-ivory/50 mt-0.5 capitalize">
+          <div>
+            <h2 className="font-semibold text-norby-ivory">
+              Onde vai seu dinheiro
+            </h2>
+            <p className="text-xs text-norby-ivory/50 mt-0.5">
+              <span className="capitalize">
                 {new Date().toLocaleDateString("pt-BR", { month: "long" })}
-                {categoryTotal > 0 && (
-                  <span className="tnum"> · {formatBRL(categoryTotal)}</span>
-                )}
-              </p>
-            </div>
+              </span>
+              {categoryTotal > 0 && (
+                <span className="tnum"> · {formatBRL(categoryTotal)} no total</span>
+              )}
+            </p>
           </div>
 
           {categoryData.length === 0 ? (
-            <div className="flex items-center justify-center h-[170px] text-norby-ivory/40 text-xs text-center px-4">
+            <div className="flex items-center justify-center h-[150px] text-norby-ivory/40 text-xs text-center px-4">
               Registre despesas para ver a distribuição por categoria
             </div>
           ) : (
@@ -435,10 +504,10 @@ export default function Dashboard() {
                       nameKey="name"
                       cx="50%"
                       cy="50%"
-                      innerRadius={44}
+                      innerRadius={46}
                       outerRadius={62}
                       paddingAngle={categoryData.length > 1 ? 3 : 0}
-                      cornerRadius={4}
+                      cornerRadius={6}
                       startAngle={90}
                       endAngle={-270}
                       stroke="none"
@@ -454,35 +523,33 @@ export default function Dashboard() {
                   </PieChart>
                 </ResponsiveContainer>
                 <div className="absolute inset-0 flex flex-col items-center justify-center pointer-events-none">
-                  <span className="text-[10px] text-norby-ivory/40 uppercase tracking-wider">
+                  <span className="text-[10px] text-norby-ivory/45 uppercase tracking-widest">
                     Maior
                   </span>
-                  <span className="text-lg font-bold text-norby-ivory tnum">
+                  <span className="text-[15px] font-semibold text-norby-teal-soft tnum mt-0.5">
                     {topCategoryPct}%
                   </span>
                 </div>
               </div>
 
-              {/* Legenda: cor + categoria + % (valor no tooltip do donut) */}
+              {/* Legenda: quadradinho de cor + categoria + % (valor no tooltip) */}
               <div className="flex-1 flex flex-col gap-2 min-w-0">
                 {categoryData.map((c, i) => {
                   const pct = categoryTotal
                     ? Math.round((c.value / categoryTotal) * 100)
                     : 0;
                   return (
-                    <div key={c.name} className="flex items-center gap-2.5">
+                    <div key={c.name} className="flex items-center gap-2 text-xs">
                       <span
-                        className="w-2 h-2 rounded-full shrink-0"
+                        className="w-2 h-2 rounded-[3px] shrink-0"
                         style={{
                           background: CATEGORY_COLORS[i % CATEGORY_COLORS.length],
                         }}
                       />
-                      <span className="text-xs text-norby-ivory/80 flex-1 truncate">
+                      <span className="text-norby-ivory/75 flex-1 truncate">
                         {c.name}
                       </span>
-                      <span className="text-xs font-semibold text-norby-ivory tnum">
-                        {pct}%
-                      </span>
+                      <span className="text-norby-ivory/55 tnum">{pct}%</span>
                     </div>
                   );
                 })}
@@ -504,22 +571,26 @@ export default function Dashboard() {
             </div>
             {hasStreakActivity && streakCount > 0 && (
               <span className="chip bg-norby-teal/15 text-norby-teal">
-                <Flame size={12} /> {streakCount}
+                🔥 {streakCount}
               </span>
             )}
           </div>
 
           <div
-            className="grid gap-1.5 mt-5"
+            className="grid gap-1 mt-4"
             style={{ gridTemplateColumns: "repeat(14, minmax(0, 1fr))" }}
           >
-            {streakCells.map((cell) => (
+            {streakCells.map((cell, i) => (
               <div
                 key={cell.key}
                 title={`${formatDateBR(cell.key)} · ${
                   cell.active ? formatBRL(cell.net) : "sem lançamentos"
                 }`}
-                className={`aspect-square rounded-[4px] ${cellClass(cell)}`}
+                className={`aspect-square rounded-[3px] ${cellClass(cell)} ${
+                  i === streakCells.length - 1
+                    ? "ring-1 ring-norby-teal ring-offset-1 ring-offset-norby-surface"
+                    : ""
+                }`}
               />
             ))}
           </div>
@@ -540,12 +611,19 @@ export default function Dashboard() {
         </div>
 
         {/* Meta em destaque */}
-        <div className="glass-card p-6 flex flex-col">
+        <div className="relative overflow-hidden glass-card border-norby-income/25 p-6 flex flex-col">
+          <div
+            className="absolute inset-0 pointer-events-none"
+            style={{
+              background:
+                "radial-gradient(circle at 15% 90%, rgba(95,191,126,0.13), transparent 55%)",
+            }}
+          />
           {featuredGoal ? (
             <>
-              <div className="flex items-center gap-3">
-                <div className="w-9 h-9 rounded-xl bg-norby-income/15 text-norby-income flex items-center justify-center shrink-0">
-                  <Target size={17} />
+              <div className="relative flex items-center gap-3">
+                <div className="w-9 h-9 rounded-xl bg-norby-income/15 flex items-center justify-center shrink-0 text-base">
+                  🎯
                 </div>
                 <div className="min-w-0">
                   <h2 className="font-semibold text-norby-ivory truncate">
@@ -555,7 +633,7 @@ export default function Dashboard() {
                 </div>
               </div>
 
-              <div className="mt-5">
+              <div className="relative mt-4">
                 <p className="tnum tracking-tight">
                   <span className="text-2xl font-semibold text-norby-ivory">
                     {formatBRL(featuredGoal.current_amount)}
@@ -572,8 +650,11 @@ export default function Dashboard() {
                   className="h-2 rounded-full bg-white/[0.06] mt-3 overflow-hidden"
                 >
                   <div
-                    className="h-full rounded-full bg-norby-income transition-all duration-500"
-                    style={{ width: `${goalPct}%` }}
+                    className="h-full rounded-full transition-all duration-500"
+                    style={{
+                      width: `${goalPct}%`,
+                      background: "linear-gradient(90deg, #5FBF7E, #7BD88F)",
+                    }}
                   />
                 </div>
                 <p className="text-xs text-norby-ivory/50 mt-2 tnum">
@@ -584,27 +665,27 @@ export default function Dashboard() {
               <Button
                 onClick={() => navigate("/goals")}
                 variant="outline"
-                className="mt-auto w-full border-norby-income/25 bg-transparent text-norby-income hover:bg-norby-income/10"
+                className="relative mt-auto w-full border-norby-income/25 bg-norby-income/[0.08] text-norby-income hover:bg-norby-income/[0.15]"
               >
                 Ver todas as metas <ArrowRight size={14} />
               </Button>
             </>
           ) : (
             <>
-              <div className="flex items-center gap-3">
-                <div className="w-9 h-9 rounded-xl bg-norby-income/15 text-norby-income flex items-center justify-center shrink-0">
-                  <Target size={17} />
+              <div className="relative flex items-center gap-3">
+                <div className="w-9 h-9 rounded-xl bg-norby-income/15 flex items-center justify-center shrink-0 text-base">
+                  🎯
                 </div>
                 <h2 className="font-semibold text-norby-ivory">Metas</h2>
               </div>
-              <p className="text-xs text-norby-ivory/50 leading-relaxed mt-4 flex-1">
+              <p className="relative text-xs text-norby-ivory/50 leading-relaxed mt-4 flex-1">
                 Crie uma meta de reserva para acompanhar o progresso dela aqui
                 no painel.
               </p>
               <Button
                 onClick={() => navigate("/goals")}
                 variant="outline"
-                className="mt-4 w-full border-norby-income/25 bg-transparent text-norby-income hover:bg-norby-income/10"
+                className="relative mt-4 w-full border-norby-income/25 bg-norby-income/[0.08] text-norby-income hover:bg-norby-income/[0.15]"
               >
                 Criar uma meta <ArrowRight size={14} />
               </Button>
@@ -614,13 +695,13 @@ export default function Dashboard() {
       </div>
 
       {/* ── Linha 3: fluxo de caixa + leitura da IA ─────────────────── */}
-      <div className="grid grid-cols-3 gap-5">
-        <div className="glass-card p-6 col-span-2">
+      <div className="grid grid-cols-[2fr_1fr] gap-4">
+        <div className="glass-card p-6">
           <div className="flex items-start justify-between mb-4">
             <div>
-              <h2 className="font-semibold text-norby-ivory">Fluxo de Caixa</h2>
+              <h2 className="font-semibold text-norby-ivory">Fluxo de caixa</h2>
               <p className="text-xs text-norby-ivory/50 mt-0.5">
-                Entradas e saídas dos últimos meses
+                Entradas vs. saídas · últimos meses
               </p>
             </div>
             <div className="flex items-center gap-4 text-xs">
@@ -641,27 +722,26 @@ export default function Dashboard() {
             </div>
           </div>
           {cashFlowData.length === 0 ? (
-            <div className="flex items-center justify-center h-[220px] text-norby-ivory/40 text-sm">
+            <div className="flex items-center justify-center h-[230px] text-norby-ivory/40 text-sm">
               Nenhuma transação registrada ainda
             </div>
           ) : (
-            <ResponsiveContainer width="100%" height={220}>
+            <ResponsiveContainer width="100%" height={230}>
               <AreaChart
                 data={cashFlowData}
-                margin={{ top: 8, right: 8, left: -16, bottom: 0 }}
+                margin={{ top: 12, right: 12, left: 12, bottom: 0 }}
               >
                 <defs>
                   <linearGradient id="gIncome" x1="0" y1="0" x2="0" y2="1">
-                    <stop offset="0%" stopColor={INCOME_COLOR} stopOpacity={0.3} />
+                    <stop offset="0%" stopColor={INCOME_COLOR} stopOpacity={0.28} />
                     <stop offset="100%" stopColor={INCOME_COLOR} stopOpacity={0} />
                   </linearGradient>
                   <linearGradient id="gExpense" x1="0" y1="0" x2="0" y2="1">
-                    <stop offset="0%" stopColor={EXPENSE_COLOR} stopOpacity={0.28} />
+                    <stop offset="0%" stopColor={EXPENSE_COLOR} stopOpacity={0.22} />
                     <stop offset="100%" stopColor={EXPENSE_COLOR} stopOpacity={0} />
                   </linearGradient>
                 </defs>
                 <CartesianGrid
-                  strokeDasharray="3 3"
                   stroke="rgba(255,255,255,0.05)"
                   vertical={false}
                 />
@@ -670,14 +750,8 @@ export default function Dashboard() {
                   axisLine={false}
                   tickLine={false}
                   tick={axisTick}
+                  dy={8}
                   className="capitalize"
-                />
-                <YAxis
-                  axisLine={false}
-                  tickLine={false}
-                  tick={axisTick}
-                  tickFormatter={fmtShort}
-                  width={48}
                 />
                 <Tooltip
                   content={<ChartTooltip />}
@@ -687,18 +761,18 @@ export default function Dashboard() {
                   type="monotone"
                   dataKey="Entradas"
                   stroke={INCOME_COLOR}
-                  strokeWidth={2.5}
+                  strokeWidth={2.6}
                   fill="url(#gIncome)"
-                  dot={false}
+                  dot={endDot(INCOME_COLOR)}
                   activeDot={{ r: 4, strokeWidth: 0 }}
                 />
                 <Area
                   type="monotone"
                   dataKey="Saídas"
                   stroke={EXPENSE_COLOR}
-                  strokeWidth={2.5}
+                  strokeWidth={2.6}
                   fill="url(#gExpense)"
-                  dot={false}
+                  dot={endDot(EXPENSE_COLOR)}
                   activeDot={{ r: 4, strokeWidth: 0 }}
                 />
               </AreaChart>
@@ -707,13 +781,13 @@ export default function Dashboard() {
         </div>
 
         {/* Leitura da IA */}
-        <div className="glass-card p-6 flex flex-col gap-3">
+        <div className="glass-card border-norby-teal/20 p-6 flex flex-col gap-3">
           <div className="flex items-center gap-3">
             <AiOrb size={34} />
             <div>
               <h2 className="font-semibold text-norby-ivory">Leitura da IA</h2>
-              <p className="text-xs text-norby-ivory/50">
-                Resumo do seu comportamento financeiro
+              <p className="text-[11px] text-norby-teal-soft tracking-wide">
+                resumo do seu comportamento
               </p>
             </div>
           </div>
@@ -723,14 +797,34 @@ export default function Dashboard() {
             </div>
           ) : (
             <div className="flex flex-col gap-2 flex-1">
-              {insightItems.map((item, i) => (
-                <div
-                  key={i}
-                  className="p-3 rounded-xl bg-white/[0.03] text-xs text-norby-ivory/80 leading-relaxed"
-                >
-                  {item.trim()}
-                </div>
-              ))}
+              {insightItems.map((item, i) => {
+                const text = item.trim();
+                // 1º insight = destaque; demais ganham chip de ícone contextual
+                if (i === 0) {
+                  return (
+                    <div
+                      key={i}
+                      className="p-3.5 rounded-xl bg-norby-night/60 border border-white/[0.06] text-[13px] text-norby-ivory/85 leading-relaxed"
+                    >
+                      {text}
+                    </div>
+                  );
+                }
+                const { Icon, chip, bg } = insightStyle(text);
+                return (
+                  <div
+                    key={i}
+                    className={`flex items-start gap-2.5 p-3 rounded-xl ${bg} text-xs text-norby-ivory/75 leading-relaxed`}
+                  >
+                    <span
+                      className={`shrink-0 w-5 h-5 rounded-md flex items-center justify-center mt-0.5 ${chip}`}
+                    >
+                      <Icon size={12} />
+                    </span>
+                    {text}
+                  </div>
+                );
+              })}
             </div>
           )}
 
@@ -744,36 +838,92 @@ export default function Dashboard() {
               </p>
             </div>
           )}
+
+          <Button
+            onClick={() => navigate("/ai")}
+            variant="outline"
+            className="w-full border-norby-teal/40 bg-transparent text-norby-teal hover:bg-norby-teal/10"
+          >
+            Conversar com a Norby <ArrowRight size={14} />
+          </Button>
         </div>
       </div>
 
-      {/* ── Linha 4: movimentações recentes + resumo do mês ─────────── */}
-      <div className="glass-card p-6">
-        <div className="flex items-center justify-between mb-3">
-          <div>
+      {/* ── Linha 4: gastos por categoria + movimentações recentes ──── */}
+      <div className="grid grid-cols-[1fr_1.15fr] gap-4">
+        {/* Gastos por categoria (barras) */}
+        <div className="glass-card p-6">
+          <div className="flex items-center justify-between mb-5">
             <h2 className="font-semibold text-norby-ivory">
-              Movimentações Recentes
+              Gastos por categoria
             </h2>
-            <p className="text-xs text-norby-ivory/50">
-              Últimos lançamentos registrados
-            </p>
+            <span className="text-xs text-norby-ivory/45">
+              {monthYearLabel}
+            </span>
           </div>
-          <Button
-            onClick={() => navigate("/transactions")}
-            variant="ghost"
-            size="sm"
-            className="text-norby-ivory/60 hover:text-norby-ivory hover:bg-white/5"
-          >
-            Ver todas <ArrowRight size={13} />
-          </Button>
+
+          {categoryData.length === 0 ? (
+            <div className="flex items-center justify-center h-[150px] text-norby-ivory/40 text-xs text-center px-4">
+              Registre despesas para ver o ranking de categorias
+            </div>
+          ) : (
+            <div className="flex flex-col gap-4">
+              {categoryData.map((c, i) => {
+                const width = Math.max(6, (c.value / categoryMax) * 92);
+                const barOpacity = [1, 0.55, 0.45, 0.4, 0.35][i] ?? 0.3;
+                return (
+                  <div key={c.name}>
+                    <div className="flex items-center justify-between mb-1.5">
+                      <span className="text-[13px] text-norby-ivory/75">
+                        {c.name}
+                      </span>
+                      <span
+                        className={`text-[13px] tnum ${
+                          i === 0
+                            ? "font-semibold text-norby-teal-soft"
+                            : "font-medium text-norby-ivory/60"
+                        }`}
+                      >
+                        {formatBRL(c.value)}
+                      </span>
+                    </div>
+                    <div className="h-2 rounded-full bg-white/[0.06] overflow-hidden">
+                      <div
+                        className="h-full rounded-full"
+                        style={{
+                          width: `${width}%`,
+                          background: `rgba(45,181,163,${barOpacity})`,
+                        }}
+                      />
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          )}
         </div>
 
-        <div className="flex gap-6">
-          <div className="flex-1 flex flex-col min-w-0">
+        {/* Movimentações recentes */}
+        <div className="glass-card p-6 flex flex-col">
+          <div className="flex items-center justify-between mb-3">
+            <h2 className="font-semibold text-norby-ivory">
+              Movimentações recentes
+            </h2>
+            <Button
+              onClick={() => navigate("/transactions")}
+              variant="ghost"
+              size="sm"
+              className="text-norby-teal hover:text-norby-teal-soft hover:bg-norby-teal/10"
+            >
+              Ver todas <ArrowRight size={13} />
+            </Button>
+          </div>
+
+          <div className="flex flex-col flex-1">
             {transactions.length === 0 ? (
               <div className="flex-1 flex items-center justify-center text-norby-ivory/40 text-xs text-center py-8">
-                Nenhuma movimentação ainda — use “+ Receita” ou “− Despesa” para
-                começar
+                Nenhuma movimentação ainda — use “+ Receita” ou “− Despesa”
+                para começar
               </div>
             ) : (
               transactions.slice(0, 5).map((t) => {
@@ -784,31 +934,24 @@ export default function Dashboard() {
                     className="flex items-center justify-between py-2.5 border-b border-white/5 last:border-0"
                   >
                     <div className="flex items-center gap-3 min-w-0">
-                      <div
-                        className={`w-8 h-8 rounded-lg flex items-center justify-center shrink-0 ${
-                          isIncome
-                            ? "bg-norby-income/15 text-norby-income"
-                            : "bg-norby-danger/15 text-norby-danger"
-                        }`}
-                      >
-                        {isIncome ? (
-                          <ArrowUpRight size={16} />
-                        ) : (
-                          <ArrowDownRight size={16} />
-                        )}
+                      <div className="w-9 h-9 rounded-[10px] bg-norby-surface2 flex items-center justify-center shrink-0 text-base">
+                        {emojiFor(t)}
                       </div>
                       <div className="min-w-0">
-                        <p className="text-sm font-medium text-norby-ivory truncate">
+                        <p className="text-[13px] font-medium text-norby-ivory truncate">
                           {t.category}
                         </p>
-                        <p className="text-xs text-norby-ivory/40">
-                          {formatDateBR(t.date)}
+                        <p className="text-xs text-norby-ivory/40 truncate">
+                          {relativeDay(t.date)}
+                          {t.description && ` · ${t.description}`}
                         </p>
                       </div>
                     </div>
                     <p
-                      className={`text-sm font-semibold tnum shrink-0 ${
-                        isIncome ? "text-norby-income" : "text-norby-ivory"
+                      className={`text-[13px] tnum shrink-0 ${
+                        isIncome
+                          ? "font-semibold text-norby-income"
+                          : "font-medium text-norby-ivory/60"
                       }`}
                     >
                       {isIncome ? "+" : "−"} {formatBRL(parseFloat(t.amount))}
@@ -817,30 +960,6 @@ export default function Dashboard() {
                 );
               })
             )}
-          </div>
-
-          <div className="w-60 shrink-0 flex flex-col gap-2">
-            <div className="p-4 rounded-2xl bg-white/[0.03]">
-              <p className="text-xs text-norby-ivory/40">Saldo do mês</p>
-              <p
-                className={`text-sm font-bold mt-1 tnum flex items-center gap-1 ${
-                  monthNet >= 0 ? "text-norby-income" : "text-norby-danger"
-                }`}
-              >
-                {monthNet >= 0 ? (
-                  <TrendingUp size={13} />
-                ) : (
-                  <TrendingDown size={13} />
-                )}
-                {formatBRL(monthNet)}
-              </p>
-            </div>
-            <div className="p-4 rounded-2xl bg-norby-teal/10 border border-norby-teal/20">
-              <p className="text-xs text-norby-teal">Maior gasto</p>
-              <p className="text-sm font-bold text-norby-ivory mt-1 truncate">
-                {categoryData[0]?.name || "—"}
-              </p>
-            </div>
           </div>
         </div>
       </div>

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -464,7 +464,7 @@ export default function Dashboard() {
             <div className="pl-3">
               <p className="microlabel">Score IA</p>
               <p className="text-sm font-semibold text-norby-teal-soft tnum mt-1">
-                {insight?.score ?? "—"}/100
+                {insight?.score != null ? `${insight.score}/100` : "—"}
               </p>
             </div>
           </div>

--- a/frontend/src/pages/Goals.jsx
+++ b/frontend/src/pages/Goals.jsx
@@ -103,7 +103,7 @@ export default function Goals() {
     <div className="space-y-6">
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-bold text-norby-ivory tracking-tight">Metas</h1>
+          <h1 className="text-3xl font-bold text-norby-ivory tracking-tight">Metas</h1>
           <p className="text-norby-ivory/50 text-sm mt-1">
             Objetivos de poupança e orçamentos mensais
           </p>
@@ -219,9 +219,20 @@ export default function Goals() {
         </Dialog>
       </div>
 
-      <div className="grid grid-cols-2 gap-4">
+      <div className="grid grid-cols-2 gap-5">
         {goals.length === 0 && (
-          <p className="col-span-2 text-norby-ivory/40 text-sm">Nenhuma meta ainda.</p>
+          <div className="col-span-2 glass-card p-10 flex flex-col items-center text-center">
+            <div className="w-11 h-11 rounded-xl bg-norby-teal/15 flex items-center justify-center mb-3">
+              <Target size={20} className="text-norby-teal" />
+            </div>
+            <p className="text-sm font-medium text-norby-ivory">
+              Nenhuma meta ainda
+            </p>
+            <p className="text-xs text-norby-ivory/50 mt-1 max-w-xs leading-relaxed">
+              Crie uma meta de poupança para acompanhar um objetivo, ou um
+              orçamento para limitar os gastos de uma categoria.
+            </p>
+          </div>
         )}
         {goals.map((g) => {
           const pct = Math.min(g.progress_pct, 100);

--- a/frontend/src/pages/Recurring.jsx
+++ b/frontend/src/pages/Recurring.jsx
@@ -5,7 +5,7 @@ import { Plus, Trash2, Repeat, Pause, Play } from "lucide-react";
 
 import { recurringApi } from "@/api/recurring";
 import { walletsApi } from "@/api/wallets";
-import { CATEGORIES } from "@/lib/categories";
+import { categoriesFor, reconcileCategory } from "@/lib/categories";
 import { recurringSchema } from "@/lib/schemas";
 import { formatDateBR, formatBRL, inputCls } from "@/lib/utils";
 import { ConfirmDialog } from "@/components/shared/ConfirmDialog";
@@ -45,14 +45,12 @@ const TYPE_OPTIONS = [
   { value: "INCOME", label: "Receita", activeClass: "bg-norby-income text-norby-night" },
 ];
 
-const CATEGORY_OPTIONS = CATEGORIES.map((c) => ({ value: c, label: c }));
-
 // Valores iniciais do formulário de recorrência.
 const emptyForm = () => ({
   wallet_id: "",
   type: "EXPENSE",
   amount: "",
-  category: CATEGORIES[0],
+  category: categoriesFor("EXPENSE")[0],
   frequency: "MONTHLY",
   day_of_month: 1,
   weekday: undefined,
@@ -70,6 +68,7 @@ export default function Recurring() {
     control,
     reset,
     getValues,
+    setValue,
     formState: { errors, isSubmitting },
   } = useForm({
     resolver: zodResolver(recurringSchema),
@@ -97,6 +96,12 @@ export default function Recurring() {
 
   // Observa a frequência para alternar entre os campos day_of_month e weekday.
   const frequency = useWatch({ control, name: "frequency" });
+
+  const watchedType = useWatch({ control, name: "type" });
+  const categoryOptions = categoriesFor(watchedType).map((c) => ({
+    value: c,
+    label: c,
+  }));
 
   function handleOpenChange(v) {
     setOpen(v);
@@ -183,7 +188,10 @@ export default function Recurring() {
                   render={({ field }) => (
                     <Segmented
                       value={field.value}
-                      onChange={field.onChange}
+                      onChange={(v) => {
+                        field.onChange(v);
+                        setValue("category", reconcileCategory(v, getValues("category")));
+                      }}
                       options={TYPE_OPTIONS}
                     />
                   )}
@@ -226,7 +234,7 @@ export default function Recurring() {
                       value={field.value}
                       onChange={field.onChange}
                       placeholder="Selecionar categoria"
-                      options={CATEGORY_OPTIONS}
+                      options={categoryOptions}
                     />
                   )}
                 />

--- a/frontend/src/pages/Recurring.jsx
+++ b/frontend/src/pages/Recurring.jsx
@@ -156,7 +156,7 @@ export default function Recurring() {
     <div className="space-y-6">
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-bold text-norby-ivory tracking-tight">
+          <h1 className="text-3xl font-bold text-norby-ivory tracking-tight">
             Recorrências
           </h1>
           <p className="text-norby-ivory/50 text-sm mt-1">

--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -78,7 +78,7 @@ export default function Settings() {
   return (
     <div className="max-w-2xl space-y-6">
       <div>
-        <h1 className="text-2xl font-bold text-norby-ivory tracking-tight">
+        <h1 className="text-3xl font-bold text-norby-ivory tracking-tight">
           Configurações
         </h1>
         <p className="text-norby-ivory/50 text-sm mt-1">Gerencie seu perfil</p>

--- a/frontend/src/pages/Transactions.jsx
+++ b/frontend/src/pages/Transactions.jsx
@@ -1,12 +1,12 @@
 import { useEffect, useState } from "react";
-import { useForm, Controller } from "react-hook-form";
+import { useForm, Controller, useWatch } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Plus, Search, Trash2, Pencil } from "lucide-react";
 
 import { transactionsApi } from "@/api/transactions";
 import { walletsApi } from "@/api/wallets";
 import { recurringApi } from "@/api/recurring";
-import { CATEGORIES } from "@/lib/categories";
+import { categoriesFor, reconcileCategory } from "@/lib/categories";
 import { transactionSchema } from "@/lib/schemas";
 import { formatDateBR, formatBRL, inputCls, toDateInput, todayInput } from "@/lib/utils";
 import { ConfirmDialog } from "@/components/shared/ConfirmDialog";
@@ -30,14 +30,12 @@ const TYPE_OPTIONS = [
   { value: "INCOME", label: "Receita", activeClass: "bg-norby-income text-norby-night" },
 ];
 
-const CATEGORY_OPTIONS = CATEGORIES.map((c) => ({ value: c, label: c }));
-
 // Valores iniciais do formulário (date sempre fresca → função).
 const emptyForm = () => ({
   wallet_id: "",
   type: "EXPENSE",
   amount: "",
-  category: CATEGORIES[0],
+  category: categoriesFor("EXPENSE")[0],
   description: "",
   date: todayInput(),
 });
@@ -58,6 +56,7 @@ export default function Transactions() {
     control,
     reset,
     getValues,
+    setValue,
     formState: { errors, isSubmitting },
   } = useForm({
     resolver: zodResolver(transactionSchema),
@@ -96,6 +95,12 @@ export default function Transactions() {
   const reload = () => load(filterType ? { type: filterType } : {});
 
   const walletOptions = wallets.map((w) => ({ value: w.id, label: w.name }));
+
+  const watchedType = useWatch({ control, name: "type" });
+  const categoryOptions = categoriesFor(watchedType).map((c) => ({
+    value: c,
+    label: c,
+  }));
 
   function openNew() {
     setEditing(null);
@@ -204,7 +209,10 @@ export default function Transactions() {
                   render={({ field }) => (
                     <Segmented
                       value={field.value}
-                      onChange={field.onChange}
+                      onChange={(v) => {
+                        field.onChange(v);
+                        setValue("category", reconcileCategory(v, getValues("category")));
+                      }}
                       options={TYPE_OPTIONS}
                     />
                   )}
@@ -247,7 +255,7 @@ export default function Transactions() {
                       value={field.value}
                       onChange={field.onChange}
                       placeholder="Selecionar categoria"
-                      options={CATEGORY_OPTIONS}
+                      options={categoryOptions}
                     />
                   )}
                 />

--- a/frontend/src/pages/Transactions.jsx
+++ b/frontend/src/pages/Transactions.jsx
@@ -76,7 +76,7 @@ export default function Transactions() {
     walletsApi.list().then((r) => {
       setWallets(r.data);
     });
-    load(); // eslint-disable-line react-hooks/set-state-in-effect
+    load();
   }, []);
 
   useEffect(() => {
@@ -104,7 +104,7 @@ export default function Transactions() {
     setEditing(null);
     setServerError(null);
     reset({ ...emptyForm(), type: preset, category: categoriesFor(preset)[0] });
-    setOpen(true); // eslint-disable-line react-hooks/set-state-in-effect
+    setOpen(true);
     navigate(location.pathname, { replace: true });
     // roda só no mount: o state chega junto com a navegação que monta a página
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -193,7 +193,7 @@ export default function Transactions() {
     <div className="space-y-6">
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-bold text-norby-ivory tracking-tight">
+          <h1 className="text-3xl font-bold text-norby-ivory tracking-tight">
             Relatórios
           </h1>
           <p className="text-norby-ivory/50 text-sm mt-1">

--- a/frontend/src/pages/Transactions.jsx
+++ b/frontend/src/pages/Transactions.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
 import { useForm, Controller, useWatch } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Plus, Search, Trash2, Pencil } from "lucide-react";
@@ -49,6 +50,8 @@ export default function Transactions() {
   const [serverError, setServerError] = useState(null);
   const [search, setSearch] = useState("");
   const [filterType, setFilterType] = useState("");
+  const location = useLocation();
+  const navigate = useNavigate();
 
   const {
     register,
@@ -91,6 +94,21 @@ export default function Transactions() {
       reset((prev) => ({ ...prev, wallet_id: wallets[0].id }));
     }
   }, [wallets, editing, reset, getValues]);
+
+  // Atalho vindo do Dashboard ("+ Receita" / "− Despesa"): abre o form já com
+  // o tipo pré-selecionado. O state da rota é limpo em seguida para o dialog
+  // não reabrir em navegação de histórico.
+  useEffect(() => {
+    const preset = location.state?.newType;
+    if (preset !== "INCOME" && preset !== "EXPENSE") return;
+    setEditing(null);
+    setServerError(null);
+    reset({ ...emptyForm(), type: preset, category: categoriesFor(preset)[0] });
+    setOpen(true); // eslint-disable-line react-hooks/set-state-in-effect
+    navigate(location.pathname, { replace: true });
+    // roda só no mount: o state chega junto com a navegação que monta a página
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const reload = () => load(filterType ? { type: filterType } : {});
 

--- a/frontend/src/pages/Wallets.jsx
+++ b/frontend/src/pages/Wallets.jsx
@@ -76,7 +76,7 @@ export default function Wallets() {
     <div className="space-y-6">
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-bold text-norby-ivory tracking-tight">
+          <h1 className="text-3xl font-bold text-norby-ivory tracking-tight">
             Carteiras
           </h1>
           <p className="text-norby-ivory/50 text-sm mt-1">
@@ -146,7 +146,21 @@ export default function Wallets() {
         </Dialog>
       </div>
 
-      <div className="grid grid-cols-3 gap-4">
+      <div className="grid grid-cols-3 gap-5">
+        {wallets.length === 0 && (
+          <div className="col-span-3 glass-card p-10 flex flex-col items-center text-center">
+            <div className="w-11 h-11 rounded-xl bg-norby-teal/15 flex items-center justify-center mb-3">
+              <Wallet size={20} className="text-norby-teal" />
+            </div>
+            <p className="text-sm font-medium text-norby-ivory">
+              Nenhuma carteira ainda
+            </p>
+            <p className="text-xs text-norby-ivory/50 mt-1 max-w-xs leading-relaxed">
+              Crie sua primeira carteira (conta, cartão ou dinheiro) para
+              começar a registrar transações.
+            </p>
+          </div>
+        )}
         {wallets.map((w) => (
           <div key={w.id} className="glass-card-hover p-5 flex flex-col gap-4">
             <div className="flex items-start justify-between">

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -15,8 +15,41 @@ export default {
             income: "#5FBF7E",
             expense: "#8A8580",
             danger: "#E06A4A",
-          }
-        }
+          },
+          // Aliases shadcn → paleta norby (mesmos hex; os primitivos ui/
+          // referenciam esses tokens, que antes não existiam e viravam no-op).
+          background: "#07100F",
+          foreground: "#EFFAF8",
+          card: { DEFAULT: "#0E1B19", foreground: "#EFFAF8" },
+          popover: { DEFAULT: "#152624", foreground: "#EFFAF8" },
+          primary: { DEFAULT: "#2DB5A3", foreground: "#07100F" },
+          secondary: { DEFAULT: "#152624", foreground: "#EFFAF8" },
+          muted: { DEFAULT: "rgba(255,255,255,0.05)", foreground: "rgba(239,250,248,0.60)" },
+          destructive: { DEFAULT: "#E06A4A", foreground: "#EFFAF8" },
+          border: "rgba(255,255,255,0.10)",
+          input: "rgba(255,255,255,0.10)",
+          ring: "#2DB5A3",
+        },
+        fontFamily: {
+          sans: ["Inter", "sans-serif"],
+          heading: ["Inter", "sans-serif"],
+        },
+        ringWidth: { 3: "3px" },
+        keyframes: {
+          // Pulso do orbe da IA: sutil (assinatura), nunca em conteúdo de dado
+          "orb-pulse": {
+            "0%, 100%": { opacity: "0.85", transform: "scale(1)" },
+            "50%": { opacity: "1", transform: "scale(1.03)" },
+          },
+          "fade-up": {
+            from: { opacity: "0", transform: "translateY(6px)" },
+            to: { opacity: "1", transform: "translateY(0)" },
+          },
+        },
+        animation: {
+          "orb-pulse": "orb-pulse 4s ease-in-out infinite",
+          "fade-up": "fade-up 0.25s ease-out both",
+        },
     },
   },
   plugins: [],


### PR DESCRIPTION
## O que entra nesta release

### Interface
- Redesign da UI (shell, dashboard e telas): nova navegação, cards, empty states, orbe da IA, heatmap de ritmo financeiro.

### Formulários
- Categorias separadas por tipo: Despesa e Receita deixam de compartilhar a mesma lista. Ao trocar o tipo, uma categoria inválida é reajustada automaticamente.

### IA
- **Score determinístico**: o "Score IA" do dashboard passa a ser calculado por regras (taxa de poupança), testável e instantâneo, no lugar de um número inventado pelo LLM. Recalculado a cada request e resiliente a falha do Gemini.
- **Leitura da IA fiel aos dados**: o texto é cacheado por mês, mas só reaproveitado se os dados não mudaram (fingerprint). Se receita/despesa/categorias mudam, é regenerado — não fica mais congelado contradizendo os KPIs.
- **Cache higienizado**: upsert em (user_id, reference_month) evita duplicatas; o score nunca é persistido no cache.
- **Histórico de conversas**: novo endpoint `GET /ai/chat/sessions/{id}` (escopado por usuário, 404 caso contrário) e a UI carrega a conversa ao clicar.

## Testes
- Backend: 99 passed (pytest). Frontend: 24 passed, ESLint limpo, build OK.
