### PR TITLE
fix(theme): render dark without JavaScript and unblock the theme script

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -6,6 +6,13 @@
    rgb(var(--x) / <alpha-value>), então bg-surface/70 continua funcionando.
    Valores de superfície amostrados dos PNGs de referência — a calibração
    canônica acontece na Task 19 do plano. */
+/* :root junto de [data-theme="dark"] de propósito: o escuro é o default do
+   CSS, não só do JavaScript. Sem isso, um <html> sem data-theme deixa TODO
+   token indefinido, cada rgb(var(--x) / a) vira inválido e a página inteira
+   perde superfície, cor de gráfico e fundo. Foi o que aconteceu em produção
+   quando a CSP bloqueou o script inline. Mesma especificidade de
+   [data-theme="light"], que vem depois e por isso continua vencendo. */
+:root,
 [data-theme="dark"] {
   /* Amostrados dos PNGs de referência na Task 19 (média/decil/moda de regiões
      do arquivo, não a olho). O fundo da referência é azul-escuro, não cinza. */
@@ -125,6 +132,7 @@
 /* Tokens de composição: carregam alpha e blur próprios, então NÃO passam pelo
    Tailwind. No escuro o vidro é branco a 3,5% sobre quase preto; no claro é
    branco a 72% sobre lavanda. Não é a mesma cor com outra opacidade. */
+:root,
 [data-theme="dark"] {
   /* Tinta azul, não branco puro: o card composto da referência mede 8 12 24
      sobre um fundo 3 5 14, ou seja o vidro ESFRIA a superfície em vez de só

--- a/frontend/src/lib/csp.test.js
+++ b/frontend/src/lib/csp.test.js
@@ -1,0 +1,51 @@
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+// O script inline do index.html aplica data-theme no <html> antes do bundle.
+// Sob a CSP de produção ele só executa se o hash dele estiver em script-src.
+// Quando os dois divergiram, o navegador bloqueou o script, o atributo nunca
+// foi aplicado, TODO token --* ficou indefinido e a aplicação subiu sem
+// superfície, sem cor de gráfico e sem fundo. Nada no build acusou.
+// Este teste existe para essa divergência quebrar aqui, e não em produção.
+describe("CSP de produção", () => {
+  function cspDeProducao() {
+    const vercel = JSON.parse(readFileSync(resolve("vercel.json"), "utf8"));
+    return vercel.headers
+      .flatMap((entrada) => entrada.headers)
+      .find((cabecalho) => cabecalho.key === "Content-Security-Policy").value;
+  }
+
+  function diretiva(csp, nome) {
+    return csp
+      .split(";")
+      .map((parte) => parte.trim())
+      .find((parte) => parte.startsWith(`${nome} `));
+  }
+
+  it("autoriza o script inline de tema pelo hash exato", () => {
+    const html = readFileSync(resolve("index.html"), "utf8");
+    const inline = html.match(/<script>([\s\S]*?)<\/script>/);
+
+    expect(inline, "o script inline de tema sumiu do index.html").not.toBeNull();
+
+    // Normaliza CRLF antes de somar: o parser HTML converte quebra de linha
+    // para LF antes de tokenizar, então é sobre o texto em LF que o navegador
+    // calcula o hash. Num checkout Windows (core.autocrlf=true) o arquivo em
+    // disco vem com CRLF e o hash cru daria diferente do de produção, onde a
+    // Vercel faz checkout Linux. O blob no git é LF nos dois casos.
+    const fonte = inline[1].replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+    const hash = createHash("sha256").update(fonte, "utf8").digest("base64");
+
+    expect(diretiva(cspDeProducao(), "script-src")).toContain(`'sha256-${hash}'`);
+  });
+
+  it("não afrouxa script-src com unsafe-inline", () => {
+    // Liberar inline em bloco resolveria o sintoma e desfaria o endurecimento:
+    // qualquer injeção de script passaria a executar. O hash autoriza um
+    // conteúdo exato, e só ele.
+    expect(diretiva(cspDeProducao(), "script-src")).not.toContain("unsafe-inline");
+  });
+});

--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -6,7 +6,7 @@
       "headers": [
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self' https://norby-production.up.railway.app; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'"
+          "value": "default-src 'self'; script-src 'self' 'sha256-R+3Pq9GSZ0ahTzusI2wOQaex2PsnJfJjEtMCubzhkJo='; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self' https://norby-production.up.railway.app; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'"
         },
         { "key": "X-Content-Type-Options", "value": "nosniff" },
         { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },


### PR DESCRIPTION
Production shipped with no theme applied at all: white page, cards without a surface, black donut, empty rhythm cells. Not a "dark mode default" bug — **no** theme was applied.

## Cause

`frontend/vercel.json` sends `script-src 'self'`, with no `'unsafe-inline'` and no hash. The inline script in `index.html` that sets `data-theme` on `<html>` before the bundle is therefore **blocked by CSP in production**.

Verified against the live site rather than inferred: the response header is `script-src 'self'` and the inline script is present in the served HTML, so the browser refuses it.

With no `data-theme`, neither `[data-theme="dark"]` nor `[data-theme="light"]` matches, every `--*` token is undefined, and each `rgb(var(--x) / a)` becomes an invalid value. That is why surfaces, chart colours and the page background all disappeared at once.

Picking a theme fixed it because `setTheme()` runs from the bundle, which CSP allows. Ctrl+F5 brought it back because nothing re-applied the attribute on a fresh load.

`style-src` already carried `'unsafe-inline'`; `script-src` never did. The policy predates the theme script.

## Fix, in three layers

1. **Dark is now the CSS default.** `:root` carries the dark tokens alongside `[data-theme="dark"]`, so a missing attribute renders the app correctly instead of stripping it. `[data-theme="light"]` has the same specificity and comes later, so light still wins. This is the layer that would have contained the failure: the worst case becomes "wrong theme", never "no theme".
2. **The inline script is authorised by hash**, `'sha256-R+3Pq9GSZ0ahTzusI2wOQaex2PsnJfJjEtMCubzhkJo='`. Not `'unsafe-inline'`: that would resolve the symptom by undoing the hardening and letting any injected script execute. A hash authorises one exact body and nothing else.
3. **A test recomputes the hash from `index.html` and asserts it is in the CSP**, and asserts `script-src` never gains `unsafe-inline`. The silent drift between those two files is what caused the outage, and no build step could catch it.

The test normalises CRLF before hashing. The HTML parser converts line endings to LF before tokenising, so that is what the browser hashes; on a Windows checkout (`core.autocrlf=true`) the working file has CRLF and a raw hash would disagree with production. The git blob is LF either way, which is what Vercel builds from.

## Also fixed by this

Nothing in the app read `localStorage` at runtime — only the blocked inline script did. A user who had chosen light and reloaded silently lost the preference, since `getTheme()` only reads the DOM attribute. With the script unblocked, the persisted choice applies again before first paint.

## Verification

With `data-theme` deleted from `<html>` in the browser:

| | `--bg-base` | `body` background |
|---|---|---|
| `data-theme="light"` | `248 248 251` | `rgb(248, 248, 251)` |
| `data-theme="dark"` | `3 5 14` | `rgb(3, 5, 14)` |
| **attribute absent** | `3 5 14` | `rgb(3, 5, 14)` |

Lint clean. 70 tests across 18 files. Build clean.