### PR TITLE
v2 Wave 1: pagination, goal editing, session redirect and the money input

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -72,6 +72,9 @@ app.add_middleware(
     allow_credentials=True, # Permite enviar cookies e headers de autenticação
     allow_methods=["*"],
     allow_headers=["*"], # Permite qualquer header
+    # O navegador esconde headers de resposta que não estejam aqui. Sem esta
+    # linha o X-Total-Count chega no wire e some antes do axios.
+    expose_headers=["X-Total-Count"],
 )
 
 

--- a/backend/app/routers/transactions.py
+++ b/backend/app/routers/transactions.py
@@ -1,6 +1,6 @@
-from fastapi import APIRouter, Depends, Query, HTTPException, status
+from fastapi import APIRouter, Depends, Query, HTTPException, status, Response
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy import select
+from sqlalchemy import func, select
 from uuid import UUID
 from datetime import date
 from typing import Optional
@@ -80,6 +80,7 @@ async def list_transactions(
     offset: int = Query(0, ge=0),
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
+    response: Response = None,
 ):
     filters = [Transaction.user_id == current_user.id]
 
@@ -99,6 +100,14 @@ async def list_transactions(
         start, end = current_month_range(date(year, month, 1))
         filters.append(Transaction.date >= start)
         filters.append(Transaction.date < end)
+
+    # Contagem com os MESMOS filtros e sem limit/offset: é o que permite a UI
+    # dizer "página 2 de 7". Sem isso o front mostra 200 linhas e cala sobre o resto.
+    total = (
+        await db.execute(select(func.count()).select_from(Transaction).where(*filters))
+    ).scalar_one()
+    response.headers["X-Total-Count"] = str(total)
+
     result = await db.execute(
         select(Transaction)
         .where(*filters)

--- a/backend/tests/test_transactions.py
+++ b/backend/tests/test_transactions.py
@@ -323,3 +323,32 @@ async def test_moving_to_someone_elses_wallet_is_404(make_auth_client):
     # E o saldo do Bob não foi tocado.
     wallets_bob = (await bob.get("/wallets/")).json()
     assert float(wallets_bob[0]["balance"]) == 100.0
+
+
+@pytest.mark.asyncio
+async def test_list_returns_total_count_header(make_auth_client):
+    # A página de Relatórios precisa saber quantas transações existem no total,
+    # não só quantas couberam no limit — senão esconde dado sem avisar.
+    ac = await make_auth_client("Alice")
+    w = await make_wallet(ac, balance=1000)
+    for _ in range(3):
+        await ac.post("/transactions/", json=tx_payload(w["id"], amount="10.00"))
+
+    res = await ac.get("/transactions/?limit=2")
+
+    assert res.status_code == 200
+    assert len(res.json()) == 2
+    assert res.headers["x-total-count"] == "3"
+
+
+@pytest.mark.asyncio
+async def test_total_count_respects_filters(make_auth_client):
+    # A contagem tem que ser a do filtro aplicado, não a da tabela inteira.
+    ac = await make_auth_client("Alice")
+    w = await make_wallet(ac, balance=1000)
+    await ac.post("/transactions/", json=tx_payload(w["id"], type="EXPENSE"))
+    await ac.post("/transactions/", json=tx_payload(w["id"], type="INCOME", amount="5.00"))
+
+    res = await ac.get("/transactions/?type=INCOME")
+
+    assert res.headers["x-total-count"] == "1"

--- a/backend/tests/test_transactions.py
+++ b/backend/tests/test_transactions.py
@@ -136,7 +136,12 @@ async def test_list_is_scoped_to_user(make_auth_client):
     w = await make_wallet(alice)
     await alice.post("/transactions/", json=tx_payload(w["id"]))
     assert len((await alice.get("/transactions/")).json()) == 1
-    assert len((await bob.get("/transactions/")).json()) == 0
+    bob_res = await bob.get("/transactions/")
+    assert len(bob_res.json()) == 0
+    # x-total-count precisa herdar o mesmo escopo de usuário do corpo: sem
+    # isto, um bug futuro na query de contagem vazaria quantas transações de
+    # Alice existem, mesmo com a lista do Bob corretamente vazia.
+    assert bob_res.headers["x-total-count"] == "0"
 
 
 @pytest.mark.asyncio

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -19,6 +19,14 @@ function ProtectedRoute({ children }) {
   return isAuthenticated ? children : <Navigate to="/" replace />;
 }
 
+// A raiz é a porta de entrada: com sessão válida ela leva ao dashboard em vez
+// de mostrar login de novo. O boot em App já validou o token no /auth/me, então
+// aqui isAuthenticated só é true se o backend confirmou.
+function RootRoute() {
+  const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
+  return isAuthenticated ? <Navigate to="/dashboard" replace /> : <Auth />;
+}
+
 export default function App() {
   const token = useAuthStore((s) => s.token);
   const [booting, setBooting] = useState(true);
@@ -49,7 +57,7 @@ export default function App() {
   return (
     <BrowserRouter>
       <Routes>
-        <Route path="/" element={<Auth />} />
+        <Route path="/" element={<RootRoute />} />
         <Route path="/privacidade" element={<Privacidade />} />
         <Route path="/termos" element={<Termos />} />
         <Route

--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+
+import { useAuthStore } from "@/store/authStore";
+import { authApi } from "@/api/auth";
+import App from "./App";
+
+vi.mock("@/api/auth", () => ({
+  authApi: { me: vi.fn(() => Promise.resolve({ data: { name: "Alice" } })) },
+}));
+// Este teste cobre routing, não a tela em si: o redirect de sessão válida
+// monta o Dashboard de verdade, que dispara chamadas reais de rede (rejeitam
+// no jsdom e ficam barulhentas, além de acoplar este teste ao formato de
+// resposta da API do Dashboard). Trocamos por um stub.
+vi.mock("./pages/Dashboard", () => ({ default: () => <div>Dashboard</div> }));
+// AppLayout (que envolve toda rota protegida) roda isso no mount para
+// materializar recorrências vencidas; mesma razão do mock acima.
+vi.mock("@/api/recurring", () => ({
+  recurringApi: { run: vi.fn(() => Promise.resolve({})) },
+}));
+
+describe("rota raiz", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useAuthStore.getState().logout();
+  });
+
+  it("manda para o dashboard quem já tem sessão", async () => {
+    useAuthStore.getState().login("t", "r", { name: "Alice" });
+
+    render(<App />);
+
+    await waitFor(() => expect(window.location.pathname).toBe("/dashboard"));
+  });
+
+  it("mostra a tela de autenticação para quem não tem sessão", async () => {
+    render(<App />);
+
+    // "Entrar" aparece em dois botões (alternância de modo e submit); o
+    // findByRole verbatim do brief é ambíguo aqui, então checamos presença.
+    expect(await screen.findAllByRole("button", { name: /entrar/i })).not.toHaveLength(0);
+  });
+
+  it("cai na autenticação sem loop quando o token persistido é inválido", async () => {
+    // Simula sessão persistida com token adulterado/expirado: o boot chama
+    // /auth/me, que rejeita -> logout() -> raiz precisa mostrar Auth uma
+    // única vez, sem re-navegar (RootRoute não redireciona quando desloga).
+    authApi.me.mockRejectedValueOnce(new Error("401"));
+    useAuthStore.getState().login("token-invalido", "r", { name: "Alice" });
+
+    render(<App />);
+
+    expect(await screen.findAllByRole("button", { name: /entrar/i })).not.toHaveLength(0);
+    expect(useAuthStore.getState().isAuthenticated).toBe(false);
+    expect(window.location.pathname).toBe("/");
+  });
+});

--- a/frontend/src/components/shared/AmountPromptDialog.jsx
+++ b/frontend/src/components/shared/AmountPromptDialog.jsx
@@ -11,14 +11,29 @@ import {
   DialogTrigger,
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
+import { Field } from "@/components/ui/field";
 import { MoneyInput } from "@/components/ui/money-input";
+import { Segmented } from "@/components/ui/segmented";
 import { apiErrorMessage } from "@/lib/utils";
+
+// "positive" | "negative" em vez de true/false: são rótulos de opção do
+// Segmented, não um segundo estado de sinal — o valor real continua sendo só
+// `amount` (ver handleSignChange).
+const SIGN_OPTIONS = [
+  { value: "positive", label: "Aporte" },
+  { value: "negative", label: "Correção" },
+];
 
 /**
  * Diálogo com um input de valor validado (R$), no lugar de `prompt()`.
  *
  * Aceita valores negativos (ex.: corrigir um aporte) mas rejeita zero/entrada
  * inválida. Erros da API do `onSubmit` aparecem inline, sem fechar o diálogo.
+ *
+ * allowNegative fixo em `true`: hoje só existe um uso (aporte de meta, em
+ * Goals.jsx), que sempre aceita correção. Quando surgir um segundo uso sem
+ * essa necessidade, isso vira prop — não antes, pra não carregar uma opção
+ * que nenhum call site usa.
  */
 export function AmountPromptDialog({
   trigger,
@@ -29,10 +44,19 @@ export function AmountPromptDialog({
   onSubmit,
 }) {
   const inputId = useId();
+  const allowNegative = true;
   const [open, setOpen] = useState(false);
   const [amount, setAmount] = useState(0);
   const [error, setError] = useState(null);
   const [loading, setLoading] = useState(false);
+
+  // Deriva do próprio `amount` (fonte única): nenhum estado de sinal
+  // separado. Em 0 é um no-op, igual ao atalho de teclado "-" do
+  // MoneyInput — não há sinal pra "prender" antes de existir magnitude.
+  function handleSignChange(v) {
+    const magnitude = Math.abs(amount);
+    setAmount(v === "negative" ? -magnitude : magnitude);
+  }
 
   function handleOpenChange(v) {
     setOpen(v);
@@ -70,11 +94,22 @@ export function AmountPromptDialog({
         </DialogHeader>
 
         <form onSubmit={handleSubmit} className="space-y-3">
+          {allowNegative && (
+            <Field label="Tipo de lançamento">
+              <Segmented
+                value={amount < 0 ? "negative" : "positive"}
+                onChange={handleSignChange}
+                options={SIGN_OPTIONS}
+                ariaLabel="Tipo de lançamento"
+              />
+            </Field>
+          )}
+
           <div className="space-y-1">
             <label htmlFor={inputId} className="text-xs text-content-2">
               Valor
             </label>
-            <MoneyInput id={inputId} value={amount} onChange={setAmount} allowNegative />
+            <MoneyInput id={inputId} value={amount} onChange={setAmount} allowNegative={allowNegative} />
           </div>
 
           {error && <p className="text-danger text-xs">{error}</p>}

--- a/frontend/src/components/shared/AmountPromptDialog.jsx
+++ b/frontend/src/components/shared/AmountPromptDialog.jsx
@@ -11,7 +11,8 @@ import {
   DialogTrigger,
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
-import { apiErrorMessage, inputCls } from "@/lib/utils";
+import { MoneyInput } from "@/components/ui/money-input";
+import { apiErrorMessage } from "@/lib/utils";
 
 /**
  * Diálogo com um input de valor validado (R$), no lugar de `prompt()`.
@@ -29,22 +30,21 @@ export function AmountPromptDialog({
 }) {
   const inputId = useId();
   const [open, setOpen] = useState(false);
-  const [value, setValue] = useState("");
+  const [amount, setAmount] = useState(0);
   const [error, setError] = useState(null);
   const [loading, setLoading] = useState(false);
 
   function handleOpenChange(v) {
     setOpen(v);
     if (!v) {
-      setValue("");
+      setAmount(0);
       setError(null);
     }
   }
 
   async function handleSubmit(e) {
     e.preventDefault();
-    const amount = Number(value);
-    if (value.trim() === "" || Number.isNaN(amount) || amount === 0) {
+    if (amount === 0) {
       setError("Informe um valor diferente de zero.");
       return;
     }
@@ -74,15 +74,7 @@ export function AmountPromptDialog({
             <label htmlFor={inputId} className="text-xs text-content-2">
               Valor
             </label>
-            <input
-              id={inputId}
-              type="number"
-              step="0.01"
-              inputMode="decimal"
-              value={value}
-              onChange={(e) => setValue(e.target.value)}
-              className={inputCls}
-            />
+            <MoneyInput id={inputId} value={amount} onChange={setAmount} allowNegative />
           </div>
 
           {error && <p className="text-danger text-xs">{error}</p>}

--- a/frontend/src/components/shared/AmountPromptDialog.jsx
+++ b/frontend/src/components/shared/AmountPromptDialog.jsx
@@ -16,9 +16,7 @@ import { MoneyInput } from "@/components/ui/money-input";
 import { Segmented } from "@/components/ui/segmented";
 import { apiErrorMessage } from "@/lib/utils";
 
-// "positive" | "negative" em vez de true/false: são rótulos de opção do
-// Segmented, não um segundo estado de sinal — o valor real continua sendo só
-// `amount` (ver handleSignChange).
+// "positive" | "negative": rótulos de opção do Segmented.
 const SIGN_OPTIONS = [
   { value: "positive", label: "Aporte" },
   { value: "negative", label: "Correção" },
@@ -46,22 +44,36 @@ export function AmountPromptDialog({
   const inputId = useId();
   const allowNegative = true;
   const [open, setOpen] = useState(false);
-  const [amount, setAmount] = useState(0);
+  // Magnitude e sinal são grandezas separadas, não um valor único. Sinal é
+  // uma intenção do usuário (clique no Segmented) que precisa sobreviver à
+  // magnitude zero: derivar o Segmented de `amount < 0` quebra porque
+  // Math.abs(0) * -1 é -0, e "-0 < 0" é false em JS — a seleção voltaria
+  // sozinha para "Aporte" na frente do usuário. O Segmented manda no sinal,
+  // o campo manda na magnitude; nenhum dos dois deriva do outro em render.
+  const [magnitude, setMagnitude] = useState(0);
+  const [sign, setSign] = useState(1);
   const [error, setError] = useState(null);
   const [loading, setLoading] = useState(false);
 
-  // Deriva do próprio `amount` (fonte única): nenhum estado de sinal
-  // separado. Em 0 é um no-op, igual ao atalho de teclado "-" do
-  // MoneyInput — não há sinal pra "prender" antes de existir magnitude.
+  const amount = magnitude * sign;
+
   function handleSignChange(v) {
-    const magnitude = Math.abs(amount);
-    setAmount(v === "negative" ? -magnitude : magnitude);
+    setSign(v === "negative" ? -1 : 1);
+  }
+
+  // MoneyInput manda na magnitude e também carrega o sinal quando o texto
+  // digitado/colado tem um (ver money-input.jsx). v === 0 não carrega sinal
+  // nenhum (campo limpo) — preserva o sinal atual em vez de forçar positivo.
+  function handleAmountChange(v) {
+    setMagnitude(Math.abs(v));
+    if (v !== 0) setSign(v < 0 ? -1 : 1);
   }
 
   function handleOpenChange(v) {
     setOpen(v);
     if (!v) {
-      setAmount(0);
+      setMagnitude(0);
+      setSign(1);
       setError(null);
     }
   }
@@ -97,7 +109,7 @@ export function AmountPromptDialog({
           {allowNegative && (
             <Field label="Tipo de lançamento">
               <Segmented
-                value={amount < 0 ? "negative" : "positive"}
+                value={sign === -1 ? "negative" : "positive"}
                 onChange={handleSignChange}
                 options={SIGN_OPTIONS}
                 ariaLabel="Tipo de lançamento"
@@ -109,7 +121,7 @@ export function AmountPromptDialog({
             <label htmlFor={inputId} className="text-xs text-content-2">
               Valor
             </label>
-            <MoneyInput id={inputId} value={amount} onChange={setAmount} allowNegative={allowNegative} />
+            <MoneyInput id={inputId} value={amount} onChange={handleAmountChange} allowNegative={allowNegative} />
           </div>
 
           {error && <p className="text-danger text-xs">{error}</p>}

--- a/frontend/src/components/shared/AmountPromptDialog.test.jsx
+++ b/frontend/src/components/shared/AmountPromptDialog.test.jsx
@@ -27,6 +27,49 @@ describe("AmountPromptDialog", () => {
     await waitFor(() => expect(onSubmit).toHaveBeenCalledWith(-150.5));
   });
 
+  it("selecting 'Correção' by click, with no keyboard event, submits a negative amount", async () => {
+    // Teclado virtual: inputMode="numeric" costuma esconder o "-", então o
+    // toque no seletor precisa ser o único caminho necessário para o sinal.
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    render(
+      <AmountPromptDialog
+        trigger={<button>abrir</button>}
+        title="Aporte"
+        submitLabel="Adicionar"
+        onSubmit={onSubmit}
+      />,
+    );
+    open();
+    const input = await screen.findByLabelText("Valor");
+    fireEvent.change(input, { target: { value: "150,50" } });
+    fireEvent.click(screen.getByRole("button", { name: "Correção" }));
+    fireEvent.click(screen.getByRole("button", { name: "Adicionar" }));
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledWith(-150.5));
+  });
+
+  it("marks 'Correção' as pressed when the pasted amount is already negative", async () => {
+    const onSubmit = vi.fn();
+    render(
+      <AmountPromptDialog
+        trigger={<button>abrir</button>}
+        title="Aporte"
+        submitLabel="Adicionar"
+        onSubmit={onSubmit}
+      />,
+    );
+    open();
+    const input = await screen.findByLabelText("Valor");
+    fireEvent.change(input, { target: { value: "-150,50" } });
+    expect(screen.getByRole("button", { name: "Correção" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(screen.getByRole("button", { name: "Aporte" })).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
+  });
+
   it("rejects zero without calling onSubmit", async () => {
     const onSubmit = vi.fn();
     render(

--- a/frontend/src/components/shared/AmountPromptDialog.test.jsx
+++ b/frontend/src/components/shared/AmountPromptDialog.test.jsx
@@ -27,6 +27,70 @@ describe("AmountPromptDialog", () => {
     await waitFor(() => expect(onSubmit).toHaveBeenCalledWith(-150.5));
   });
 
+  it("clicking 'Correção' while the amount is still zero, then typing, submits a negative amount", async () => {
+    // Reproduz o defeito: Math.abs(0) * -1 é -0, e "-0 < 0" é false em JS, então
+    // derivar o Segmented de `amount < 0` faz a seleção voltar sozinha para
+    // "Aporte" assim que o usuário digita. O sinal precisa ser um estado que
+    // sobrevive à magnitude zero.
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    render(
+      <AmountPromptDialog
+        trigger={<button>abrir</button>}
+        title="Aporte"
+        submitLabel="Adicionar"
+        onSubmit={onSubmit}
+      />,
+    );
+    open();
+    const input = await screen.findByLabelText("Valor");
+    fireEvent.click(screen.getByRole("button", { name: "Correção" }));
+    fireEvent.change(input, { target: { value: "150,50" } });
+    fireEvent.click(screen.getByRole("button", { name: "Adicionar" }));
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledWith(-150.5));
+  });
+
+  it("keeps 'Correção' pressed after clicking it while the amount is still zero", async () => {
+    const onSubmit = vi.fn();
+    render(
+      <AmountPromptDialog
+        trigger={<button>abrir</button>}
+        title="Aporte"
+        submitLabel="Adicionar"
+        onSubmit={onSubmit}
+      />,
+    );
+    open();
+    await screen.findByLabelText("Valor");
+    fireEvent.click(screen.getByRole("button", { name: "Correção" }));
+    expect(screen.getByRole("button", { name: "Correção" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(screen.getByRole("button", { name: "Aporte" })).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
+  });
+
+  it("switching from 'Correção' back to 'Aporte' turns an already typed amount positive again", async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    render(
+      <AmountPromptDialog
+        trigger={<button>abrir</button>}
+        title="Aporte"
+        submitLabel="Adicionar"
+        onSubmit={onSubmit}
+      />,
+    );
+    open();
+    const input = await screen.findByLabelText("Valor");
+    fireEvent.change(input, { target: { value: "150,50" } });
+    fireEvent.click(screen.getByRole("button", { name: "Correção" }));
+    fireEvent.click(screen.getByRole("button", { name: "Aporte" }));
+    fireEvent.click(screen.getByRole("button", { name: "Adicionar" }));
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledWith(150.5));
+  });
+
   it("selecting 'Correção' by click, with no keyboard event, submits a negative amount", async () => {
     // Teclado virtual: inputMode="numeric" costuma esconder o "-", então o
     // toque no seletor precisa ser o único caminho necessário para o sinal.

--- a/frontend/src/components/shared/AmountPromptDialog.test.jsx
+++ b/frontend/src/components/shared/AmountPromptDialog.test.jsx
@@ -18,7 +18,11 @@ describe("AmountPromptDialog", () => {
       />,
     );
     open();
-    fireEvent.change(await screen.findByLabelText("Valor"), { target: { value: "-150.5" } });
+    const input = await screen.findByLabelText("Valor");
+    // MoneyInput: digita o valor e depois usa "-" para alternar o sinal
+    // (correção de um aporte lançado errado), como no fluxo real do usuário.
+    fireEvent.change(input, { target: { value: "150,50" } });
+    fireEvent.keyDown(input, { key: "-" });
     fireEvent.click(screen.getByRole("button", { name: "Adicionar" }));
     await waitFor(() => expect(onSubmit).toHaveBeenCalledWith(-150.5));
   });

--- a/frontend/src/components/ui/money-input.jsx
+++ b/frontend/src/components/ui/money-input.jsx
@@ -1,0 +1,39 @@
+import { Input } from "@/components/ui/input";
+
+// Máscara monetária: o campo guarda CENTAVOS, e o que o usuário digita entra
+// sempre pela direita. Toda a lógica é "pegue os dígitos, divida por 100" — é
+// isso que faz o cursor parecer andar da direita para a esquerda sem precisar
+// gerenciar posição de cursor à mão.
+//
+// Contrato: value e onChange trafegam NÚMERO EM REAIS (12.34), nunca a string
+// mascarada. Assim o Zod e o payload da API continuam iguais.
+function formatar(centavos) {
+  return (centavos / 100).toLocaleString("pt-BR", {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
+}
+
+function MoneyInput({ value = 0, onChange, ...props }) {
+  const centavos = Math.round(Number(value || 0) * 100);
+
+  function handleChange(e) {
+    const digitos = e.target.value.replace(/\D/g, "");
+    // Corta em 13 dígitos: Numeric(15,2) no banco não aceita mais que isso, e
+    // sem o corte o número estoura a precisão do float do JS antes disso.
+    const limitado = digitos.slice(0, 13);
+    onChange(Number(limitado || 0) / 100);
+  }
+
+  return (
+    <Input
+      {...props}
+      type="text"
+      inputMode="numeric"
+      value={formatar(centavos)}
+      onChange={handleChange}
+    />
+  );
+}
+
+export { MoneyInput };

--- a/frontend/src/components/ui/money-input.jsx
+++ b/frontend/src/components/ui/money-input.jsx
@@ -7,6 +7,12 @@ import { Input } from "@/components/ui/input";
 //
 // Contrato: value e onChange trafegam NÚMERO EM REAIS (12.34), nunca a string
 // mascarada. Assim o Zod e o payload da API continuam iguais.
+//
+// allowNegative (default false, os call sites atuais não mudam em nada): a
+// tecla "-" alterna o sinal do valor atual em vez de ser um dígito. Digitar
+// "-" num valor positivo torna negativo, digitar de novo torna positivo. Com
+// allowNegative desligado, "-" é ignorado como qualquer outro caractere não
+// numérico, igual ao comportamento de sempre.
 function formatar(centavos) {
   return (centavos / 100).toLocaleString("pt-BR", {
     minimumFractionDigits: 2,
@@ -14,15 +20,27 @@ function formatar(centavos) {
   });
 }
 
-function MoneyInput({ value = 0, onChange, ...props }) {
+function MoneyInput({ value = 0, onChange, allowNegative = false, ...props }) {
   const centavos = Math.round(Number(value || 0) * 100);
 
   function handleChange(e) {
     const digitos = e.target.value.replace(/\D/g, "");
-    // Corta em 13 dígitos: Numeric(15,2) no banco não aceita mais que isso, e
-    // sem o corte o número estoura a precisão do float do JS antes disso.
-    const limitado = digitos.slice(0, 13);
-    onChange(Number(limitado || 0) / 100);
+    // Corta em 15 dígitos: MAX_MONEY (Numeric(15,2) no banco) é
+    // 9999999999999.99 — 13 dígitos inteiros + 2 decimais = 15 dígitos de
+    // centavos. Acima disso o dígito extra é ignorado, não desloca o número.
+    const limitado = digitos.slice(0, 15);
+    const magnitude = Number(limitado || 0) / 100;
+    const negativo = allowNegative && value < 0;
+    onChange(negativo ? -magnitude : magnitude);
+  }
+
+  // "-" alterna o sinal do valor atual (não é um dígito): intercepta no
+  // keydown para nunca deixar o caractere entrar no texto. Em 0 é um no-op —
+  // não há sinal para "prender" antes de existir magnitude.
+  function handleKeyDown(e) {
+    if (!allowNegative || e.key !== "-") return;
+    e.preventDefault();
+    if (value !== 0) onChange(-value);
   }
 
   // Preenchimento é sempre pela direita: o cursor tem que ficar preso no fim,
@@ -49,6 +67,7 @@ function MoneyInput({ value = 0, onChange, ...props }) {
       inputMode="numeric"
       value={formatar(centavos)}
       onChange={handleChange}
+      onKeyDown={handleKeyDown}
       onClick={fixarCursorNoFim}
       onFocus={fixarCursorNoFim}
       onKeyUp={fixarCursorNoFim}

--- a/frontend/src/components/ui/money-input.jsx
+++ b/frontend/src/components/ui/money-input.jsx
@@ -25,6 +25,19 @@ function MoneyInput({ value = 0, onChange, ...props }) {
     onChange(Number(limitado || 0) / 100);
   }
 
+  // Preenchimento é sempre pela direita: o cursor tem que ficar preso no fim,
+  // senão clicar no meio do texto faz a tecla seguinte entrar numa posição
+  // diferente da que o usuário via (o dígito cai no lugar errado). Cobre
+  // clique, foco por tab e navegação por teclado — qualquer jeito de mudar a
+  // seleção reposiciona ela no fim de novo.
+  function fixarCursorNoFim(e) {
+    const el = e.target;
+    const fim = el.value.length;
+    if (el.selectionStart !== fim || el.selectionEnd !== fim) {
+      el.setSelectionRange(fim, fim);
+    }
+  }
+
   return (
     <Input
       {...props}
@@ -32,6 +45,10 @@ function MoneyInput({ value = 0, onChange, ...props }) {
       inputMode="numeric"
       value={formatar(centavos)}
       onChange={handleChange}
+      onClick={fixarCursorNoFim}
+      onFocus={fixarCursorNoFim}
+      onKeyUp={fixarCursorNoFim}
+      onSelect={fixarCursorNoFim}
     />
   );
 }

--- a/frontend/src/components/ui/money-input.jsx
+++ b/frontend/src/components/ui/money-input.jsx
@@ -39,7 +39,11 @@ function MoneyInput({ value = 0, onChange, allowNegative = false, ...props }) {
     // Sinal vem do texto que chegou (colar "-150,50" num campo zerado tem
     // que resultar em negativo) OU do sinal que o valor já carregava (digitar
     // por cima de um valor já negativo não apaga o "-" que ele mostrava).
-    const negativo = allowNegative && (texto.includes("-") || value < 0);
+    // Object.is(value, -0): quem controla este input pode representar
+    // "magnitude zero, sinal negativo" como -0 (ver AmountPromptDialog) —
+    // "-0 < 0" é false em JS, então sem esse check o sinal se perderia
+    // exatamente quando o usuário digita o primeiro dígito depois de zero.
+    const negativo = allowNegative && (texto.includes("-") || value < 0 || Object.is(value, -0));
     onChange(negativo ? -magnitude : magnitude);
   }
 

--- a/frontend/src/components/ui/money-input.jsx
+++ b/frontend/src/components/ui/money-input.jsx
@@ -28,12 +28,16 @@ function MoneyInput({ value = 0, onChange, ...props }) {
   // Preenchimento é sempre pela direita: o cursor tem que ficar preso no fim,
   // senão clicar no meio do texto faz a tecla seguinte entrar numa posição
   // diferente da que o usuário via (o dígito cai no lugar errado). Cobre
-  // clique, foco por tab e navegação por teclado — qualquer jeito de mudar a
-  // seleção reposiciona ela no fim de novo.
+  // clique, foco por tab e navegação por teclado.
+  //
+  // Guard: só reposiciona se a seleção estiver colapsada (selectionStart ===
+  // selectionEnd). Uma seleção de intervalo (ex.: Ctrl+A) é intenção do
+  // usuário de substituir o valor, então deixamos ela intacta e o usuário
+  // consegue digitar por cima normalmente.
   function fixarCursorNoFim(e) {
     const el = e.target;
     const fim = el.value.length;
-    if (el.selectionStart !== fim || el.selectionEnd !== fim) {
+    if (el.selectionStart === el.selectionEnd && el.selectionEnd !== fim) {
       el.setSelectionRange(fim, fim);
     }
   }

--- a/frontend/src/components/ui/money-input.jsx
+++ b/frontend/src/components/ui/money-input.jsx
@@ -13,6 +13,11 @@ import { Input } from "@/components/ui/input";
 // "-" num valor positivo torna negativo, digitar de novo torna positivo. Com
 // allowNegative desligado, "-" é ignorado como qualquer outro caractere não
 // numérico, igual ao comportamento de sempre.
+//
+// Colar também carrega sinal: um "-" presente no texto que chega (colagem ou
+// digitação livre) vira negativo mesmo partindo de um campo zerado — não dá
+// pra depender só do "value" anterior, porque em 0 não existe sinal prévio
+// pra reaplicar (ver handleChange).
 function formatar(centavos) {
   return (centavos / 100).toLocaleString("pt-BR", {
     minimumFractionDigits: 2,
@@ -24,13 +29,17 @@ function MoneyInput({ value = 0, onChange, allowNegative = false, ...props }) {
   const centavos = Math.round(Number(value || 0) * 100);
 
   function handleChange(e) {
-    const digitos = e.target.value.replace(/\D/g, "");
+    const texto = e.target.value;
+    const digitos = texto.replace(/\D/g, "");
     // Corta em 15 dígitos: MAX_MONEY (Numeric(15,2) no banco) é
     // 9999999999999.99 — 13 dígitos inteiros + 2 decimais = 15 dígitos de
     // centavos. Acima disso o dígito extra é ignorado, não desloca o número.
     const limitado = digitos.slice(0, 15);
     const magnitude = Number(limitado || 0) / 100;
-    const negativo = allowNegative && value < 0;
+    // Sinal vem do texto que chegou (colar "-150,50" num campo zerado tem
+    // que resultar em negativo) OU do sinal que o valor já carregava (digitar
+    // por cima de um valor já negativo não apaga o "-" que ele mostrava).
+    const negativo = allowNegative && (texto.includes("-") || value < 0);
     onChange(negativo ? -magnitude : magnitude);
   }
 

--- a/frontend/src/components/ui/money-input.test.jsx
+++ b/frontend/src/components/ui/money-input.test.jsx
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+
+import { MoneyInput } from "./money-input";
+
+function setup(valorInicial = 0) {
+  const onChange = vi.fn();
+  render(<MoneyInput value={valorInicial} onChange={onChange} aria-label="Valor" />);
+  return { input: screen.getByLabelText("Valor"), onChange };
+}
+
+describe("MoneyInput", () => {
+  it("começa em 0,00", () => {
+    const { input } = setup();
+    expect(input).toHaveValue("0,00");
+  });
+
+  it("preenche da direita para a esquerda", () => {
+    const { input, onChange } = setup();
+
+    fireEvent.change(input, { target: { value: "0,001" } }); // usuário digitou "1"
+    expect(onChange).toHaveBeenLastCalledWith(0.01);
+
+    fireEvent.change(input, { target: { value: "0,0112" } }); // digitou "1" e "2"
+    expect(onChange).toHaveBeenLastCalledWith(1.12);
+  });
+
+  it("ignora qualquer coisa que não seja dígito", () => {
+    const { input, onChange } = setup();
+    fireEvent.change(input, { target: { value: "0,00abc5" } });
+    expect(onChange).toHaveBeenLastCalledWith(0.05);
+  });
+
+  it("apaga da direita para a esquerda", () => {
+    const { input, onChange } = setup(12.34);
+    fireEvent.change(input, { target: { value: "12,3" } }); // backspace
+    expect(onChange).toHaveBeenLastCalledWith(1.23);
+  });
+
+  it("formata o valor recebido por prop", () => {
+    const { input } = setup(1234.5);
+    expect(input).toHaveValue("1.234,50");
+  });
+});

--- a/frontend/src/components/ui/money-input.test.jsx
+++ b/frontend/src/components/ui/money-input.test.jsx
@@ -116,6 +116,21 @@ describe("MoneyInput", () => {
     expect(onChange).not.toHaveBeenCalled();
   });
 
+  it("com allowNegative, colar um valor com '-' num campo zerado preserva o sinal", () => {
+    // Bug real: colar "-150,50" descartava o "-" e enviava 150.5, porque o
+    // sinal só era reaplicado a partir do "value" anterior (que em 0 não tem
+    // sinal nenhum pra reaplicar). O texto colado tem que ser lido também.
+    const { input, onChange } = setup(0, { allowNegative: true });
+    fireEvent.change(input, { target: { value: "-150,50" } });
+    expect(onChange).toHaveBeenLastCalledWith(-150.5);
+  });
+
+  it("sem allowNegative, colar um valor com '-' ignora o sinal", () => {
+    const { input, onChange } = setup(0);
+    fireEvent.change(input, { target: { value: "-150,50" } });
+    expect(onChange).toHaveBeenLastCalledWith(150.5);
+  });
+
   it("corta em 15 dígitos de centavos (MAX_MONEY): o 16º dígito é ignorado, não desloca o número", () => {
     const { input, onChange } = setup();
 

--- a/frontend/src/components/ui/money-input.test.jsx
+++ b/frontend/src/components/ui/money-input.test.jsx
@@ -66,4 +66,17 @@ describe("MoneyInput", () => {
     expect(input.selectionStart).toBe(fim);
     expect(input.selectionEnd).toBe(fim);
   });
+
+  it("deixa seleção de intervalo intacta para Ctrl+A (substituir)", () => {
+    // Reproduz o bug real: Ctrl+A seleciona todo o texto, mas fixarCursorNoFim
+    // colapsava a seleção no fim, impedindo o usuário de digitar por cima. Com
+    // a correção, uma seleção de intervalo (selectionStart !== selectionEnd)
+    // sobrevive ao evento select, e o usuário consegue substituir o valor.
+    const { input } = setup(1234.56);
+    const fim = input.value.length;
+    input.setSelectionRange(0, fim); // simula Ctrl+A (seleção completa)
+    fireEvent.select(input);
+    expect(input.selectionStart).toBe(0);
+    expect(input.selectionEnd).toBe(fim);
+  });
 });

--- a/frontend/src/components/ui/money-input.test.jsx
+++ b/frontend/src/components/ui/money-input.test.jsx
@@ -3,10 +3,27 @@ import { render, screen, fireEvent } from "@testing-library/react";
 
 import { MoneyInput } from "./money-input";
 
-function setup(valorInicial = 0) {
+function setup(valorInicial = 0, extraProps = {}) {
   const onChange = vi.fn();
-  render(<MoneyInput value={valorInicial} onChange={onChange} aria-label="Valor" />);
-  return { input: screen.getByLabelText("Valor"), onChange };
+  const utils = render(
+    <MoneyInput value={valorInicial} onChange={onChange} aria-label="Valor" {...extraProps} />,
+  );
+  return {
+    input: screen.getByLabelText("Valor"),
+    onChange,
+    // Re-renderiza com um novo `value`: MoneyInput é controlado, então o
+    // teste precisa "devolver" o valor emitido pelo onChange como faria o
+    // componente pai, senão o segundo evento ainda vê o value antigo.
+    setValue: (novoValor, novasProps = extraProps) =>
+      utils.rerender(
+        <MoneyInput
+          value={novoValor}
+          onChange={onChange}
+          aria-label="Valor"
+          {...novasProps}
+        />,
+      ),
+  };
 }
 
 describe("MoneyInput", () => {
@@ -78,5 +95,34 @@ describe("MoneyInput", () => {
     fireEvent.select(input);
     expect(input.selectionStart).toBe(0);
     expect(input.selectionEnd).toBe(fim);
+  });
+
+  it("com allowNegative, a tecla '-' alterna o sinal do valor atual", () => {
+    const { input, onChange, setValue } = setup(150.5, { allowNegative: true });
+
+    fireEvent.keyDown(input, { key: "-" });
+    expect(onChange).toHaveBeenLastCalledWith(-150.5);
+
+    // Simula o pai controlado devolvendo o valor que o onChange emitiu.
+    setValue(-150.5);
+    fireEvent.keyDown(input, { key: "-" });
+    expect(onChange).toHaveBeenLastCalledWith(150.5);
+  });
+
+  it("sem allowNegative (default), a tecla '-' é ignorada como qualquer outro caractere", () => {
+    const { input, onChange } = setup(150.5);
+
+    fireEvent.keyDown(input, { key: "-" });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("corta em 15 dígitos de centavos (MAX_MONEY): o 16º dígito é ignorado, não desloca o número", () => {
+    const { input, onChange } = setup();
+
+    fireEvent.change(input, { target: { value: "999999999999999" } }); // 15 dígitos
+    expect(onChange).toHaveBeenLastCalledWith(9999999999999.99);
+
+    fireEvent.change(input, { target: { value: "9999999999999999" } }); // 16 dígitos
+    expect(onChange).toHaveBeenLastCalledWith(9999999999999.99);
   });
 });

--- a/frontend/src/components/ui/money-input.test.jsx
+++ b/frontend/src/components/ui/money-input.test.jsx
@@ -41,4 +41,29 @@ describe("MoneyInput", () => {
     const { input } = setup(1234.5);
     expect(input).toHaveValue("1.234,50");
   });
+
+  it("prende o cursor no fim ao clicar no meio do texto", () => {
+    // Bug real: clicar no meio de "1.234,56" e digitar deixava o dígito
+    // entrar na posição do clique em vez de ir pro fim, trocando o valor
+    // inteiro sem o usuário entender por quê. jsdom não simula clique →
+    // posição de caret (não calcula layout de texto), então simulamos o
+    // clique no meio ajustando selectionRange manualmente antes do evento —
+    // o que dá pra verificar aqui é que o handler sempre devolve a seleção
+    // pro fim, não a posição visual real do clique.
+    const { input } = setup(1234.56);
+    input.setSelectionRange(3, 3);
+    fireEvent.click(input);
+    const fim = input.value.length;
+    expect(input.selectionStart).toBe(fim);
+    expect(input.selectionEnd).toBe(fim);
+  });
+
+  it("prende o cursor no fim também por navegação de teclado (setas, home)", () => {
+    const { input } = setup(1234.56);
+    input.setSelectionRange(0, 0); // simula "Home"
+    fireEvent.keyUp(input, { key: "Home" });
+    const fim = input.value.length;
+    expect(input.selectionStart).toBe(fim);
+    expect(input.selectionEnd).toBe(fim);
+  });
 });

--- a/frontend/src/pages/Goals.jsx
+++ b/frontend/src/pages/Goals.jsx
@@ -95,7 +95,11 @@ export default function Goals() {
 
   // Abre o dialog em modo edição, pré-preenchido com nome e valor-alvo.
   // `type` também é preservado: não é enviado no PUT, mas o rótulo do campo
-  // de valor ("Valor-alvo" vs "Teto mensal") depende dele.
+  // de valor ("Valor-alvo" vs "Teto mensal") depende dele. `category` também
+  // precisa vir junto: o campo de categoria não é renderizado em modo edição,
+  // mas o .refine do goalSchema exige categoria não-vazia quando type ===
+  // BUDGET. Sem isso a validação falha contra um campo invisível e o submit
+  // trava sem erro visível nenhum.
   function abrirEdicao(goal) {
     setEditing(goal);
     setServerError(null);
@@ -104,8 +108,17 @@ export default function Goals() {
       name: goal.name,
       target_amount: Number(goal.target_amount),
       type: goal.type,
+      category: goal.category || "",
     });
     setOpen(true);
+  }
+
+  // Rede de segurança: se a validação falhar por qualquer motivo que não
+  // tenha campo visível pra mostrar o erro (ex.: uma meta BUDGET legada com
+  // categoria vazia, o que o backend não deveria permitir mas não é garantia
+  // absoluta), o usuário vê uma mensagem em vez de o botão não fazer nada.
+  function onInvalid() {
+    setServerError("Confira os campos do formulário.");
   }
 
   async function onSubmit(data) {
@@ -206,7 +219,7 @@ export default function Goals() {
               </div>
             </DialogHeader>
 
-            <form onSubmit={handleSubmit(onSubmit)} className="space-y-3 mt-1">
+            <form onSubmit={handleSubmit(onSubmit, onInvalid)} className="space-y-3 mt-1">
               {/* Tipo (edição não altera: GoalUpdate não aceita este campo) */}
               {!editing && (
                 <Field label="Tipo" error={errors.type?.message}>

--- a/frontend/src/pages/Goals.jsx
+++ b/frontend/src/pages/Goals.jsx
@@ -93,10 +93,17 @@ export default function Goals() {
   }
 
   // Abre o dialog em modo edição, pré-preenchido com nome e valor-alvo.
+  // `type` também é preservado: não é enviado no PUT, mas o rótulo do campo
+  // de valor ("Valor-alvo" vs "Teto mensal") depende dele.
   function abrirEdicao(goal) {
     setEditing(goal);
     setServerError(null);
-    reset({ ...EMPTY_FORM, name: goal.name, target_amount: Number(goal.target_amount) });
+    reset({
+      ...EMPTY_FORM,
+      name: goal.name,
+      target_amount: Number(goal.target_amount),
+      type: goal.type,
+    });
     setOpen(true);
   }
 

--- a/frontend/src/pages/Goals.jsx
+++ b/frontend/src/pages/Goals.jsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useForm, Controller, useWatch } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { Plus, Trash2, Target, PiggyBank, ArrowRight, Check } from "lucide-react";
+import { Plus, Trash2, Target, PiggyBank, ArrowRight, Check, Pencil } from "lucide-react";
 
 import { goalsApi } from "@/api/goals";
 import { aiApi } from "@/api/ai";
@@ -57,6 +57,7 @@ export default function Goals() {
   // registrar quem abriu, o foco não volta para o card ao fechar.
   const ultimoGatilho = useRef(null);
   const [serverError, setServerError] = useState(null);
+  const [editing, setEditing] = useState(null);
   const navigate = useNavigate();
 
   const {
@@ -86,23 +87,43 @@ export default function Goals() {
     setOpen(v);
     if (!v) {
       setServerError(null);
+      setEditing(null);
       reset(EMPTY_FORM);
     }
   }
 
+  // Abre o dialog em modo edição, pré-preenchido com nome e valor-alvo.
+  function abrirEdicao(goal) {
+    setEditing(goal);
+    setServerError(null);
+    reset({ ...EMPTY_FORM, name: goal.name, target_amount: Number(goal.target_amount) });
+    setOpen(true);
+  }
+
   async function onSubmit(data) {
     setServerError(null);
-    const payload = {
-      name: data.name,
-      type: data.type,
-      target_amount: data.target_amount,
-      ...(data.type === "SAVINGS"
-        ? { current_amount: data.current_amount || 0 }
-        : { category: data.category }),
-    };
     try {
-      await goalsApi.create(payload);
-      setOpen(false);
+      if (editing) {
+        // GoalUpdate aceita SÓ name e target_amount; qualquer outro campo é
+        // descartado em silêncio pelo backend.
+        await goalsApi.update(editing.id, {
+          name: data.name,
+          target_amount: data.target_amount,
+        });
+      } else {
+        await goalsApi.create({
+          name: data.name,
+          type: data.type,
+          target_amount: data.target_amount,
+          ...(data.type === "SAVINGS"
+            ? { current_amount: data.current_amount || 0 }
+            : { category: data.category }),
+        });
+      }
+      // Via handleOpenChange (não só setOpen) para limpar `editing` e o
+      // formulário: senão "Nova meta" logo depois de editar reabre em modo
+      // edição, com o risco de um PUT no id da meta antiga em vez de POST.
+      handleOpenChange(false);
       load();
     } catch (err) {
       setServerError(apiErrorMessage(err, "Não foi possível salvar a meta."));
@@ -169,7 +190,7 @@ export default function Goals() {
                   <Target size={20} className="text-accent-contrast" />
                 </div>
                 <div>
-                  <DialogTitle>Nova meta</DialogTitle>
+                  <DialogTitle>{editing ? "Editar meta" : "Nova meta"}</DialogTitle>
                   <p className="text-xs text-content-2 mt-0.5">
                     Poupança para um objetivo ou orçamento de uma categoria
                   </p>
@@ -178,21 +199,23 @@ export default function Goals() {
             </DialogHeader>
 
             <form onSubmit={handleSubmit(onSubmit)} className="space-y-3 mt-1">
-              {/* Tipo */}
-              <Field label="Tipo" error={errors.type?.message}>
-                <Controller
-                  name="type"
-                  control={control}
-                  render={({ field }) => (
-                    <Segmented
-                      value={field.value}
-                      onChange={field.onChange}
-                      options={GOAL_TYPE_OPTIONS}
-                      ariaLabel="Tipo"
-                    />
-                  )}
-                />
-              </Field>
+              {/* Tipo (edição não altera: GoalUpdate não aceita este campo) */}
+              {!editing && (
+                <Field label="Tipo" error={errors.type?.message}>
+                  <Controller
+                    name="type"
+                    control={control}
+                    render={({ field }) => (
+                      <Segmented
+                        value={field.value}
+                        onChange={field.onChange}
+                        options={GOAL_TYPE_OPTIONS}
+                        ariaLabel="Tipo"
+                      />
+                    )}
+                  />
+                </Field>
+              )}
 
               {/* Nome */}
               <Field label="Nome" htmlFor="name" error={errors.name?.message}>
@@ -221,8 +244,9 @@ export default function Goals() {
                 />
               </Field>
 
-              {/* Condicional: SAVINGS → já guardado; BUDGET → categoria */}
-              {type === "SAVINGS" ? (
+              {/* Condicional: SAVINGS → já guardado; BUDGET → categoria.
+                  Edição não altera nenhum dos dois: GoalUpdate não aceita. */}
+              {!editing && (type === "SAVINGS" ? (
                 <Field
                   label="Já guardado (opcional)"
                   htmlFor="current_amount"
@@ -258,7 +282,7 @@ export default function Goals() {
                     )}
                   />
                 </Field>
-              )}
+              ))}
 
               {serverError && (
                 <p className="text-danger text-xs">{serverError}</p>
@@ -278,7 +302,7 @@ export default function Goals() {
                   disabled={isSubmitting}
                   className="flex-[1.4] bg-accent-fill text-accent-contrast hover:bg-accent-fill/90 font-medium"
                 >
-                  {isSubmitting ? "Salvando…" : "Criar meta"}
+                  {isSubmitting ? "Salvando…" : editing ? "Salvar" : "Criar meta"}
                 </Button>
               </div>
             </form>
@@ -436,6 +460,18 @@ export default function Goals() {
                     }
                   />
                 )}
+                <button
+                  type="button"
+                  title="Editar"
+                  aria-label={`Editar meta ${g.name}`}
+                  onClick={(e) => {
+                    ultimoGatilho.current = e.currentTarget;
+                    abrirEdicao(g);
+                  }}
+                  className="w-8 h-8 flex items-center justify-center rounded-lg border border-line/10 text-content-3 hover:text-accent hover:border-accent/40 transition-colors"
+                >
+                  <Pencil size={14} />
+                </button>
                 <ConfirmDialog
                   title="Remover esta meta?"
                   confirmLabel="Remover"

--- a/frontend/src/pages/Goals.jsx
+++ b/frontend/src/pages/Goals.jsx
@@ -472,7 +472,7 @@ export default function Goals() {
                 {isSavings && (
                   <AmountPromptDialog
                     title={`Aporte em "${g.name}"`}
-                    description="Use um valor negativo para corrigir um aporte."
+                    description="Escolha se é um aporte novo ou a correção de um valor já lançado."
                     submitLabel="Adicionar"
                     errorFallback="Não foi possível salvar o aporte."
                     onSubmit={(amount) => contribute(g.id, amount)}

--- a/frontend/src/pages/Goals.jsx
+++ b/frontend/src/pages/Goals.jsx
@@ -16,6 +16,7 @@ import AiOrb from "@/components/shared/AiOrb";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { MoneyInput } from "@/components/ui/money-input";
 import { Field } from "@/components/ui/field";
 import { Segmented } from "@/components/ui/segmented";
 import { Select } from "@/components/ui/select";
@@ -240,14 +241,17 @@ export default function Goals() {
                 htmlFor="target_amount"
                 error={errors.target_amount?.message}
               >
-                <Input
-                  id="target_amount"
-                  type="number"
-                  step="0.01"
-                  min="0"
-                  placeholder="0,00"
-                  className={`${inputCls} [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none`}
-                  {...register("target_amount")}
+                <Controller
+                  name="target_amount"
+                  control={control}
+                  render={({ field }) => (
+                    <MoneyInput
+                      id="target_amount"
+                      value={field.value}
+                      onChange={field.onChange}
+                      className={inputCls}
+                    />
+                  )}
                 />
               </Field>
 
@@ -259,14 +263,17 @@ export default function Goals() {
                   htmlFor="current_amount"
                   error={errors.current_amount?.message}
                 >
-                  <Input
-                    id="current_amount"
-                    type="number"
-                    step="0.01"
-                    min="0"
-                    placeholder="0,00"
-                    className={`${inputCls} [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none`}
-                    {...register("current_amount")}
+                  <Controller
+                    name="current_amount"
+                    control={control}
+                    render={({ field }) => (
+                      <MoneyInput
+                        id="current_amount"
+                        value={field.value}
+                        onChange={field.onChange}
+                        className={inputCls}
+                      />
+                    )}
                   />
                 </Field>
               ) : (

--- a/frontend/src/pages/Goals.test.jsx
+++ b/frontend/src/pages/Goals.test.jsx
@@ -90,7 +90,7 @@ describe("Goals", () => {
     renderGoals();
 
     fireEvent.click(await screen.findByRole("button", { name: /editar meta/i }));
-    const dialog = await screen.findByRole("dialog");
+    await screen.findByRole("dialog");
 
     fireEvent.change(screen.getByLabelText(/nome/i), {
       target: { value: "Reserva nova" },

--- a/frontend/src/pages/Goals.test.jsx
+++ b/frontend/src/pages/Goals.test.jsx
@@ -124,6 +124,32 @@ describe("Goals", () => {
     expect(Object.keys(payload).sort()).toEqual(["name", "target_amount"]);
   });
 
+  it("salva a edição de uma meta BUDGET (categoria some do form mas não pode travar o submit)", async () => {
+    // Bug real: abrirEdicao não copiava goal.category pro form. O type é
+    // preservado (correção anterior) e o .refine do goalSchema exige categoria
+    // não-vazia quando type === BUDGET — mas o campo de categoria não é
+    // renderizado em modo edição, então o erro de validação não tinha onde
+    // aparecer: handleSubmit bloqueava calado e nenhuma request saía.
+    goalsApi.list.mockResolvedValue({ data: [META_BUDGET] });
+    goalsApi.update.mockResolvedValue({ data: META_BUDGET });
+    renderGoals();
+
+    fireEvent.click(await screen.findByRole("button", { name: /editar meta/i }));
+    await screen.findByRole("dialog");
+
+    fireEvent.click(screen.getByRole("button", { name: /salvar/i }));
+
+    await waitFor(() =>
+      expect(goalsApi.update).toHaveBeenCalledWith("2", {
+        name: "Mercado",
+        target_amount: 600,
+      }),
+    );
+    await waitFor(() =>
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument(),
+    );
+  });
+
   it("mostra o rótulo 'Teto mensal' ao editar uma meta do tipo BUDGET", async () => {
     // reset() do abrirEdicao precisa preservar goal.type: EMPTY_FORM.type é
     // "SAVINGS", e sem isso o rótulo do campo de valor mostra "Valor-alvo"

--- a/frontend/src/pages/Goals.test.jsx
+++ b/frontend/src/pages/Goals.test.jsx
@@ -31,6 +31,19 @@ const META = {
   created_at: "2026-08-01T00:00:00Z",
 };
 
+const META_BUDGET = {
+  id: "2",
+  name: "Mercado",
+  type: "BUDGET",
+  target_amount: "600.00",
+  current_amount: "150.00",
+  category: "Alimentação",
+  deadline: null,
+  progress_pct: 25,
+  remaining: "450.00",
+  created_at: "2026-08-01T00:00:00Z",
+};
+
 function renderGoals() {
   render(
     <MemoryRouter>
@@ -109,5 +122,19 @@ describe("Goals", () => {
     await waitFor(() => expect(goalsApi.update).toHaveBeenCalled());
     const [, payload] = goalsApi.update.mock.calls[0];
     expect(Object.keys(payload).sort()).toEqual(["name", "target_amount"]);
+  });
+
+  it("mostra o rótulo 'Teto mensal' ao editar uma meta do tipo BUDGET", async () => {
+    // reset() do abrirEdicao precisa preservar goal.type: EMPTY_FORM.type é
+    // "SAVINGS", e sem isso o rótulo do campo de valor mostra "Valor-alvo"
+    // mesmo editando uma meta BUDGET.
+    goalsApi.list.mockResolvedValue({ data: [META_BUDGET] });
+    renderGoals();
+
+    fireEvent.click(await screen.findByRole("button", { name: /editar meta/i }));
+    await screen.findByRole("dialog");
+
+    expect(screen.getByLabelText(/teto mensal/i)).toBeInTheDocument();
+    expect(screen.queryByLabelText(/valor-alvo/i)).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/Goals.test.jsx
+++ b/frontend/src/pages/Goals.test.jsx
@@ -71,4 +71,43 @@ describe("Goals", () => {
     await abrirEFechar(botaoTopo);
     await waitFor(() => expect(botaoTopo).toHaveFocus());
   });
+
+  it("edita nome e valor da meta pelo dialog de edição", async () => {
+    goalsApi.update.mockResolvedValue({ data: { ...META, name: "Reserva nova" } });
+    renderGoals();
+
+    fireEvent.click(await screen.findByRole("button", { name: /editar meta/i }));
+    const dialog = await screen.findByRole("dialog");
+
+    fireEvent.change(screen.getByLabelText(/nome/i), {
+      target: { value: "Reserva nova" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /salvar/i }));
+
+    await waitFor(() =>
+      expect(goalsApi.update).toHaveBeenCalledWith("1", {
+        name: "Reserva nova",
+        target_amount: 1000,
+      }),
+    );
+    // O dialog fecha no sucesso; se ficar aberto, o usuário salva duas vezes.
+    await waitFor(() =>
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument(),
+    );
+  });
+
+  it("não envia campos que o backend ignora na edição", async () => {
+    // GoalUpdate aceita só name e target_amount. Mandar type/category dá a
+    // impressão de que foram salvos.
+    goalsApi.update.mockResolvedValue({ data: META });
+    renderGoals();
+
+    fireEvent.click(await screen.findByRole("button", { name: /editar meta/i }));
+    await screen.findByRole("dialog");
+    fireEvent.click(screen.getByRole("button", { name: /salvar/i }));
+
+    await waitFor(() => expect(goalsApi.update).toHaveBeenCalled());
+    const [, payload] = goalsApi.update.mock.calls[0];
+    expect(Object.keys(payload).sort()).toEqual(["name", "target_amount"]);
+  });
 });

--- a/frontend/src/pages/Recurring.jsx
+++ b/frontend/src/pages/Recurring.jsx
@@ -12,6 +12,7 @@ import { ConfirmDialog } from "@/components/shared/ConfirmDialog";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { MoneyInput } from "@/components/ui/money-input";
 import { Field } from "@/components/ui/field";
 import { Segmented } from "@/components/ui/segmented";
 import { Select } from "@/components/ui/select";
@@ -243,14 +244,17 @@ export default function Recurring() {
                 htmlFor="amount"
                 error={errors.amount?.message}
               >
-                <Input
-                  id="amount"
-                  type="number"
-                  step="0.01"
-                  min="0"
-                  placeholder="0,00"
-                  className={inputCls}
-                  {...register("amount")}
+                <Controller
+                  name="amount"
+                  control={control}
+                  render={({ field }) => (
+                    <MoneyInput
+                      id="amount"
+                      value={field.value}
+                      onChange={field.onChange}
+                      className={inputCls}
+                    />
+                  )}
                 />
               </Field>
 

--- a/frontend/src/pages/Transactions.jsx
+++ b/frontend/src/pages/Transactions.jsx
@@ -51,6 +51,10 @@ export default function Transactions() {
   const [filterType, setFilterType] = useState("");
   const [offset, setOffset] = useState(0);
   const [total, setTotal] = useState(0);
+  // false quando o header X-Total-Count não chegou (backend antigo, proxy,
+  // CORS mal configurado): nesse caso `total` é só o length da página, não o
+  // total real, e a UI não pode tratá-lo como se fosse.
+  const [totalConhecido, setTotalConhecido] = useState(true);
   const location = useLocation();
   const navigate = useNavigate();
 
@@ -77,16 +81,24 @@ export default function Transactions() {
 
   async function load(params = {}, novoOffset = 0) {
     const seq = ++requisicaoAtual.current;
-    const res = await transactionsApi.list({
-      ...params,
-      limit: PAGE_SIZE,
-      offset: novoOffset,
-    });
-    if (seq !== requisicaoAtual.current) return; // resposta obsoleta
-    setTransactions(res.data);
-    // O header só chega ao JS porque o backend o declara em expose_headers.
-    setTotal(Number(res.headers?.["x-total-count"] ?? res.data.length));
-    setOffset(novoOffset);
+    try {
+      const res = await transactionsApi.list({
+        ...params,
+        limit: PAGE_SIZE,
+        offset: novoOffset,
+      });
+      if (seq !== requisicaoAtual.current) return; // resposta obsoleta
+      setTransactions(res.data);
+      // O header só chega ao JS porque o backend o declara em expose_headers.
+      const headerTotal = res.headers?.["x-total-count"];
+      setTotal(headerTotal != null ? Number(headerTotal) : res.data.length);
+      setTotalConhecido(headerTotal != null);
+      setOffset(novoOffset);
+      setServerError(null);
+    } catch (err) {
+      if (seq !== requisicaoAtual.current) return; // resposta obsoleta
+      setServerError(apiErrorMessage(err, "Não foi possível carregar as transações."));
+    }
   }
 
   useEffect(() => {
@@ -119,6 +131,9 @@ export default function Transactions() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  // Delete desloca offsets (o item some e os seguintes sobem uma posição) —
+  // voltar pra página 1 evita mostrar uma página com buracos. Mantido de
+  // propósito, ver onSubmit para o caso de edição (que preserva a página).
   const reload = () => load(filterType ? { type: filterType } : {}, 0);
 
   const walletOptions = wallets.map((w) => ({ value: w.id, label: w.name }));
@@ -171,6 +186,7 @@ export default function Transactions() {
       description: data.description || "",
       date: data.date,
     };
+    const wasEditing = Boolean(editing);
     try {
       if (editing) {
         await transactionsApi.update(editing.id, payload);
@@ -179,7 +195,13 @@ export default function Transactions() {
       }
       setOpen(false);
       setEditing(null);
-      reload();
+      // Editar não muda quantos itens existem: preserva a página atual em vez
+      // de reload() (que sempre volta pra página 1).
+      if (wasEditing) {
+        load(filterType ? { type: filterType } : {}, offset);
+      } else {
+        reload();
+      }
     } catch (err) {
       setServerError(apiErrorMessage(err, "Não foi possível salvar a transação."));
     }
@@ -192,8 +214,15 @@ export default function Transactions() {
 
   // A busca é client-side sobre a página carregada, não sobre todo o
   // histórico. Se houver mais páginas, precisamos avisar em vez de afirmar
-  // que a transação não existe.
-  const haMaisPaginas = total > transactions.length;
+  // que a transação não existe. Sem total conhecido (header ausente), uma
+  // página cheia é o sinal disponível de que pode haver mais.
+  const haMaisPaginas = totalConhecido
+    ? total > transactions.length
+    : transactions.length === PAGE_SIZE;
+  // Idem para "Próxima": sem total, avança enquanto a página vier cheia.
+  const podeAvancar = totalConhecido
+    ? offset + PAGE_SIZE < total
+    : transactions.length === PAGE_SIZE;
 
   const filtered = transactions.filter(
     (t) =>
@@ -362,6 +391,9 @@ export default function Transactions() {
 
       {/* Filtros e relatório em uma única superfície */}
       <div className="glass overflow-hidden p-4 sm:p-5">
+        {serverError && !open && (
+          <p className="text-danger text-xs pb-3">{serverError}</p>
+        )}
         <div className="inset-panel mb-4 flex flex-col gap-3 p-4 sm:flex-row">
           <div className="relative flex-1 sm:max-w-xs">
             <Search size={16} className="absolute left-3 top-2.5 text-content-3" />
@@ -536,18 +568,28 @@ export default function Transactions() {
           ))}
         </div>
 
+        {/* Independente do resultado ter vindo vazio: a busca só olha a página
+            carregada, então "poucos resultados" é tão enganoso quanto "zero". */}
+        {search && haMaisPaginas && (
+          <p className="pt-2 text-center text-xs text-content-3">
+            A busca cobre só as transações desta página. Pode haver mais resultados em outras páginas.
+          </p>
+        )}
+
         {filtered.length === 0 && (
           <div className="text-center py-12 text-content-3 text-sm">
-            {search && haMaisPaginas
-              ? "Nenhuma transação encontrada nesta página. A busca cobre só as transações já carregadas."
-              : "Nenhuma transação encontrada."}
+            Nenhuma transação encontrada.
           </div>
         )}
 
-        {total > PAGE_SIZE && (
+        {(haMaisPaginas || offset > 0) && (
           <div className="flex items-center justify-between gap-4 pt-2">
             <p className="text-sm text-content-2 tnum">
-              {offset + 1}–{Math.min(offset + PAGE_SIZE, total)} de {total}
+              {search
+                ? "Busca ativa: contagem total oculta"
+                : totalConhecido
+                  ? `${offset + 1}–${Math.min(offset + PAGE_SIZE, total)} de ${total}`
+                  : `${offset + 1}–${offset + transactions.length}`}
             </p>
             <div className="flex gap-2">
               <Button
@@ -561,7 +603,7 @@ export default function Transactions() {
               </Button>
               <Button
                 variant="ghost"
-                disabled={offset + PAGE_SIZE >= total}
+                disabled={!podeAvancar}
                 onClick={() =>
                   load(filterType ? { type: filterType } : {}, offset + PAGE_SIZE)
                 }

--- a/frontend/src/pages/Transactions.jsx
+++ b/frontend/src/pages/Transactions.jsx
@@ -13,6 +13,7 @@ import { ConfirmDialog } from "@/components/shared/ConfirmDialog";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { MoneyInput } from "@/components/ui/money-input";
 import { Field } from "@/components/ui/field";
 import { Segmented } from "@/components/ui/segmented";
 import { Select } from "@/components/ui/select";
@@ -144,7 +145,7 @@ export default function Transactions() {
     reset({
       wallet_id: t.wallet_id,
       type: t.type,
-      amount: String(t.amount),
+      amount: Number(t.amount),
       category: t.category,
       description: t.description || "",
       date: toDateInput(t.date),
@@ -297,14 +298,17 @@ export default function Transactions() {
                 htmlFor="amount"
                 error={errors.amount?.message}
               >
-                <Input
-                  id="amount"
-                  type="number"
-                  step="0.01"
-                  min="0"
-                  placeholder="0,00"
-                  className={`${inputCls} [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none`}
-                  {...register("amount")}
+                <Controller
+                  name="amount"
+                  control={control}
+                  render={({ field }) => (
+                    <MoneyInput
+                      id="amount"
+                      value={field.value}
+                      onChange={field.onChange}
+                      className={inputCls}
+                    />
+                  )}
                 />
               </Field>
 

--- a/frontend/src/pages/Transactions.jsx
+++ b/frontend/src/pages/Transactions.jsx
@@ -27,6 +27,8 @@ import {
 
 
 
+const PAGE_SIZE = 50;
+
 // Valores iniciais do formulário (date sempre fresca → função).
 const emptyForm = () => ({
   wallet_id: "",
@@ -46,6 +48,8 @@ export default function Transactions() {
   const [serverError, setServerError] = useState(null);
   const [search, setSearch] = useState("");
   const [filterType, setFilterType] = useState("");
+  const [offset, setOffset] = useState(0);
+  const [total, setTotal] = useState(0);
   const location = useLocation();
   const navigate = useNavigate();
 
@@ -70,11 +74,18 @@ export default function Transactions() {
   // request, só ignorar a resposta obsoleta. Trocar se o custo da chamada pesar.
   const requisicaoAtual = useRef(0);
 
-  async function load(params = {}) {
+  async function load(params = {}, novoOffset = 0) {
     const seq = ++requisicaoAtual.current;
-    const res = await transactionsApi.list(params);
+    const res = await transactionsApi.list({
+      ...params,
+      limit: PAGE_SIZE,
+      offset: novoOffset,
+    });
     if (seq !== requisicaoAtual.current) return; // resposta obsoleta
     setTransactions(res.data);
+    // O header só chega ao JS porque o backend o declara em expose_headers.
+    setTotal(Number(res.headers?.["x-total-count"] ?? res.data.length));
+    setOffset(novoOffset);
   }
 
   useEffect(() => {
@@ -107,7 +118,7 @@ export default function Transactions() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const reload = () => load(filterType ? { type: filterType } : {});
+  const reload = () => load(filterType ? { type: filterType } : {}, 0);
 
   const walletOptions = wallets.map((w) => ({ value: w.id, label: w.name }));
 
@@ -178,10 +189,10 @@ export default function Transactions() {
     reload();
   }
 
-  // Teto que o backend aplica na listagem (Query(200, le=500)). A busca é
-  // client-side sobre o que veio, então precisamos saber se batemos no teto
-  // para não afirmar que nada existe quando só não foi carregado.
-  const LISTAGEM_MAX = 200;
+  // A busca é client-side sobre a página carregada, não sobre todo o
+  // histórico. Se houver mais páginas, precisamos avisar em vez de afirmar
+  // que a transação não existe.
+  const haMaisPaginas = total > transactions.length;
 
   const filtered = transactions.filter(
     (t) =>
@@ -366,7 +377,7 @@ export default function Transactions() {
                 aria-pressed={filterType === t}
                 onClick={() => {
                   setFilterType(t);
-                  load(t ? { type: t } : {});
+                  load(t ? { type: t } : {}, 0);
                 }}
                 className={`rounded-xl px-3 py-2 text-sm transition-colors ${
                   filterType === t
@@ -523,9 +534,37 @@ export default function Transactions() {
 
         {filtered.length === 0 && (
           <div className="text-center py-12 text-content-3 text-sm">
-            {search && transactions.length >= LISTAGEM_MAX
-              ? "Nenhuma transação encontrada entre as mais recentes. A busca cobre só as transações já carregadas."
+            {search && haMaisPaginas
+              ? "Nenhuma transação encontrada nesta página. A busca cobre só as transações já carregadas."
               : "Nenhuma transação encontrada."}
+          </div>
+        )}
+
+        {total > PAGE_SIZE && (
+          <div className="flex items-center justify-between gap-4 pt-2">
+            <p className="text-sm text-content-2 tnum">
+              {offset + 1}–{Math.min(offset + PAGE_SIZE, total)} de {total}
+            </p>
+            <div className="flex gap-2">
+              <Button
+                variant="ghost"
+                disabled={offset === 0}
+                onClick={() =>
+                  load(filterType ? { type: filterType } : {}, offset - PAGE_SIZE)
+                }
+              >
+                Anterior
+              </Button>
+              <Button
+                variant="ghost"
+                disabled={offset + PAGE_SIZE >= total}
+                onClick={() =>
+                  load(filterType ? { type: filterType } : {}, offset + PAGE_SIZE)
+                }
+              >
+                Próxima
+              </Button>
+            </div>
           </div>
         )}
       </div>

--- a/frontend/src/pages/Transactions.jsx
+++ b/frontend/src/pages/Transactions.jsx
@@ -589,7 +589,9 @@ export default function Transactions() {
                 ? "Busca ativa: contagem total oculta"
                 : totalConhecido
                   ? `${offset + 1}–${Math.min(offset + PAGE_SIZE, total)} de ${total}`
-                  : `${offset + 1}–${offset + transactions.length}`}
+                  : transactions.length === 0
+                    ? "Nenhuma transação nesta página"
+                    : `${offset + 1}–${offset + transactions.length}`}
             </p>
             <div className="flex gap-2">
               <Button

--- a/frontend/src/pages/Transactions.test.jsx
+++ b/frontend/src/pages/Transactions.test.jsx
@@ -64,6 +64,8 @@ describe("Transactions", () => {
     expect((await screen.findAllByText("Item p1-0")).length).toBeGreaterThan(0);
   });
 
+  // Timeout aumentado para 15s: este teste renderiza 50 linhas mockadas e encadeia
+  // múltiplos waitFor; sob disputa de CPU na execução da suíte completa passa dos 5s padrão.
   it("avança de página, busca o offset seguinte e troca a lista renderizada", async () => {
     transactionsApi.list
       .mockResolvedValueOnce(pagina(50, 120, "p1-"))
@@ -90,7 +92,7 @@ describe("Transactions", () => {
     expect((await screen.findAllByText("Item p2-0")).length).toBeGreaterThan(0);
     expect(screen.queryByText("Item p1-0")).not.toBeInTheDocument();
     expect(await screen.findByText(/51.+100.+120/)).toBeInTheDocument();
-  });
+  }, 15000);
 
   it("mostra quantas transações existem no total", async () => {
     transactionsApi.list.mockResolvedValue(pagina(50, 120));
@@ -180,6 +182,8 @@ describe("Transactions", () => {
     expect(screen.queryByText("51–50")).not.toBeInTheDocument();
   });
 
+  // Timeout aumentado para 15s: este teste renderiza 50 linhas mockadas, navega entre páginas
+  // e dispara um diálogo de edição; encadeia múltiplos waitFor; sob disputa de CPU passa dos 5s padrão.
   it("preserva a página ao editar uma transação, em vez de voltar para offset 0", async () => {
     // A rodada anterior alegou "cobertura indireta pelos testes de paginação",
     // mas aqueles exercitam o load() disparado por "Próxima", não o disparado
@@ -214,5 +218,5 @@ describe("Transactions", () => {
         expect.objectContaining({ offset: 50 }),
       ),
     );
-  });
+  }, 15000);
 });

--- a/frontend/src/pages/Transactions.test.jsx
+++ b/frontend/src/pages/Transactions.test.jsx
@@ -149,4 +149,70 @@ describe("Transactions", () => {
     // Sem total conhecido, o contador não pode inventar um "de X".
     expect(screen.getByText("1–50")).toBeInTheDocument();
   });
+
+  it("não mostra faixa invertida quando, sem X-Total-Count, a página seguinte vem vazia", async () => {
+    // Heurística do modo fallback: "página veio cheia, habilita Próxima". Com
+    // um total que é múltiplo exato de PAGE_SIZE isso é falso positivo — a
+    // página seguinte volta vazia e offset+1–offset+0 vira "51–50" ao lado de
+    // "Nenhuma transação encontrada".
+    transactionsApi.list
+      .mockResolvedValueOnce({
+        data: Array.from({ length: 50 }, (_, i) => tx(`f-${i}`)),
+        headers: {},
+      })
+      .mockResolvedValueOnce({ data: [], headers: {} });
+
+    render(
+      <MemoryRouter>
+        <Transactions />
+      </MemoryRouter>,
+    );
+
+    await screen.findAllByText("Item f-0");
+    fireEvent.click(await screen.findByRole("button", { name: /próxima/i }));
+
+    await waitFor(() =>
+      expect(transactionsApi.list).toHaveBeenLastCalledWith(
+        expect.objectContaining({ offset: 50 }),
+      ),
+    );
+    await screen.findByText(/nenhuma transação encontrada/i);
+    expect(screen.queryByText("51–50")).not.toBeInTheDocument();
+  });
+
+  it("preserva a página ao editar uma transação, em vez de voltar para offset 0", async () => {
+    // A rodada anterior alegou "cobertura indireta pelos testes de paginação",
+    // mas aqueles exercitam o load() disparado por "Próxima", não o disparado
+    // pelo submit da edição — call sites diferentes, sem garantia nenhuma.
+    transactionsApi.list
+      .mockResolvedValueOnce(pagina(50, 120, "p1-"))
+      .mockResolvedValueOnce(pagina(50, 120, "p2-"));
+    transactionsApi.update.mockResolvedValue({ data: tx("p2-0") });
+
+    render(
+      <MemoryRouter>
+        <Transactions />
+      </MemoryRouter>,
+    );
+
+    await screen.findAllByText("Item p1-0");
+    fireEvent.click(await screen.findByRole("button", { name: /próxima/i }));
+    await screen.findAllByText("Item p2-0");
+
+    transactionsApi.list.mockResolvedValueOnce(pagina(50, 120, "p2-"));
+
+    const editButtons = await screen.findAllByRole("button", {
+      name: /editar transação/i,
+    });
+    fireEvent.click(editButtons[0]);
+    await screen.findByRole("dialog");
+    fireEvent.click(screen.getByRole("button", { name: /salvar alterações/i }));
+
+    await waitFor(() => expect(transactionsApi.update).toHaveBeenCalled());
+    await waitFor(() =>
+      expect(transactionsApi.list).toHaveBeenLastCalledWith(
+        expect.objectContaining({ offset: 50 }),
+      ),
+    );
+  });
 });

--- a/frontend/src/pages/Transactions.test.jsx
+++ b/frontend/src/pages/Transactions.test.jsx
@@ -30,9 +30,11 @@ function tx(id) {
   };
 }
 
-function pagina(qtd, total) {
+// prefixo diferente por página deixa os itens distinguíveis no DOM, para
+// provar que o render acompanhou a troca de página e não só a chamada à API.
+function pagina(qtd, total, prefixo = "") {
   return {
-    data: Array.from({ length: qtd }, (_, i) => tx(String(i))),
+    data: Array.from({ length: qtd }, (_, i) => tx(`${prefixo}${i}`)),
     headers: { "x-total-count": String(total) },
   };
 }
@@ -42,9 +44,9 @@ describe("Transactions", () => {
     vi.clearAllMocks();
   });
 
-  it("pede a primeira página com limit e offset explícitos", async () => {
+  it("pede a primeira página com limit e offset explícitos e renderiza os itens recebidos", async () => {
     // Sem limit explícito o backend aplica 200 e o resto some calado.
-    transactionsApi.list.mockResolvedValue(pagina(50, 50));
+    transactionsApi.list.mockResolvedValue(pagina(50, 50, "p1-"));
 
     render(
       <MemoryRouter>
@@ -57,16 +59,23 @@ describe("Transactions", () => {
         expect.objectContaining({ limit: 50, offset: 0 }),
       ),
     );
+    // Não basta a API ter sido chamada certo: setTransactions precisa ter
+    // de fato colocado a resposta na tela.
+    expect((await screen.findAllByText("Item p1-0")).length).toBeGreaterThan(0);
   });
 
-  it("avança de página e busca o offset seguinte", async () => {
-    transactionsApi.list.mockResolvedValue(pagina(50, 120));
+  it("avança de página, busca o offset seguinte e troca a lista renderizada", async () => {
+    transactionsApi.list
+      .mockResolvedValueOnce(pagina(50, 120, "p1-"))
+      .mockResolvedValueOnce(pagina(50, 120, "p2-"));
 
     render(
       <MemoryRouter>
         <Transactions />
       </MemoryRouter>,
     );
+
+    expect((await screen.findAllByText("Item p1-0")).length).toBeGreaterThan(0);
 
     const proxima = await screen.findByRole("button", { name: /próxima/i });
     fireEvent.click(proxima);
@@ -76,6 +85,11 @@ describe("Transactions", () => {
         expect.objectContaining({ limit: 50, offset: 50 }),
       ),
     );
+    // Prova que o render acompanhou a chamada: item da página 1 some, item
+    // da página 2 aparece, e o contador reflete a faixa nova.
+    expect((await screen.findAllByText("Item p2-0")).length).toBeGreaterThan(0);
+    expect(screen.queryByText("Item p1-0")).not.toBeInTheDocument();
+    expect(await screen.findByText(/51.+100.+120/)).toBeInTheDocument();
   });
 
   it("mostra quantas transações existem no total", async () => {

--- a/frontend/src/pages/Transactions.test.jsx
+++ b/frontend/src/pages/Transactions.test.jsx
@@ -103,4 +103,50 @@ describe("Transactions", () => {
 
     expect(await screen.findByText(/120/)).toBeInTheDocument();
   });
+
+  it("avisa que a busca cobre só a página atual mesmo quando encontra resultados nela", async () => {
+    // Bug real: com 120 transações e busca batendo em 2 na página 1 e mais 9
+    // nas páginas seguintes, o usuário via só as 2 e não sabia que faltavam.
+    // O aviso não pode depender de filtered.length === 0.
+    transactionsApi.list.mockResolvedValue(pagina(50, 120, "p1-"));
+
+    render(
+      <MemoryRouter>
+        <Transactions />
+      </MemoryRouter>,
+    );
+
+    await screen.findAllByText("Item p1-0");
+    fireEvent.change(screen.getByLabelText(/buscar transações/i), {
+      target: { value: "p1-0" },
+    });
+
+    // A busca encontrou resultado (não é o caso de "zero resultados").
+    expect(screen.getAllByText("Item p1-0").length).toBeGreaterThan(0);
+    expect(
+      await screen.findByText(/busca cobre só as transações desta página/i),
+    ).toBeInTheDocument();
+  });
+
+  it("mantém a paginação utilizável quando a resposta não traz X-Total-Count, contanto que a página venha cheia", async () => {
+    // Backend/proxy sem o header: sem isso a página ficava travada em 50 itens
+    // sem controles e sem aviso, mesmo tendo mais dados por trás.
+    transactionsApi.list.mockResolvedValueOnce({
+      data: Array.from({ length: 50 }, (_, i) => tx(`f-${i}`)),
+      headers: {},
+    });
+
+    render(
+      <MemoryRouter>
+        <Transactions />
+      </MemoryRouter>,
+    );
+
+    await screen.findAllByText("Item f-0");
+
+    const proxima = await screen.findByRole("button", { name: /próxima/i });
+    expect(proxima).toBeEnabled();
+    // Sem total conhecido, o contador não pode inventar um "de X".
+    expect(screen.getByText("1–50")).toBeInTheDocument();
+  });
 });

--- a/frontend/src/pages/Transactions.test.jsx
+++ b/frontend/src/pages/Transactions.test.jsx
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+
+import { transactionsApi } from "@/api/transactions";
+import Transactions from "./Transactions";
+
+vi.mock("@/api/transactions", () => ({
+  transactionsApi: {
+    list: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+vi.mock("@/api/wallets", () => ({
+  walletsApi: { list: vi.fn(() => Promise.resolve({ data: [] })) },
+}));
+
+function tx(id) {
+  return {
+    id,
+    wallet_id: "w1",
+    type: "EXPENSE",
+    amount: "10.00",
+    category: "Food",
+    description: `Item ${id}`,
+    date: "2026-06-10",
+    created_at: "2026-06-10T00:00:00Z",
+  };
+}
+
+function pagina(qtd, total) {
+  return {
+    data: Array.from({ length: qtd }, (_, i) => tx(String(i))),
+    headers: { "x-total-count": String(total) },
+  };
+}
+
+describe("Transactions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("pede a primeira página com limit e offset explícitos", async () => {
+    // Sem limit explícito o backend aplica 200 e o resto some calado.
+    transactionsApi.list.mockResolvedValue(pagina(50, 50));
+
+    render(
+      <MemoryRouter>
+        <Transactions />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() =>
+      expect(transactionsApi.list).toHaveBeenCalledWith(
+        expect.objectContaining({ limit: 50, offset: 0 }),
+      ),
+    );
+  });
+
+  it("avança de página e busca o offset seguinte", async () => {
+    transactionsApi.list.mockResolvedValue(pagina(50, 120));
+
+    render(
+      <MemoryRouter>
+        <Transactions />
+      </MemoryRouter>,
+    );
+
+    const proxima = await screen.findByRole("button", { name: /próxima/i });
+    fireEvent.click(proxima);
+
+    await waitFor(() =>
+      expect(transactionsApi.list).toHaveBeenLastCalledWith(
+        expect.objectContaining({ limit: 50, offset: 50 }),
+      ),
+    );
+  });
+
+  it("mostra quantas transações existem no total", async () => {
+    transactionsApi.list.mockResolvedValue(pagina(50, 120));
+
+    render(
+      <MemoryRouter>
+        <Transactions />
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText(/120/)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/Wallets.jsx
+++ b/frontend/src/pages/Wallets.jsx
@@ -7,6 +7,7 @@ import { ConfirmDialog } from "@/components/shared/ConfirmDialog";
 import Money from "@/components/shared/Money";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { MoneyInput } from "@/components/ui/money-input";
 import {
   Dialog,
   DialogContent,
@@ -168,15 +169,10 @@ export default function Wallets() {
                   <span className="absolute left-3.5 top-1/2 -translate-y-1/2 text-sm text-content-3 pointer-events-none">
                     R$
                   </span>
-                  <Input
+                  <MoneyInput
                     id={saldoId}
-                    type="number"
-                    step="0.01"
-                    placeholder="0,00"
                     value={form.balance}
-                    onChange={(e) =>
-                      setForm({ ...form, balance: e.target.value })
-                    }
+                    onChange={(n) => setForm({ ...form, balance: n })}
                     className={`${shadcnInputCls} pl-10`}
                   />
                 </div>


### PR DESCRIPTION
First wave of the v2 map (#15). Five tasks, all already decided, no open questions. The theme is the same in every one of them: the app was hiding or corrupting information without telling the user.

Closes #30, #31, #32, #33.

## What changed

**The reports list was silently hiding data.** `Transactions.jsx` called the API with no `limit`/`offset`, so the backend applied its default of 200 and every older transaction vanished from the screen with no indication. The list is now paginated for real, and `GET /transactions/` returns an `X-Total-Count` header (scoped by `user_id` and by the same filters as the listing, with a test that fails if that scope ever breaks). `CORSMiddleware` exposes the header, without which the browser hides it from the frontend and pagination silently degrades in production only.

**Goals can be edited.** The backend already accepted `PUT /goals/{id}`; only the UI was missing. The edit form shows exactly the two fields `GoalUpdate` accepts, because a field the user edits and the server discards is worse than no field at all.

**A valid session no longer lands on the login screen.** `/` redirects to `/dashboard` when a session exists, and still falls back to the auth screen without a redirect loop when the stored token is expired or revoked.

**Money fields behave like a banking app.** A single `MoneyInput` replaces every `type="number"` money field: the field starts at `0,00` and typed digits fill from the right. It traffics numbers, never masked strings, so Zod schemas and API payloads are untouched. Goal contributions accept negative amounts (used to correct a wrong entry), so the contribution dialog carries an explicit Aporte/Correção control: sign is an intention that must survive a zero amount and must be reachable without a physical keyboard.

## Deploy order matters

**Deploy the backend before the frontend.** The two live on separate services, so they roll out independently. Without `X-Total-Count` the frontend falls back to a degraded mode: pagination stays usable when a page comes back full, but the total count is unknown and the counter hides rather than showing a fabricated number.

After deploying, confirm in devtools that `x-total-count` is visible on `GET /transactions/` against the deployed origin. If it is missing, check that `VITE_API_URL` is `https://`: an `http://` value makes Railway answer 301, and the redirect drops both the method and the header.

## Verification

- Backend: 154 tests.
- Frontend: 124 tests, ESLint clean, production build clean.
- Real browser run against the running stack, authenticated, with data created and removed through the API. That run is what caught the worst defect of the wave: saving an edited BUDGET goal did nothing at all, silently, because validation failed against a field that is not rendered in edit mode. No unit test reached it.

## Known debt, deliberately not fixed here

- The reports search is client-side, so it only covers the loaded page. A warning now says so whenever a search is active and other pages exist, but server-side search is the real fix and belongs to its own issue.
- `Dashboard.jsx` still requests `limit: 500` — the same silent-ceiling bug in a screen this wave did not touch.
- Two buttons share the accessible name "Entrar" on the auth screen; the pagination block has no `aria-live`. Both belong with the Wave 2 auth work.
- `MoneyInput` does not forward `onBlur`/`ref` from its `Controller`, matching what `Select` already does in this repo.
- Money fields show `0,00` instead of an empty state, so an optional amount looks pre-filled.
