### PR TITLE
v2 Wave 3: the subscription data model decision (ADR 0001)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,8 +71,11 @@ npm run test     # Vitest
   `data-theme` no `<html>`. Cor **só** por token semântico (`bg-surface`,
   `text-content-2`, `--glass-bg`…) — hex fixo em componente e o namespace
   `norby-*` não existem mais. Ver [DESIGN.md](DESIGN.md).
-- Specs e planos vivem no Second Brain (Obsidian), **não** no repo (`docs/` está
-  no `.gitignore`).
+- Specs e planos vivem no Second Brain (Obsidian), **não** no repo (`docs/*`
+  está no `.gitignore`). Duas exceções, essas versionadas: `docs/agents/`
+  (config das engineering skills) e `docs/adr/` (decisões de arquitetura). O
+  vocabulário de domínio fica no [CONTEXT.md](CONTEXT.md) da raiz e cresce por
+  decisão, não de uma vez.
 - Dependências: `requirements.txt` é **só produção**; pytest e afins vivem em
   `requirements-dev.txt`. Os arquivos `.lock` fixam também as transitivas usadas
   pelo Docker; regenerá-los após alterar os arquivos-fonte. Rodar o comando de

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,40 @@
+# CONTEXT.md — vocabulário do domínio
+
+> Glossário do Norby. **Cresce por decisão**, não de uma vez: um termo entra
+> aqui quando uma decisão o resolve, e as decisões ficam em [`docs/adr/`](docs/adr/).
+> Se um conceito não está aqui, ou a linguagem é nova (reconsidere) ou é lacuna
+> real (registre).
+>
+> Regra de uso: quando um título de issue, um nome de teste, um comentário ou um
+> identificador nomeia um destes conceitos, usar **o termo desta tabela**. Não
+> derivar para sinônimo.
+
+## Plano e assinatura
+
+Resolvido pelo [ADR 0001](docs/adr/0001-modelo-de-assinatura.md) (issue #19).
+
+| Termo | Significa | Como se mede |
+|---|---|---|
+| **`premium_until`** | O portão. Instante em que o período pago termina (`current_period_end` do Stripe) | A **única** coluna que a autorização lê |
+| **premium** / **ativo** | Tem acesso pago agora | `now < premium_until` |
+| **free** | Nunca assinou | `premium_until IS NULL` |
+| **trial de IA** | 7 dias de IA sem cartão, concedidos no cadastro. Concede **só IA**, nunca carteira | `ai_trial_ends_at > now` |
+| **vencido** | Assinou e o período pago acabou | `premium_until <= now` |
+| **carência** (`GRACE`) | 72 horas exatas depois de `premium_until` em que o vencido ainda escapa do teto de carteiras. A IA já parou | `premium_until <= now < premium_until + 72h` |
+| **teto de carteiras** | Limite de 2 carteiras ativas. Vale para free e para vencido fora da carência | `premium_until IS NULL OR now >= premium_until + 72h` |
+| **carteira excedente** | Carteira acima do teto: fica somente-leitura, mas **continua contando em todo total** | as 2 mais antigas nunca são excedentes |
+
+Os dois portões, escritos por extenso:
+
+- **IA:** `ai_trial_ends_at > now OR premium_until > now`
+- **Teto de carteiras aplica:** `premium_until IS NULL OR now >= premium_until + 72h`
+
+### Termos que este glossário evita de propósito
+
+| Não usar | Usar | Por quê |
+|---|---|---|
+| `is_paid`, `is_premium` como coluna | `premium_until` | Booleano guardado desincroniza do relógio; a data é auto-suficiente e falha fechado |
+| `plan`, "plano do usuário" | premium / free | Existe **um** plano pago. Coluna com um valor possível é decoração |
+| `subscription_status` para decidir acesso | `premium_until` | O status existe **só para exibição**. Autorizar por ele move a decisão para um vocabulário que o Stripe pode estender sem avisar |
+| "assinante" para quem já pagou um dia | premium (ativo) ou vencido | "Assinante" apaga a diferença que o teto de carteiras depende de enxergar |
+| "trial" para período pago | trial de IA | O trial nunca concede carteira. Confundir os dois inverte o teto |

--- a/docs/adr/0001-modelo-de-assinatura.md
+++ b/docs/adr/0001-modelo-de-assinatura.md
@@ -1,0 +1,281 @@
+# ADR 0001 — Modelo de dados de assinatura
+
+- **Status:** aceito
+- **Data:** 2026-08-25
+- **Issue:** [#19](https://github.com/DigoDuck/Norby/issues/19), parte do mapa da v2 ([#15](https://github.com/DigoDuck/Norby/issues/15))
+- **Decide:** onde mora o estado de plano, como o webhook o alimenta e o que o
+  app lê para autorizar.
+- **Não decide:** onde os portões são aplicados (#20), teto diário de IA (#21),
+  papéis e área de admin (#23), layout da `/perfil` (#25).
+
+> Primeiro ADR do repositório. Escrito em português, como os demais documentos
+> daqui (`AGENTS.md`, `DESIGN.md`, `LGPD.md`); o que vai para issue e PR no
+> GitHub continua em inglês.
+
+## Contexto
+
+A v2 cobra uma assinatura mensal de BRL 20,00 via Stripe, com dinheiro recebido
+como pessoa física (CPF). O schema de hoje — `users`, `refresh_tokens`,
+`login_throttles`, `wallets`, `transactions`, `recurring_transactions`,
+`goals` — não tem nada de plano, assinatura ou papel. Nenhuma linha de código de
+billing pode ser escrita antes desta decisão.
+
+As regras de negócio já estavam travadas no #15 e **não** são decididas aqui:
+free são 2 carteiras e nenhuma IA; conta nova ganha 7 dias de IA sem cartão;
+carteira excedente fica somente-leitura mas continua contando em todo total;
+usuário pré-v2 vira free no dia do deploy, sem grandfathering; assinatura
+vencida para só a IA. Uma decisão foi refinada durante a sessão de grilling:
+o vencido perde a IA imediatamente e mantém as carteiras extras por **72 horas**
+antes de voltar ao teto de 2.
+
+A pesquisa do #16 confirmou que o Stripe aceita conta individual com CPF, com
+repasse doméstico em 30 dias e custo efetivo de ~6,6% sobre os BRL 20,00. Restou
+um item não confirmado por fonte primária — se conta `individual` pode rodar
+Billing — que o #26 fecha abrindo a conta real. Este ADR foi escrito assumindo
+que sim, e a seção "Acoplamento" abaixo diz exatamente o que muda se não for.
+
+## Decisão
+
+### O portão é uma data, não um enum de status
+
+`users.premium_until` guarda o `current_period_end` do Stripe e é **a única
+coluna que a autorização lê**.
+
+O Stripe não move `current_period_end` quando o cartão falha — ele continua
+tentando cobrar dentro do período já pago. Logo a data, sozinha, já responde
+"essa pessoa tem acesso agora". Três consequências caem de graça:
+
+- `cancel_at_period_end` deixa de ser estado. No Stripe é `status=active` mais
+  uma flag, e o app não faz nada diferente: o acesso vai até o fim do período
+  pago de qualquer forma.
+- A carência de `past_due` deixa de ser política nossa. É o cronograma de retry
+  do Stripe, acontecendo dentro de um período que já foi pago.
+- **Webhook perdido falha fechado.** A pior coisa que a perda de um evento
+  consegue fazer é deixar o acesso expirar. Nunca conceder acesso indevido.
+
+Um enum de status como portão faria o contrário: um status novo que o Stripe
+invente cai no `else` de algum gate e vira concessão ou negação silenciosa.
+
+### As quatro faixas são comparações de data
+
+Com `GRACE = 72h` — 72 horas exatas a partir de `premium_until`, não dias de
+calendário: `premium_until` é um instante vindo do Stripe, e dia de calendário
+exigiria um fuso que este modelo não precisa ter.
+
+| condição | carteiras | IA |
+|---|---|---|
+| `premium_until IS NULL` | teto de 2 | só se `ai_trial_ends_at > now` |
+| `now < premium_until` | ilimitadas | sim |
+| `premium_until <= now < premium_until + GRACE` | ilimitadas | não |
+| `now >= premium_until + GRACE` | teto de 2 | não |
+
+- Portão de IA: `ai_trial_ends_at > now OR premium_until > now`
+- Teto de carteira aplica quando: `premium_until IS NULL OR now >= premium_until + GRACE`
+
+O trial concede **só IA**. Quem está em trial continua com teto de 2 carteiras,
+que é o que a decisão travada diz.
+
+### Colunas em `users`, não tabela `subscriptions`
+
+Sete colunas novas, todas alimentadas direto do payload do webhook, sem tradução
+para vocabulário próprio.
+
+| coluna | tipo | papel |
+|---|---|---|
+| `premium_until` | `timestamptz`, indexada | o portão |
+| `ai_trial_ends_at` | `timestamptz` | trial de 7 dias, gravado no `POST /auth/register` |
+| `stripe_customer_id` | `varchar(255)`, único | reabrir Checkout e Customer Portal de quem volta |
+| `stripe_subscription_id` | `varchar(255)` | cancelar na exclusão de conta e no admin |
+| `subscription_status` | `varchar(32)` | string crua do Stripe, **só exibição** |
+| `cancel_at_period_end` | `boolean`, default `false` | exibição: "sua assinatura termina em X" |
+| `stripe_event_at` | `timestamptz` | `created` do último evento aplicado, guarda contra chegada fora de ordem |
+
+O critério: **uma coluna só entra se afirmar um fato que `premium_until` não
+consegue afirmar.** Por esse corte ficaram de fora `plan` (um plano só, sem
+tiers — coluna com um valor possível é decoração) e qualquer marca de "já foi
+premium alguma vez". `subscription_status` e `cancel_at_period_end` entraram
+porque a data não consegue dizer que a pessoa já cancelou mas ainda está dentro
+do período pago, nem que o pagamento falhou e o Stripe está retentando — sem
+elas o `/perfil` mente para quem acabou de cancelar e cala para quem está com o
+cartão recusado.
+
+O ganho concreto de colunas sobre tabela dedicada: `get_current_user` já carrega
+o objeto `User` em toda rota autenticada, então **o portão custa zero query
+extra**. Uma tabela `subscriptions` exigiria um JOIN ou uma segunda query em
+cada requisição protegida, e o histórico que ela carregaria já está no Stripe,
+que é o sistema de registro do dinheiro. Duplicar o relatório dele numa tabela
+nossa é manter um segundo livro-caixa que pode divergir do primeiro.
+
+### O trial é conceito do Norby, não do Stripe
+
+`ai_trial_ends_at` gravado no cadastro. A alternativa — Subscription do Stripe
+com `trial_period_days` sem método de pagamento — obrigaria a criar Customer e
+Subscription **no cadastro de todo mundo**, inclusive de quem nunca vai pagar, e
+acoplaria o registro a uma chamada de terceiro que pode falhar.
+
+Efeito colateral desejado: a migration deixa a coluna `NULL` para todo usuário
+existente, e `NULL` significa "sem trial". O requisito "usuário pré-v2 não ganha
+trial retroativo" sai de graça. Derivar o trial de `created_at` faria exatamente
+o oposto.
+
+### `stripe_webhook_events`: projeção, não payload cru
+
+Colunas: `event_id` (PK), `type`, `stripe_created`, `customer_id`,
+`subscription_id`, `current_period_end`, `status`, `cancel_at_period_end`,
+`received_at`, `processed_at`.
+
+Guardar o evento inteiro em JSONB colocaria PII fora do alcance do
+`delete_account` — `checkout.session.completed` traz `customer_details.email`, e
+o [LGPD.md](../../LGPD.md) trata exclusão como direito, não cortesia. Guardando
+só os campos que o handler usa, não existe nada a apagar depois: o problema
+morre na origem em vez de virar rotina de limpeza.
+
+Nada de real se perde. A capacidade de *replay* que o payload cru daria é
+redundante com a reconciliação preguiçosa (abaixo), que consulta o Stripe ao
+vivo — recuperação melhor do que reprocessar uma cópia velha. Para depuração, o
+painel do Stripe guarda todo evento por 30 dias com botão de reenviar; manter
+uma segunda cópia duplica um sistema que já faz isso melhor. A idempotência só
+precisa do `event_id` único.
+
+### Webhook
+
+`POST /billing/webhook`.
+
+- **Corpo cru obrigatório.** A verificação de assinatura exige os bytes
+  originais (`await request.body()`), então este handler **não pode** receber um
+  modelo Pydantic — deixar o FastAPI parsear o JSON invalida a assinatura.
+- Assinatura por `stripe.Webhook.construct_event` com `STRIPE_WEBHOOK_SECRET`.
+- Corpo acima de **64 KB é recusado antes do HMAC**, para ninguém pagar CPU de
+  HMAC sobre lixo. Essa é a proteção certa para endpoint anônimo que roda HMAC.
+- **Sem rate limit por IP, por decisão.** Atrás do proxy do Railway todos os IPs
+  são o mesmo (ver "Rate limit atrás do proxy" no `AGENTS.md`), então um teto
+  por IP aqui deixaria qualquer pessoa derrubar as entregas do Stripe. É o bug
+  que a Onda 2 inteira existiu para matar; não reintroduzir numa rota nova.
+
+Três eventos consumidos:
+
+| evento | por quê |
+|---|---|
+| `checkout.session.completed` | primeira compra; amarra customer e subscription ao usuário via `client_reference_id` |
+| `customer.subscription.updated` | renovação, cancelamento agendado e pagamento falhado — o cavalo de batalha |
+| `customer.subscription.deleted` | fim da assinatura |
+
+`invoice.paid` e `invoice.payment_failed` **não** são consumidos: renovação paga
+já dispara `subscription.updated` com o `current_period_end` novo, e cartão
+recusado já dispara `subscription.updated` com `status=past_due`. São o mesmo
+fato chegando por outra porta.
+
+Fluxo, inline e sem fila:
+
+1. verifica assinatura
+2. insere a linha em `stripe_webhook_events`; conflito no `event_id` responde
+   200 **sem reprocessar** (idempotência)
+3. descarta sem aplicar se `stripe_created < users.stripe_event_at` (chegada
+   fora de ordem — o Stripe não garante ordem)
+4. aplica nas colunas, commita, responde 200
+
+Falha da aplicação responde 500 e o Stripe reentrega por até 3 dias, que é o
+comportamento de uma fila com retry sem infra de fila. Este projeto não tem
+scheduler nem worker e esta decisão não introduz um.
+
+A guarda de ordem é `stripe_event_at`, não "nunca deixar `premium_until` andar
+para trás": a segunda quebraria o cancelamento de verdade, que precisa andar
+para trás.
+
+### Chamadas de saída ao Stripe — três
+
+- criar sessão de **Checkout hospedado** (`client_reference_id = user.id`)
+- criar sessão de **Customer Portal**
+- cancelar assinatura — só a área de admin (#23)
+
+**Checkout hospedado, não Payment Element.** O argumento decisivo é a CSP: o
+Payment Element exige abrir `script-src` para `js.stripe.com` mais frames, ou
+seja, afrouxar a CSP na mesma release que começa a processar pagamento. O #15 já
+trata a CSP como intocável a ponto de recusar API externa de logo de banco por
+causa dela. O Checkout ainda resolve 3DS/SCA e recibo sem código nosso. O preço,
+que é real: a pessoa sai do app na hora de pagar. Mitigado com locale pt-BR,
+logo e cor configurados no próprio Checkout.
+
+**Customer Portal para cancelamento, troca de cartão e histórico de faturas.** Um
+endpoint próprio só de cancelar entregaria um terço da feature: cartão recusado
+precisa de tela de atualizar cartão, e o #25 já pede histórico de cobrança na
+`/perfil`. Isso **não** zera o cliente Stripe do lado do servidor — o admin
+precisa cancelar a assinatura de outra pessoa e não pode usar a sessão de portal
+dela.
+
+### Exclusão de conta cancela no Stripe primeiro
+
+Havendo `stripe_subscription_id`, cancela no Stripe **antes** de qualquer
+exclusão; recusa do Stripe **aborta a exclusão inteira** com erro claro. Depois
+segue o fluxo Mongo → Postgres atual.
+
+A ordem vem da assimetria dos modos de falha: exclusão que falhou é recuperável,
+basta tentar de novo; cartão sendo cobrado por uma conta que não existe mais não
+é — vira chargeback e a pessoa não tem nem onde clicar para cancelar. A LGPD dá
+direito à exclusão, e uma falha temporária com mensagem honesta não fere isso;
+continuar cobrando em silêncio, sim.
+
+Sem `stripe_subscription_id`, a chamada não acontece.
+
+### Reconciliação preguiçosa de webhook perdido
+
+Dispara **só** quando `premium_until <= now` **e** `stripe_subscription_id IS
+NOT NULL`: uma leitura no Stripe para atualizar as colunas. Usuário free nunca
+paga essa chamada.
+
+Não existe scheduler neste projeto; o padrão é o mesmo do
+`materialize_due_recurring`, que já roda de carona em requisição. E como o
+desenho já falha fechado, a reconciliação não existe para proteger receita —
+existe para consertar a única direção que machuca cliente pagante: pagou, o
+webhook se perdeu, e o app diz que ele não é premium.
+
+### Testes de billing sem falar com o Stripe
+
+Fixtures JSON dos 3 eventos, assinadas em teste com um segredo de teste. Cobrem
+assinatura válida, assinatura inválida recusada, evento duplicado sem efeito,
+evento com `stripe_created` mais antigo ignorado, e cada transição de
+`premium_until`.
+
+Toda a superfície que é nossa se resume a "dado este payload, as colunas
+terminam assim" — função pura do payload, sem chamada ao Stripe no meio.
+`stripe-mock` testaria o formato da API do Stripe, que é a parte que quase não
+chamamos; a CLI do Stripe exigiria chave real e rede em CI, que é o mesmo motivo
+pelo qual este repo recusou o Snyk. As chamadas de saída ficam stubadas na
+fronteira do serviço, no padrão que o Gemini já usa.
+
+## Acoplamento — o que muda se o #26 derrubar o Stripe
+
+Se conta individual não puder rodar Billing, o fallback é o Asaas (o Pagar.me
+está fora: exige CNPJ ou MEI). Quatro pontos mudam:
+
+1. os 3 nomes de evento e os caminhos de campo que alimentam as colunas
+2. o nome das duas colunas de id externo
+3. o helper de verificação de assinatura
+4. as 3 chamadas de saída
+
+O resto é agnóstico de gateway: data-como-portão, as quatro faixas, idempotência
+por id de evento, ordenação por timestamp de evento e a reconciliação preguiçosa.
+
+## Consequências aceitas
+
+- **Webhook perdido bloqueia cliente pagante** até a reconciliação disparar.
+  Mitigado, não eliminado.
+- **Duas saídas do app na jornada de dinheiro** (Checkout e Portal). Custo
+  consciente de não afrouxar a CSP e de não construir UI de billing.
+- **`subscription_status` guarda vocabulário estrangeiro.** Status novo do Stripe
+  aparece na tela sem ser entendido — mas não autoriza nada, então não vira
+  falha de segurança.
+- **Repasse em 30 dias** no cartão doméstico. É fato do Stripe e atinge fluxo de
+  caixa, não o modelo.
+
+## Alternativas consideradas e recusadas
+
+| Alternativa | Por que não |
+|---|---|
+| Consultar o Stripe ao vivo a cada requisição | Chamada de rede a terceiro no caminho de toda rota protegida; instabilidade do Stripe viraria paywall na cara de quem paga |
+| Tabela `subscriptions` dedicada | JOIN ou segunda query por requisição, e o histórico que ela guardaria já vive no Stripe. A tabela de eventos, que é obrigatória para idempotência, já carrega o que sobraria de útil |
+| Enum próprio de status como portão | Move a autorização para um vocabulário que o Stripe pode estender sem avisar; a data já responde a pergunta e falha fechado |
+| Trial como Subscription do Stripe | Criaria Customer e Subscription para todo cadastro, inclusive de quem nunca paga, e acoplaria o registro a uma chamada externa |
+| Payload cru em JSONB | PII (`customer_details.email`) fora do alcance do `delete_account`, e o replay que ele daria é redundante com a reconciliação |
+| Payment Element embutido | Exigiria afrouxar a CSP na mesma release que começa a cobrar |
+| `stripe-mock` ou Stripe CLI em CI | Testariam a API do Stripe, não o nosso handler; a CLI ainda exigiria chave real e rede |


### PR DESCRIPTION
Third wave of the v2 map (#15). Wave 3 is decisions, not code — the execution backlog had only #34 and #35 left, while the paid core had no decision locked and therefore no ticket to implement.

Resolves #19. No code, no migration, no schema change. Implementation is wave 4.

## The load-bearing choice: authorization reads a date, not a status enum

Stripe does not move `current_period_end` when a card fails — it retries inside the period the user already paid for. So that single timestamp already answers "does this account have access right now", and three things fall out of it for free:

- `cancel_at_period_end` stops being a state. In Stripe it is `status=active` plus a flag, and the app behaves identically either way: access runs to the end of the paid period.
- The `past_due` grace period stops being our policy. It is Stripe's retry schedule, running inside a period that was already paid for.
- **A lost webhook fails closed.** The worst a dropped event can do is let access expire. It can never grant access that was not paid for.

A status enum as the gate does the opposite: a status Stripe invents later lands in some gate's `else` and becomes a silent grant or a silent denial.

## What the model is

Seven nullable columns on `users` — `premium_until` (the gate), `ai_trial_ends_at`, `stripe_customer_id`, `stripe_subscription_id`, `subscription_status` (display only), `cancel_at_period_end`, `stripe_event_at` — plus a `stripe_webhook_events` table. No `subscriptions` table, no `plan` column, no role column.

Columns beat a dedicated table here for one concrete reason: `get_current_user` already loads the `User` on every authenticated route, so the gate costs **zero extra queries**. A `subscriptions` table would mean a JOIN or a second query on every protected request, and the per-period history it would carry already lives in Stripe, which is the system of record for money. Duplicating that is keeping a second ledger that can disagree with the first.

The criterion for admitting a column was that it must state a fact `premium_until` cannot. `plan` failed it — there is one paid plan, so a column with one possible value is decoration. `subscription_status` and `cancel_at_period_end` passed: the date cannot say that someone already cancelled but is still inside the paid period, nor that a payment failed and Stripe is retrying. Without them the profile page lies to whoever just cancelled and stays silent for whoever has a declined card.

## Four access tiers, all date comparisons

`GRACE = 72h`, exact hours from `premium_until` rather than calendar days — `premium_until` is an instant from Stripe, and calendar days would need a timezone this model does not have to carry.

| condition | wallets | AI |
|---|---|---|
| `premium_until IS NULL` | capped at 2 | only while `ai_trial_ends_at > now` |
| `now < premium_until` | unlimited | yes |
| `premium_until <= now < premium_until + GRACE` | unlimited | no |
| `now >= premium_until + GRACE` | capped at 2 | no |

This refines one locked decision. #15 said a lapsed subscription stops AI and nothing else, which left a never-paying user capped at 2 wallets while a lapsed one kept every wallet forever. AI now stops at `premium_until` and the wallet cap returns 72 hours later.

## Webhook

`POST /billing/webhook`, three events consumed: `checkout.session.completed`, `customer.subscription.updated`, `customer.subscription.deleted`. `invoice.paid` and `invoice.payment_failed` are deliberately not consumed — a paid renewal already fires `subscription.updated` with the new `current_period_end`, and a declined card already fires it with `status=past_due`. Same fact, second door.

Inline processing, no queue: verify signature, insert the event row (a conflict on `event_id` answers 200 without reprocessing), drop the event without applying if `stripe_created < users.stripe_event_at`, apply, commit, 200. A failure answers 500 and Stripe redelivers for up to 3 days, which is a retrying queue without queue infrastructure. This project has no scheduler and this decision does not add one.

Two things recorded so they are not discovered in production:

- **The handler must read the raw body.** Signature verification needs the original bytes, so it cannot take a Pydantic model — letting FastAPI parse the JSON invalidates the signature.
- **No IP rate limit on this route, by decision.** Behind Railway's proxy every IP is the same one, so an IP-keyed ceiling here would let anyone knock out Stripe's deliveries. That is the exact bug wave 2 existed to kill, and it is not getting reintroduced on a new route. The right guard for an anonymous endpoint running HMAC is a body size cap: reject anything over 64 KB before verifying.

## The events table stores a projection, not the payload

`checkout.session.completed` carries `customer_details.email`. Storing the raw event in JSONB would park personal data outside the reach of `delete_account`, and `LGPD.md` treats deletion as a right rather than a courtesy. Storing only the fields the handler uses means there is nothing to erase later — the problem dies at the source instead of becoming a cleanup routine.

Nothing real is lost. The replay a raw payload would allow is redundant with the lazy reconciliation, which reads Stripe live and is a better recovery than reprocessing a stale copy. For debugging, Stripe's own dashboard keeps every event for 30 days with a resend button. Idempotency only ever needed the unique `event_id`.

## Hosted Checkout and the Customer Portal

Checkout is hosted rather than the embedded Payment Element, and the deciding argument is the CSP: Payment Element requires opening `script-src` to `js.stripe.com` plus frames — loosening the CSP in the same release that starts processing payments. #15 already treats the CSP as untouchable to the point of refusing an external bank-logo API over it. The cost is real and not hidden: the user leaves the app to pay.

The Customer Portal covers cancellation, card updates and invoice history. A cancel-only endpoint of our own would ship a third of the feature — a declined card needs an update-card screen, and #25 already asks for billing history on `/perfil`. This does not eliminate the server-side Stripe client: an admin has to cancel someone else's subscription and cannot use that person's portal session.

## Account deletion cancels at Stripe first

With a `stripe_subscription_id` present, cancel at Stripe before deleting anything; a refusal from Stripe aborts the whole deletion with a clear error. The order comes from the asymmetry of the failure modes: a failed deletion is recoverable by retrying, while a card charged for an account that no longer exists is not — it becomes a chargeback, and the person has nowhere left to click. LGPD grants a right to deletion, and a temporary failure with an honest message does not breach it; silently continuing to bill does.

## If #26 finds that an individual account cannot run Billing

Four things change: the three event names and the field paths feeding the columns, the names of the two external id columns, the signature verification helper, and the three outbound calls. Everything else is gateway-agnostic — date-as-gate, the four tiers, idempotency by event id, ordering by event timestamp, lazy reconciliation. The fallback is Asaas; Pagar.me is out, since its signup requires a CNPJ or MEI.

## Also in this PR

`CONTEXT.md`, the domain glossary, carrying the plan vocabulary this decision settled plus the synonyms to avoid — four downstream tickets are about to be written in these words, and `is_paid` drifting in next to `premium_until` is how the model rots. It grows one decision at a time rather than being written up front.

The `AGENTS.md` line claiming `docs/` is entirely gitignored is corrected: `docs/agents/` and `docs/adr/` are versioned exceptions, and the second one now carries content.
