### PR TITLE
v2 Wave 4: subscription columns, the webhook events table and the access gates

### DIFF
--- a/backend/alembic/versions/154dd832e2d8_subscription_columns_and_stripe_webhook_.py
+++ b/backend/alembic/versions/154dd832e2d8_subscription_columns_and_stripe_webhook_.py
@@ -1,0 +1,100 @@
+"""subscription columns and stripe webhook events
+
+Revision ID: 154dd832e2d8
+Revises: 764bc1132df0
+Create Date: 2026-08-25 19:34:37.418453
+
+Issue #44, implementando o ADR 0001 (docs/adr/0001-modelo-de-assinatura.md).
+
+PURAMENTE ADITIVA, sem backfill: toda coluna nova nasce NULL nas linhas
+existentes, e NULL em `premium_until` significa "nunca assinou" enquanto NULL em
+`ai_trial_ends_at` significa "sem trial". É assim que a decisão travada do #15 —
+usuário pré-v2 vira free, sem grandfathering nem trial retroativo — sai de graça,
+sem uma linha de UPDATE.
+
+DUAS MUDANÇAS DO AUTOGENERATE FORAM REMOVIDAS À MÃO (mesmo drift pré-existente
+que as migrations 1c1a72a15b9e e 764bc1132df0 já haviam recusado):
+
+  1. `recurring_transactions.active`: o autogenerate queria derrubar o
+     server_default. Fora de escopo e com efeito destrutivo — INSERT que hoje
+     omite a coluna passaria a falhar.
+  2. `refresh_tokens.token_hash`: queria trocar a unique constraint por índice
+     único. Fora de escopo, e mexer em índice de tabela de sessão numa migration
+     de billing é acoplar dois riscos sem motivo.
+
+Uma TERCEIRA correção, esta de bug do próprio autogenerate: ele emitiu
+`create_unique_constraint(None, ...)` no upgrade e `drop_constraint(None, ...)`
+no downgrade. Com nome None o Postgres batiza sozinho, e o downgrade
+quebraria na hora de derrubar uma constraint chamada "None". Nomeada
+explicitamente abaixo.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '154dd832e2d8'
+down_revision: Union[str, None] = '764bc1132df0'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+UQ_STRIPE_CUSTOMER = "uq_users_stripe_customer_id"
+
+
+def upgrade() -> None:
+    # Projeção dos campos que o handler do webhook usa — nunca o payload cru.
+    # O `checkout.session.completed` traz `customer_details.email`, e guardar o
+    # evento inteiro colocaria PII fora do alcance do delete_account.
+    # A idempotência mora na PK: event_id repetido conflita e o handler (#45)
+    # responde 200 sem reprocessar.
+    op.create_table(
+        'stripe_webhook_events',
+        sa.Column('event_id', sa.String(length=255), nullable=False),
+        sa.Column('type', sa.String(length=64), nullable=False),
+        sa.Column('stripe_created', sa.DateTime(timezone=True), nullable=False),
+        sa.Column('customer_id', sa.String(length=255), nullable=True),
+        sa.Column('subscription_id', sa.String(length=255), nullable=True),
+        sa.Column('current_period_end', sa.DateTime(timezone=True), nullable=True),
+        sa.Column('status', sa.String(length=32), nullable=True),
+        sa.Column('cancel_at_period_end', sa.Boolean(), nullable=True),
+        sa.Column('received_at', sa.DateTime(timezone=True), nullable=False),
+        sa.Column('processed_at', sa.DateTime(timezone=True), nullable=True),
+        sa.PrimaryKeyConstraint('event_id'),
+    )
+    op.create_index(
+        op.f('ix_stripe_webhook_events_customer_id'),
+        'stripe_webhook_events', ['customer_id'], unique=False,
+    )
+
+    # premium_until é o portão e a única coluna que a autorização lê; indexada
+    # porque a reconciliação preguiçosa (#48) vai filtrar por ela.
+    op.add_column('users', sa.Column('premium_until', sa.DateTime(timezone=True), nullable=True))
+    op.add_column('users', sa.Column('ai_trial_ends_at', sa.DateTime(timezone=True), nullable=True))
+    op.add_column('users', sa.Column('stripe_customer_id', sa.String(length=255), nullable=True))
+    op.add_column('users', sa.Column('stripe_subscription_id', sa.String(length=255), nullable=True))
+    op.add_column('users', sa.Column('subscription_status', sa.String(length=32), nullable=True))
+    # server_default false é o que permite adicionar coluna NOT NULL numa tabela
+    # que já tem linhas: sem ele o ALTER falha em produção, não aqui.
+    op.add_column(
+        'users',
+        sa.Column('cancel_at_period_end', sa.Boolean(), server_default=sa.text('false'), nullable=False),
+    )
+    op.add_column('users', sa.Column('stripe_event_at', sa.DateTime(timezone=True), nullable=True))
+    op.create_index(op.f('ix_users_premium_until'), 'users', ['premium_until'], unique=False)
+    op.create_unique_constraint(UQ_STRIPE_CUSTOMER, 'users', ['stripe_customer_id'])
+
+
+def downgrade() -> None:
+    op.drop_constraint(UQ_STRIPE_CUSTOMER, 'users', type_='unique')
+    op.drop_index(op.f('ix_users_premium_until'), table_name='users')
+    op.drop_column('users', 'stripe_event_at')
+    op.drop_column('users', 'cancel_at_period_end')
+    op.drop_column('users', 'subscription_status')
+    op.drop_column('users', 'stripe_subscription_id')
+    op.drop_column('users', 'stripe_customer_id')
+    op.drop_column('users', 'ai_trial_ends_at')
+    op.drop_column('users', 'premium_until')
+    op.drop_index(op.f('ix_stripe_webhook_events_customer_id'), table_name='stripe_webhook_events')
+    op.drop_table('stripe_webhook_events')

--- a/backend/app/models/sql_models.py
+++ b/backend/app/models/sql_models.py
@@ -58,6 +58,40 @@ class User(Base):
         DateTime(timezone=True), nullable=True
     )
 
+    # --- Plano e assinatura (ADR 0001, issue #19) ----------------------------
+    # premium_until é O PORTÃO: o current_period_end do Stripe, e a única coluna
+    # que a autorização lê. O Stripe não move essa data quando o cartão falha —
+    # ele retenta DENTRO do período já pago — então ela sozinha responde "tem
+    # acesso agora", e webhook perdido só consegue expirar acesso, nunca
+    # conceder. As quatro faixas estão em app/services/plan_service.py.
+    premium_until: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), nullable=True, index=True
+    )
+    # Trial de IA de 7 dias, gravado no cadastro. Concede SÓ IA: quem está em
+    # trial continua com teto de 2 carteiras. NULL significa "sem trial", que é
+    # o que a migration deixa em todo usuário pré-v2 — o "sem grandfathering"
+    # da decisão travada sai de graça, sem backfill.
+    ai_trial_ends_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    stripe_customer_id: Mapped[Optional[str]] = mapped_column(
+        String(255), unique=True, nullable=True
+    )
+    stripe_subscription_id: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    # String crua do Stripe, SÓ exibição. Nenhum portão lê isto: autorizar por um
+    # vocabulário que o Stripe pode estender sem avisar faria um status novo cair
+    # no else de algum gate e virar concessão ou negação silenciosa.
+    subscription_status: Mapped[Optional[str]] = mapped_column(String(32), nullable=True)
+    cancel_at_period_end: Mapped[bool] = mapped_column(
+        Boolean, default=False, server_default=text("false"), nullable=False
+    )
+    # `created` do último evento aplicado. O Stripe NÃO garante ordem de entrega,
+    # e dois customer.subscription.updated invertidos empurrariam premium_until
+    # para trás ou ressuscitariam um cancel_at_period_end velho.
+    stripe_event_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+
     # passive_deletes=True: as FKs já têm ondelete="CASCADE", mas sem isto o
     # SQLAlchemy ignora o banco, CARREGA todos os filhos na sessão e emite um
     # DELETE por linha. A conta de demo tem ~170 transações, então DELETE
@@ -189,3 +223,40 @@ class Goal(Base):
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utcnow)
 
     user: Mapped["User"] = relationship("User", back_populates="goals")
+class StripeWebhookEvent(Base):
+    """Projeção dos campos que o handler usa — NUNCA o payload cru (ADR 0001).
+
+    Guardar o evento inteiro em JSONB colocaria PII fora do alcance do
+    `delete_account`: o `checkout.session.completed` traz
+    `customer_details.email`, e o LGPD.md trata exclusão como direito, não
+    cortesia. Guardando só o que o handler lê, não existe nada a apagar depois.
+
+    Nada de real se perde. O replay que o payload cru permitiria é redundante
+    com a reconciliação preguiçosa (issue #48), que consulta o Stripe ao vivo —
+    recuperação melhor do que reprocessar cópia velha. E o painel do Stripe já
+    guarda todo evento por 30 dias com botão de reenviar.
+
+    A idempotência mora na PK: `event_id` repetido conflita, e o handler
+    responde 200 sem reprocessar.
+    """
+
+    __tablename__ = "stripe_webhook_events"
+
+    event_id: Mapped[str] = mapped_column(String(255), primary_key=True)
+    type: Mapped[str] = mapped_column(String(64), nullable=False)
+    # `created` do evento no Stripe, não a hora em que chegou aqui: é ele que
+    # ordena os eventos entre si quando a entrega vem fora de ordem.
+    stripe_created: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    customer_id: Mapped[Optional[str]] = mapped_column(String(255), nullable=True, index=True)
+    subscription_id: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    current_period_end: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    status: Mapped[Optional[str]] = mapped_column(String(32), nullable=True)
+    cancel_at_period_end: Mapped[Optional[bool]] = mapped_column(Boolean, nullable=True)
+    received_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=utcnow, nullable=False
+    )
+    processed_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -21,6 +21,7 @@ from app.services.auth_service import (
     _DUMMY_HASH,
 )
 from app.services.account_service import delete_account, export_data
+from app.services.plan_service import AI_TRIAL
 from app.services.throttle_service import check_throttle, record_failure, record_success
 
 router = APIRouter(prefix="/auth", tags=["Auth"])
@@ -79,11 +80,18 @@ async def register(
     # bcrypt é CPU-bound e síncrono (~100-300ms). Rodar direto na rota async
     # travaria o event loop; offload para thread, como já é feito com o Gemini.
     password_hash = await asyncio.to_thread(hash_password, payload.password)
+    # ADR 0001: o trial de IA é conceito do Norby, não Subscription do Stripe —
+    # aquela alternativa criaria Customer e Subscription lá para TODO cadastro,
+    # inclusive de quem nunca vai pagar, e acoplaria o registro a uma chamada
+    # externa que pode falhar. Concede só IA: o teto de 2 carteiras continua
+    # valendo durante o trial (premium_until segue NULL).
+    agora = datetime.now(timezone.utc)
     user = User(
         name=payload.name,
         email=payload.email,
         password_hash=password_hash,
-        privacy_accepted_at=datetime.now(timezone.utc),
+        privacy_accepted_at=agora,
+        ai_trial_ends_at=agora + AI_TRIAL,
     )
     db.add(user)
     try:

--- a/backend/app/services/plan_service.py
+++ b/backend/app/services/plan_service.py
@@ -1,0 +1,50 @@
+"""As quatro faixas de acesso do ADR 0001.
+
+O portão é uma DATA, não um enum de status: `users.premium_until` guarda o
+`current_period_end` do Stripe e é a única coluna que a autorização lê. Ver
+`docs/adr/0001-modelo-de-assinatura.md` e o glossário em `CONTEXT.md`.
+
+`now` é parâmetro e não gancho de teste: "esse usuário era premium no instante
+T" é pergunta legítima (a área de admin, issue #23, vai fazer). Chamador de
+produção omite e pega o relógio.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+from app.models.sql_models import User
+
+# 72 horas EXATAS a partir de `premium_until`, não dias de calendário:
+# `premium_until` é um instante vindo do Stripe, e dia de calendário exigiria um
+# fuso que este modelo não precisa carregar.
+GRACE = timedelta(hours=72)
+
+# Trial de IA concedido no cadastro (decisão travada do #15: 7 dias de IA sem
+# cartão). Mora aqui, junto das outras regras de plano, e não no router.
+AI_TRIAL = timedelta(days=7)
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _no_futuro(quando: datetime | None, now: datetime) -> bool:
+    return quando is not None and quando > now
+
+
+def ai_allowed(user: User, now: datetime | None = None) -> bool:
+    """IA liberada durante o trial de 7 dias OU enquanto a assinatura vale.
+
+    No vencimento a IA para na hora: o que ganha carência de 72h é o teto de
+    carteiras, não isto.
+    """
+    now = now or _utcnow()
+    return _no_futuro(user.ai_trial_ends_at, now) or _no_futuro(user.premium_until, now)
+
+
+def wallet_cap_applies(user: User, now: datetime | None = None) -> bool:
+    """Teto de 2 carteiras: vale para quem nunca assinou e para quem venceu
+    há 72h ou mais. Dentro da carência as carteiras extras seguem abertas."""
+    now = now or _utcnow()
+    if user.premium_until is None:
+        return True
+    return now >= user.premium_until + GRACE

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -168,6 +168,39 @@ async def test_register_persists_consent_timestamp(client, db_session):
 
 
 @pytest.mark.asyncio
+async def test_register_grants_a_seven_day_ai_trial(client, db_session):
+    # ADR 0001: o trial é conceito do Norby, não Subscription do Stripe — senão
+    # todo cadastro criaria Customer e Subscription lá, inclusive de quem nunca
+    # paga. Assertivo no banco pelo mesmo motivo do teste de consentimento
+    # acima: o campo não é exposto no UserResponse, e expor agora pré-decidiria
+    # a issue #20, que é quem escolhe como o frontend descobre o plano.
+    from datetime import datetime, timedelta, timezone
+
+    from sqlalchemy import select
+    from app.models.sql_models import User
+
+    antes = datetime.now(timezone.utc)
+    res = await client.post(
+        "/auth/register",
+        json={
+            "name": "Dani",
+            "email": "dani@test.com",
+            "password": "secret123",
+            "accept_privacy": True,
+        },
+    )
+    assert res.status_code == 201, res.text
+
+    user = (
+        await db_session.execute(select(User).where(User.email == "dani@test.com"))
+    ).scalar_one()
+    # Janela em vez de igualdade exata: o cadastro roda bcrypt no meio.
+    assert antes + timedelta(days=7) <= user.ai_trial_ends_at <= datetime.now(timezone.utc) + timedelta(days=7)
+    # E o trial não pode vazar para o teto de carteiras.
+    assert user.premium_until is None
+
+
+@pytest.mark.asyncio
 async def test_register_rejects_password_over_72_bytes(client):
     # bcrypt trunca em 72 bytes. Sem o teto, o sufixo seria ignorado e a senha
     # longa se comportaria como uma senha de 72 bytes disfarçada.

--- a/backend/tests/test_plan.py
+++ b/backend/tests/test_plan.py
@@ -1,0 +1,89 @@
+"""Faixas de acesso do ADR 0001 (issue #44).
+
+`premium_until` é o portão: as quatro faixas do plano são comparações de data,
+não estados guardados. Vocabulário em CONTEXT.md — free, trial de IA, premium,
+vencido, carência, teto de carteiras.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+from app.models.sql_models import User
+from app.services.plan_service import ai_allowed, wallet_cap_applies
+
+AGORA = datetime(2026, 9, 1, 12, 0, tzinfo=timezone.utc)
+
+
+def _user(**campos) -> User:
+    # Objeto solto, sem sessão: os predicados são funções puras sobre o User.
+    return User(name="Fulano", email="fulano@test.com", password_hash="x", **campos)
+
+
+def test_free_user_without_a_trial_has_no_ai():
+    free = _user(premium_until=None, ai_trial_ends_at=None)
+    assert ai_allowed(free, AGORA) is False
+
+
+def test_user_inside_the_ai_trial_has_ai():
+    em_trial = _user(premium_until=None, ai_trial_ends_at=AGORA + timedelta(days=3))
+    assert ai_allowed(em_trial, AGORA) is True
+
+
+def test_active_premium_has_ai_even_with_the_trial_long_gone():
+    # O trial venceu meses atrás; quem paga não depende dele.
+    premium = _user(
+        premium_until=AGORA + timedelta(days=10),
+        ai_trial_ends_at=AGORA - timedelta(days=90),
+    )
+    assert ai_allowed(premium, AGORA) is True
+
+
+def test_lapsed_subscription_loses_ai_immediately():
+    # Decisão travada: no vencimento a IA para na hora. O que ganha carência
+    # de 72h é o teto de carteiras, não a IA.
+    vencido = _user(
+        premium_until=AGORA - timedelta(minutes=1),
+        ai_trial_ends_at=AGORA - timedelta(days=90),
+    )
+    assert ai_allowed(vencido, AGORA) is False
+
+
+def test_free_user_is_capped_at_two_wallets():
+    free = _user(premium_until=None, ai_trial_ends_at=None)
+    assert wallet_cap_applies(free, AGORA) is True
+
+
+def test_trial_user_is_still_capped_at_two_wallets():
+    # O trial concede SÓ IA. Confundir os dois inverteria o teto.
+    em_trial = _user(premium_until=None, ai_trial_ends_at=AGORA + timedelta(days=3))
+    assert wallet_cap_applies(em_trial, AGORA) is True
+
+
+def test_active_premium_has_no_wallet_cap():
+    premium = _user(premium_until=AGORA + timedelta(days=10))
+    assert wallet_cap_applies(premium, AGORA) is False
+
+
+def test_lapsed_inside_the_grace_window_keeps_the_extra_wallets():
+    # Refinamento do #19: a IA para no vencimento, mas as carteiras extras
+    # sobrevivem 72h. Bloquear carteira de quem teve o cartão expirado tira a
+    # pessoa dos próprios dados na pior hora possível.
+    vencido = _user(premium_until=AGORA - timedelta(hours=1))
+    assert wallet_cap_applies(vencido, AGORA) is False
+
+
+def test_lapsed_past_the_grace_window_is_capped_again():
+    vencido = _user(premium_until=AGORA - timedelta(days=4))
+    assert wallet_cap_applies(vencido, AGORA) is True
+
+
+def test_at_the_exact_instant_the_period_ends_ai_stops_and_wallets_do_not():
+    # Borda da tabela do ADR: `premium_until <= now < premium_until + GRACE`.
+    expirando = _user(premium_until=AGORA)
+    assert ai_allowed(expirando, AGORA) is False
+    assert wallet_cap_applies(expirando, AGORA) is False
+
+
+def test_at_the_exact_end_of_the_grace_window_the_cap_returns():
+    # Borda da tabela do ADR: `now >= premium_until + GRACE`.
+    vencido = _user(premium_until=AGORA - timedelta(hours=72))
+    assert wallet_cap_applies(vencido, AGORA) is True


### PR DESCRIPTION
Wave 4 of #15, first ticket. The schema half of ADR 0001.

Closes #44.

No Stripe call, no endpoint, and **nothing enforced yet** — where the gates get applied is #20, which has not been decided.

## `premium_until` is the gate

Stripe does not move `current_period_end` when a card fails; it retries inside the period the user already paid for. So that one timestamp answers "does this account have access right now", and a lost webhook can only let access lapse, never grant it.

The four tiers are date comparisons rather than stored state, which is why a single nullable column expresses all of them:

| condition | wallets | AI |
|---|---|---|
| `premium_until IS NULL` | capped at 2 | only while `ai_trial_ends_at > now` |
| `now < premium_until` | unlimited | yes |
| `premium_until <= now < premium_until + 72h` | unlimited | no |
| `now >= premium_until + 72h` | capped at 2 | no |

AI stops the instant the period ends; only the wallet cap gets the grace window. `GRACE` is 72 exact hours rather than calendar days, because `premium_until` is an instant from Stripe and calendar days would need a timezone this model does not have to carry.

`ai_allowed` and `wallet_cap_applies` take an optional `now`. That is not a test hook: "was this user premium at instant T" is a question the admin area (#23) will ask. Production callers omit it.

## The trial is a Norby concept

`ai_trial_ends_at` is written at registration. A Stripe trial would have created a Customer and a Subscription for every signup including those who never pay, and coupled registration to an external call that can fail. It also settles the retroactive-trial requirement for free: the migration leaves the column `NULL` on existing rows, and `NULL` means no trial. The trial grants **AI only** — a trialing user is still capped at 2 wallets, and there is a test pinning that, because confusing the two would invert the cap.

## The events table stores a projection

`checkout.session.completed` carries `customer_details.email`. Storing the raw event would put personal data outside the reach of `delete_account`, and `LGPD.md` treats deletion as a right. Idempotency only ever needed the unique `event_id`, which is the primary key here.

## Three fixes by hand in the generated migration

Autogenerate again swept in the two **pre-existing** drift items that migrations `1c1a72a15b9e` and `764bc1132df0` had already refused:

- `recurring_transactions.active` — it wanted to drop the server default, which would break any insert that omits the column.
- `refresh_tokens.token_hash` — it wanted to swap the unique constraint for a unique index. Touching a session table's index inside a billing migration couples two risks for nothing.

And one bug of its own: it emitted `create_unique_constraint(None, ...)`, whose matching `drop_constraint(None, ...)` in the downgrade **would have failed**, since there is no constraint named `None`. Named explicitly as `uq_users_stripe_customer_id`.

## Verification

The suite builds its schema with `Base.metadata.create_all`, so **it would pass over a broken migration** — while production runs `alembic upgrade head` on boot under `set -e`, where a broken migration means the container does not start. So the migration was exercised by hand inside the container:

1. `upgrade head` → seven columns present, `cancel_at_period_end` NOT NULL defaulting to false, `ix_users_premium_until` and `uq_users_stripe_customer_id` created, `stripe_webhook_events` created
2. `downgrade -1` → all of it gone, and both drift items verified untouched (`active` still defaults to `true`, `refresh_tokens` still has its unique constraint and non-unique index)
3. `upgrade head` again
4. `alembic check` → reports **only** those two pre-existing items, so the new columns match the models exactly and the constraint naming introduces no drift

184 backend tests, up from 172. Eleven of the new ones cover the four tiers plus both boundaries — the exact instant the period ends, and the exact end of the grace window — with the expected values taken from the ADR table rather than from the implementation.

## Worth its own ticket

`alembic check` is a ready-made drift detector, and this is now the **third migration in a row** that has to manually exclude the same two items. That is a recurring tax on every future migration, and it is one command away from being a CI gate once the two are resolved. Not done here — one of them changes an existing default, which `AGENTS.md` says needs the owner's confirmation.
