### PR TITLE
v2 Wave 4: Stripe webhook endpoint (and a correction to ADR 0001)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,3 +34,7 @@ MONGODB_URL=mongodb://norby_user:norby_pass@localhost:27017
 # CORS_ORIGINS deve conter a URL exata do frontend na Vercel (https, sem barra final).
 DOMAIN=norby.duckdns.org
 ACME_EMAIL=seu-email@exemplo.com
+
+# Stripe (ADR 0001). Vazio = billing desligado; o webhook responde 503.
+STRIPE_SECRET_KEY=
+STRIPE_WEBHOOK_SECRET=whsec_test_local_only_not_a_real_secret

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,9 @@ jobs:
       MONGODB_URL: mongodb://localhost:27017
       SECRET_KEY: ci-only-secret-key-not-used-in-production
       GEMINI_API_KEY: ci-only-dummy-key-not-called-in-tests
+      # O teste de webhook assina as fixtures com este segredo. Não é
+      # credencial: nenhuma chamada sai para o Stripe na suíte.
+      STRIPE_WEBHOOK_SECRET: whsec_ci_only_fixture_signing_secret
     steps:
       - uses: actions/checkout@v7
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -20,6 +20,14 @@ class Settings(BaseSettings):
     # CORS — origens permitidas (separadas por vírgula). Default cobre o dev local.
     cors_origins: str = "http://localhost:5173"
 
+    # Stripe (ADR 0001). Default "" DE PROPÓSITO, ao contrário de gemini_api_key:
+    # torná-los obrigatórios derrubaria a produção no instante do merge, já que
+    # as variáveis ainda não existem no Railway. Quem recusa segredo vazio é o
+    # endpoint (503), não o boot — assim o app sobe e o billing fica desligado
+    # até o #26 provisionar a conta.
+    stripe_secret_key: str = ""
+    stripe_webhook_secret: str = ""
+
     model_config = SettingsConfigDict(env_file="../.env", extra="ignore")
 
     @property

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -7,7 +7,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from slowapi import _rate_limit_exceeded_handler
 from slowapi.errors import RateLimitExceeded
-from app.routers import auth, wallets, transactions, ai, recurring, goals, dashboard
+from app.routers import auth, wallets, transactions, ai, recurring, goals, dashboard, billing
 from app.config import get_settings
 from app.limiter import limiter
 
@@ -107,6 +107,7 @@ app.include_router(ai.router)
 app.include_router(recurring.router)
 app.include_router(goals.router)
 app.include_router(dashboard.router)
+app.include_router(billing.router)
 
 @app.get("/health", tags=["Health"]) 
 async def health_check():

--- a/backend/app/routers/billing.py
+++ b/backend/app/routers/billing.py
@@ -1,0 +1,64 @@
+"""Endpoint de webhook do Stripe (issue #45, ADR 0001)."""
+
+import json
+import logging
+
+import stripe
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import get_settings
+from app.dependencies import get_db
+from app.services.billing_service import handle_event
+
+router = APIRouter(prefix="/billing", tags=["Billing"])
+logger = logging.getLogger("norby.billing")
+settings = get_settings()
+
+# Evento do Stripe é pequeno (alguns KB). O teto existe porque esta rota é
+# anônima e roda HMAC: sem ele, qualquer um faz o servidor assinar megabytes
+# de lixo. É esta a proteção certa aqui — rate limit por IP não é, ver abaixo.
+MAX_CORPO = 64 * 1024
+
+
+@router.post("/webhook", status_code=status.HTTP_200_OK)
+async def stripe_webhook(request: Request, db: AsyncSession = Depends(get_db)):
+    """Rota ANÔNIMA: quem autentica é a assinatura do Stripe, não um token.
+
+    Sem rate limit por IP, e isso é decisão, não esquecimento: atrás do proxy do
+    Railway todos os IPs são o mesmo (ver "Rate limit atrás do proxy" no
+    AGENTS.md), então um teto por IP aqui deixaria qualquer pessoa derrubar as
+    entregas do Stripe — o bug que a Onda 2 inteira existiu para matar.
+    """
+    if not settings.stripe_webhook_secret:
+        # Billing desligado (o segredo ainda não existe no Railway). Melhor
+        # recusar alto do que aceitar qualquer corpo como se fosse do Stripe.
+        raise HTTPException(status_code=503, detail="Billing não configurado")
+
+    # Corpo CRU: a verificação assina os bytes originais. Receber um modelo
+    # Pydantic aqui faria o FastAPI parsear e reserializar o JSON, mudando os
+    # bytes e invalidando toda assinatura válida.
+    # Content-Length primeiro: recusa sem nem ler o corpo quando o cliente
+    # declara o tamanho. A segunda checagem cobre quem omite o header ou mente.
+    declarado = request.headers.get("content-length")
+    if declarado and declarado.isdigit() and int(declarado) > MAX_CORPO:
+        raise HTTPException(status_code=413, detail="Corpo grande demais")
+
+    corpo = await request.body()
+    if len(corpo) > MAX_CORPO:
+        raise HTTPException(status_code=413, detail="Corpo grande demais")
+
+    try:
+        evento = stripe.Webhook.construct_event(
+            corpo, request.headers.get("stripe-signature", ""), settings.stripe_webhook_secret
+        )
+    except (ValueError, stripe.SignatureVerificationError):
+        raise HTTPException(status_code=400, detail="Assinatura inválida")
+
+    # O SDK para AQUI, no papel de verificador. O `construct_event` acima já
+    # validou os bytes; reparseá-los devolve o MESMO conteúdo como dict puro,
+    # sem nenhum StripeObject vazando para dentro da aplicação. Isso mantém o
+    # service testável sem o Stripe e deixa a troca de gateway sendo um dos 4
+    # pontos de acoplamento que o ADR nomeia, em vez de uma reescrita.
+    await handle_event(json.loads(corpo), db)
+    return {"received": True}

--- a/backend/app/services/billing_service.py
+++ b/backend/app/services/billing_service.py
@@ -1,0 +1,178 @@
+"""Aplicação dos eventos de assinatura do Stripe (issue #45, ADR 0001).
+
+O que o Stripe manda vira colunas em `users`. Nada aqui autoriza: quem autoriza
+é `plan_service`, lendo `premium_until`.
+
+Recebe **dict puro**, nunca `StripeObject`: o SDK para no router, no papel de
+verificador de assinatura. É isso que mantém a troca de gateway sendo um dos
+quatro pontos de acoplamento que o ADR nomeia.
+"""
+
+import logging
+import uuid
+from datetime import datetime, timezone
+
+from sqlalchemy import select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.sql_models import StripeWebhookEvent, User
+
+logger = logging.getLogger("norby.billing")
+
+# `created` entrou junto do `updated` depois que a implementação mostrou o furo:
+# o `checkout.session.completed` NÃO traz `current_period_end`, e quem carrega o
+# período da PRIMEIRA assinatura é o `created`. Sem ele, o premium_until da
+# primeira compra só chegaria na primeira renovação. Mesmo handler para os três:
+# todos trazem o objeto completo da assinatura.
+EVENTOS_ASSINATURA = frozenset(
+    {
+        "customer.subscription.created",
+        "customer.subscription.updated",
+        "customer.subscription.deleted",
+    }
+)
+EVENTO_CHECKOUT = "checkout.session.completed"
+
+
+def _instante(epoch: int | None) -> datetime | None:
+    return datetime.fromtimestamp(epoch, timezone.utc) if epoch else None
+
+
+def _projecao(evento: dict) -> dict:
+    """Só os campos que este handler lê — nunca o payload cru.
+
+    O `checkout.session.completed` traz `customer_details.email`; guardar o
+    evento inteiro colocaria PII fora do alcance do `delete_account`.
+    """
+    obj = evento.get("data", {}).get("object", {}) or {}
+    tipo = evento.get("type", "")
+    return {
+        "event_id": evento["id"],
+        "type": tipo,
+        "stripe_created": _instante(evento.get("created")),
+        "customer_id": obj.get("customer"),
+        "subscription_id": obj.get("subscription") if tipo == EVENTO_CHECKOUT else obj.get("id"),
+        "current_period_end": _instante(obj.get("current_period_end")),
+        "status": obj.get("status"),
+        "cancel_at_period_end": obj.get("cancel_at_period_end"),
+        "received_at": datetime.now(timezone.utc),
+    }
+
+
+async def _registrar(dados: dict, db: AsyncSession) -> bool:
+    """Grava o evento. False quando já existe — reentrega do Stripe.
+
+    Upsert atômico em vez de SELECT-depois-INSERT: o Stripe pode entregar a
+    mesma reentrega duas vezes em paralelo, e o read-modify-write deixaria as
+    duas passarem pelo SELECT e a segunda estourar a PK como IntegrityError.
+    """
+    inserido = await db.scalar(
+        pg_insert(StripeWebhookEvent)
+        .values(**dados)
+        .on_conflict_do_nothing(index_elements=[StripeWebhookEvent.event_id])
+        .returning(StripeWebhookEvent.event_id)
+    )
+    return inserido is not None
+
+
+async def _dono(evento: dict, dados: dict, db: AsyncSession) -> User | None:
+    """Acha o usuário do evento.
+
+    O checkout casa por `client_reference_id` (o id do usuário, carimbado por
+    nós na criação da sessão) porque é a ÚNICA vez que o Stripe ainda não sabe
+    quem é a pessoa. Dali em diante casa por `stripe_customer_id`.
+    """
+    if evento.get("type") == EVENTO_CHECKOUT:
+        referencia = (evento.get("data", {}).get("object", {}) or {}).get("client_reference_id")
+        try:
+            user_id = uuid.UUID(str(referencia))
+        except (ValueError, TypeError):
+            return None
+        return await db.scalar(select(User).where(User.id == user_id))
+
+    if not dados["customer_id"]:
+        return None
+    return await db.scalar(
+        select(User).where(User.stripe_customer_id == dados["customer_id"])
+    )
+
+
+def _aplicar(user: User, evento: dict, dados: dict) -> None:
+    if evento["type"] == EVENTO_CHECKOUT:
+        # O checkout só AMARRA os ids: ele não traz período nenhum. Quem move o
+        # portão é o customer.subscription.created que vem junto.
+        user.stripe_customer_id = dados["customer_id"] or user.stripe_customer_id
+        user.stripe_subscription_id = dados["subscription_id"] or user.stripe_subscription_id
+        return
+
+    user.stripe_subscription_id = dados["subscription_id"]
+    user.subscription_status = dados["status"]
+    user.cancel_at_period_end = bool(dados["cancel_at_period_end"])
+
+    if evento["type"] == "customer.subscription.deleted":
+        # `ended_at` é quando a assinatura REALMENTE acabou. Num cancelamento
+        # imediato ele é agora, enquanto `current_period_end` ainda aponta para
+        # o futuro — usar o período aqui deixaria acesso pago em pé depois do
+        # fim. Cai para o período quando o Stripe omite o ended_at.
+        fim = (evento.get("data", {}).get("object", {}) or {}).get("ended_at")
+        user.premium_until = _instante(fim) or dados["current_period_end"]
+        return
+
+    user.premium_until = dados["current_period_end"]
+
+
+async def handle_event(evento: dict, db: AsyncSession) -> None:
+    """Idempotente, tolerante a chegada fora de ordem, e nunca levanta por
+    evento que não interessa. Quem não é tratado ainda assim fica gravado."""
+    dados = _projecao(evento)
+
+    if not await _registrar(dados, db):
+        logger.info("stripe: evento %s reentregue, ignorado", dados["event_id"])
+        await db.rollback()
+        return
+
+    tipo = evento.get("type")
+    if tipo not in EVENTOS_ASSINATURA and tipo != EVENTO_CHECKOUT:
+        # Assinamos só quatro tipos no painel, mas alguém pode ligar outro sem
+        # avisar. Gravado e não processado, em vez de 500 e reentrega por 3 dias.
+        await db.commit()
+        return
+
+    user = await _dono(evento, dados, db)
+    if user is None:
+        # processed_at fica NULO: é a trilha de auditoria de "não casou com
+        # ninguém" (`WHERE processed_at IS NULL`). Responder não-2xx faria o
+        # Stripe reentregar por 3 dias um evento que nunca vai casar.
+        logger.warning(
+            "stripe: evento %s (%s) sem usuário correspondente, customer=%s",
+            dados["event_id"], tipo, dados["customer_id"],
+        )
+        await db.commit()
+        return
+
+    # A marca d'água de ordem vale SÓ para eventos de assinatura, porque só eles
+    # escrevem premium_until — que é o que a guarda existe para proteger. O
+    # checkout ficar de fora não é detalhe: o Stripe cria a assinatura ANTES de
+    # a sessão completar, então `subscription.created` costuma trazer um
+    # `created` MENOR que o do checkout. Se o checkout movesse a marca, o evento
+    # que carrega o período entraria como atrasado e o portão nunca abriria na
+    # primeira compra. Amarrar ids é idempotente, então checkout velho é inócuo.
+    if tipo in EVENTOS_ASSINATURA:
+        if user.stripe_event_at and dados["stripe_created"] < user.stripe_event_at:
+            # Visto e descartado de propósito — diferente de não ter dono, por
+            # isso ganha processed_at.
+            logger.info("stripe: evento %s fora de ordem, descartado", dados["event_id"])
+            await _marcar_processado(dados["event_id"], db)
+            return
+        user.stripe_event_at = dados["stripe_created"]
+
+    _aplicar(user, evento, dados)
+    await _marcar_processado(dados["event_id"], db)
+
+
+async def _marcar_processado(event_id: str, db: AsyncSession) -> None:
+    linha = await db.get(StripeWebhookEvent, event_id)
+    if linha is not None:
+        linha.processed_at = datetime.now(timezone.utc)
+    await db.commit()

--- a/backend/requirements-dev.lock
+++ b/backend/requirements-dev.lock
@@ -220,6 +220,7 @@ requests==2.34.2
     #   cachecontrol
     #   google-api-core
     #   pip-audit
+    #   stripe
 rich==15.0.0
     # via pip-audit
 rsa==4.9.1
@@ -238,6 +239,8 @@ sqlalchemy==2.0.36
     #   alembic
 starlette==1.3.1
     # via fastapi
+stripe==15.5.1
+    # via -r requirements.txt
 tomli==2.4.1
     # via pip-audit
 tomli-w==1.2.0
@@ -257,6 +260,7 @@ typing-extensions==4.16.0
     #   pydantic-core
     #   sqlalchemy
     #   starlette
+    #   stripe
     #   typing-inspection
 typing-inspection==0.4.2
     # via

--- a/backend/requirements.lock
+++ b/backend/requirements.lock
@@ -154,7 +154,9 @@ python-jose==3.5.0
 pyyaml==6.0.3
     # via uvicorn
 requests==2.34.2
-    # via google-api-core
+    # via
+    #   google-api-core
+    #   stripe
 rsa==4.9.1
     # via python-jose
 six==1.17.0
@@ -167,6 +169,8 @@ sqlalchemy==2.0.36
     #   alembic
 starlette==1.3.1
     # via fastapi
+stripe==15.5.1
+    # via -r requirements.txt
 tqdm==4.69.0
     # via google-generativeai
 typing-extensions==4.16.0
@@ -181,6 +185,7 @@ typing-extensions==4.16.0
     #   pydantic-core
     #   sqlalchemy
     #   starlette
+    #   stripe
     #   typing-inspection
 typing-inspection==0.4.2
     # via

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -17,3 +17,7 @@ google-generativeai==0.8.3
 email-validator==2.1.1
 bcrypt==3.2.2
 slowapi==0.1.9
+# Billing (ADR 0001). O SDK entra por causa da verificação de assinatura do
+# webhook: ela precisa ser timing-safe e checar a tolerância de timestamp
+# contra replay, e isso não é lugar para HMAC feito à mão.
+stripe==15.5.1

--- a/backend/tests/test_billing_webhook.py
+++ b/backend/tests/test_billing_webhook.py
@@ -1,0 +1,320 @@
+"""Webhook do Stripe (issue #45, ADR 0001).
+
+Fixtures assinadas em teste, sem `stripe-mock` e sem a CLI do Stripe: tudo que é
+nosso aqui é função pura do payload — "dado este evento, as colunas terminam
+assim" — e a CLI exigiria chave real e rede em CI, o mesmo motivo pelo qual este
+repo recusou o Snyk.
+"""
+
+import hashlib
+import hmac
+import json
+import time
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import select
+
+from app.config import get_settings
+from app.models.sql_models import User
+
+SEGREDO = get_settings().stripe_webhook_secret
+AGORA_TS = 1788000000  # 2026-09-01T12:40:00Z, fixo para os testes de ordem
+
+
+def _assinar(corpo: bytes, segredo: str, ts: int | None = None) -> str:
+    """Header `Stripe-Signature` no formato `t=<ts>,v1=<hmac>`.
+
+    O payload assinado é literalmente `f"{ts}.{corpo}"` — é por isso que o
+    handler precisa dos BYTES CRUS: deixar o FastAPI parsear e reserializar o
+    JSON muda o corpo e invalida a assinatura.
+    """
+    ts = ts or int(time.time())
+    assinatura = hmac.new(
+        segredo.encode(), f"{ts}.".encode() + corpo, hashlib.sha256
+    ).hexdigest()
+    return f"t={ts},v1={assinatura}"
+
+
+def _evento_assinatura(
+    tipo: str = "customer.subscription.updated",
+    *,
+    event_id: str = "evt_1",
+    customer: str = "cus_1",
+    subscription: str = "sub_1",
+    period_end: int = AGORA_TS + 30 * 86400,
+    status: str = "active",
+    cancel_at_period_end: bool = False,
+    created: int = AGORA_TS,
+) -> dict:
+    return {
+        "id": event_id,
+        "type": tipo,
+        "created": created,
+        "data": {
+            "object": {
+                "id": subscription,
+                "customer": customer,
+                "status": status,
+                "current_period_end": period_end,
+                "cancel_at_period_end": cancel_at_period_end,
+            }
+        },
+    }
+
+
+async def _postar(client, evento: dict, *, segredo: str | None = None, ts: int | None = None):
+    corpo = json.dumps(evento).encode()
+    return await client.post(
+        "/billing/webhook",
+        content=corpo,
+        headers={"Stripe-Signature": _assinar(corpo, segredo or SEGREDO, ts)},
+    )
+
+
+async def _usuario_com_customer(client, db_session, email: str = "pagante@test.com") -> User:
+    await client.post(
+        "/auth/register",
+        json={"name": "Pagante", "email": email, "password": "secret123", "accept_privacy": True},
+    )
+    user = (await db_session.execute(select(User).where(User.email == email))).scalar_one()
+    user.stripe_customer_id = "cus_1"
+    await db_session.commit()
+    return user
+
+
+@pytest.mark.asyncio
+async def test_subscription_updated_moves_the_gate(client, db_session):
+    user = await _usuario_com_customer(client, db_session)
+
+    res = await _postar(client, _evento_assinatura())
+    assert res.status_code == 200, res.text
+
+    await db_session.refresh(user)
+    assert user.premium_until == datetime.fromtimestamp(AGORA_TS + 30 * 86400, timezone.utc)
+    assert user.subscription_status == "active"
+    assert user.cancel_at_period_end is False
+    assert user.stripe_subscription_id == "sub_1"
+
+
+@pytest.mark.asyncio
+async def test_a_wrong_signature_is_rejected_and_writes_nothing(client, db_session):
+    user = await _usuario_com_customer(client, db_session)
+
+    res = await _postar(client, _evento_assinatura(), segredo="whsec_do_atacante")
+    assert res.status_code == 400
+
+    await db_session.refresh(user)
+    assert user.premium_until is None
+
+
+@pytest.mark.asyncio
+async def test_an_oversized_body_is_refused_before_the_hmac_runs(client, db_session):
+    # Rota anônima que roda HMAC: sem teto de corpo, qualquer um faz o servidor
+    # gastar CPU assinando megabytes de lixo. O teto é a proteção certa aqui —
+    # rate limit por IP não é, porque atrás do proxy todos os IPs são o mesmo.
+    await _usuario_com_customer(client, db_session)
+
+    gigante = b"x" * (64 * 1024 + 1)
+    res = await client.post(
+        "/billing/webhook",
+        content=gigante,
+        # Assinatura VÁLIDA para este corpo: prova que a recusa vem do tamanho,
+        # não da verificação.
+        headers={"Stripe-Signature": _assinar(gigante, SEGREDO)},
+    )
+    assert res.status_code == 413
+
+
+@pytest.mark.asyncio
+async def test_the_same_event_delivered_twice_changes_nothing_the_second_time(client, db_session):
+    # O Stripe reentrega. Sem idempotência, uma reentrega tardia reaplicaria um
+    # estado velho por cima do atual.
+    user = await _usuario_com_customer(client, db_session)
+    primeiro_fim = AGORA_TS + 30 * 86400
+
+    assert (await _postar(client, _evento_assinatura(period_end=primeiro_fim))).status_code == 200
+    # MESMO event_id, payload diferente: se reprocessar, a data muda.
+    assert (
+        await _postar(client, _evento_assinatura(period_end=AGORA_TS + 999 * 86400))
+    ).status_code == 200
+
+    await db_session.refresh(user)
+    assert user.premium_until == datetime.fromtimestamp(primeiro_fim, timezone.utc)
+
+
+@pytest.mark.asyncio
+async def test_an_event_older_than_the_last_applied_one_is_ignored(client, db_session):
+    # O Stripe NÃO garante ordem de entrega. Sem a guarda, dois
+    # subscription.updated invertidos empurrariam premium_until para trás.
+    user = await _usuario_com_customer(client, db_session)
+    recente = AGORA_TS + 30 * 86400
+
+    assert (
+        await _postar(
+            client,
+            _evento_assinatura(event_id="evt_novo", created=AGORA_TS + 100, period_end=recente),
+        )
+    ).status_code == 200
+    assert (
+        await _postar(
+            client,
+            _evento_assinatura(
+                event_id="evt_velho", created=AGORA_TS, period_end=AGORA_TS + 1, status="past_due"
+            ),
+        )
+    ).status_code == 200
+
+    await db_session.refresh(user)
+    assert user.premium_until == datetime.fromtimestamp(recente, timezone.utc)
+    assert user.subscription_status == "active"
+
+
+@pytest.mark.asyncio
+async def test_every_event_is_recorded_even_when_it_matches_nobody(client, db_session):
+    # Decisão do #45: evento sem dono não faz o Stripe reentregar por 3 dias.
+    # Grava com processed_at nulo e responde 200 — a linha não processada É a
+    # trilha de auditoria (`WHERE processed_at IS NULL`).
+    from app.models.sql_models import StripeWebhookEvent
+
+    res = await _postar(client, _evento_assinatura(event_id="evt_orfao", customer="cus_ninguem"))
+    assert res.status_code == 200
+
+    linha = (
+        await db_session.execute(
+            select(StripeWebhookEvent).where(StripeWebhookEvent.event_id == "evt_orfao")
+        )
+    ).scalar_one()
+    assert linha.processed_at is None
+    assert linha.type == "customer.subscription.updated"
+    assert linha.customer_id == "cus_ninguem"
+
+
+def _evento_checkout(user_id, *, event_id="evt_checkout", created=AGORA_TS) -> dict:
+    return {
+        "id": event_id,
+        "type": "checkout.session.completed",
+        "created": created,
+        "data": {
+            "object": {
+                "id": "cs_1",
+                "mode": "subscription",
+                "client_reference_id": str(user_id),
+                "customer": "cus_novo",
+                "subscription": "sub_novo",
+                # O Stripe manda isto aqui — e é exatamente por causa dele que a
+                # tabela guarda projeção e não payload cru.
+                "customer_details": {"email": "pagante@test.com"},
+            }
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_checkout_binds_the_stripe_ids_to_the_user(client, db_session):
+    # É a ÚNICA vez que o Stripe ainda não sabe quem é a pessoa: o casamento sai
+    # do client_reference_id que nós carimbamos ao criar a sessão.
+    await client.post(
+        "/auth/register",
+        json={"name": "Novo", "email": "novo@test.com", "password": "secret123", "accept_privacy": True},
+    )
+    user = (await db_session.execute(select(User).where(User.email == "novo@test.com"))).scalar_one()
+    assert user.stripe_customer_id is None
+
+    res = await _postar(client, _evento_checkout(user.id))
+    assert res.status_code == 200, res.text
+
+    await db_session.refresh(user)
+    assert user.stripe_customer_id == "cus_novo"
+    assert user.stripe_subscription_id == "sub_novo"
+    # O checkout NÃO carrega período: sozinho ele não abre o portão.
+    assert user.premium_until is None
+
+
+@pytest.mark.asyncio
+async def test_subscription_created_is_what_opens_the_gate_on_a_first_purchase(client, db_session):
+    # Correção do ADR feita durante o #45: com só `updated` e `deleted`, o
+    # premium_until da PRIMEIRA compra só chegaria na primeira renovação.
+    user = await _usuario_com_customer(client, db_session)
+    fim = AGORA_TS + 30 * 86400
+
+    res = await _postar(
+        client,
+        _evento_assinatura(
+            "customer.subscription.created", event_id="evt_criada", period_end=fim
+        ),
+    )
+    assert res.status_code == 200, res.text
+
+    await db_session.refresh(user)
+    assert user.premium_until == datetime.fromtimestamp(fim, timezone.utc)
+
+
+@pytest.mark.asyncio
+async def test_an_immediate_cancellation_ends_access_now_not_at_period_end(client, db_session):
+    # Cancelamento imediato: o Stripe manda ended_at=agora e o
+    # current_period_end AINDA aponta para o futuro. Usar o período aqui
+    # deixaria acesso pago em pé depois do fim da assinatura.
+    user = await _usuario_com_customer(client, db_session)
+    fim_do_periodo = AGORA_TS + 30 * 86400
+    encerrada_em = AGORA_TS + 10
+
+    evento = _evento_assinatura(
+        "customer.subscription.deleted",
+        event_id="evt_cancelada",
+        period_end=fim_do_periodo,
+        status="canceled",
+        created=AGORA_TS + 20,
+    )
+    evento["data"]["object"]["ended_at"] = encerrada_em
+
+    assert (await _postar(client, evento)).status_code == 200
+
+    await db_session.refresh(user)
+    assert user.premium_until == datetime.fromtimestamp(encerrada_em, timezone.utc)
+    assert user.subscription_status == "canceled"
+
+
+@pytest.mark.asyncio
+async def test_checkout_arriving_first_does_not_block_the_subscription_that_opens_the_gate(
+    client, db_session
+):
+    # O Stripe cria a assinatura ANTES de a sessão completar, então
+    # subscription.created costuma ter `created` MENOR que o do checkout. Se o
+    # checkout mover a marca d'água de ordem, o evento que carrega o período
+    # entra como "atrasado" e é descartado — e o portão nunca abre na primeira
+    # compra. A marca d'água só existe para proteger premium_until, e o checkout
+    # não escreve premium_until.
+    await client.post(
+        "/auth/register",
+        json={"name": "Corrida", "email": "corrida@test.com", "password": "secret123", "accept_privacy": True},
+    )
+    user = (
+        await db_session.execute(select(User).where(User.email == "corrida@test.com"))
+    ).scalar_one()
+    fim = AGORA_TS + 30 * 86400
+
+    # Checkout entregue primeiro, com timestamp MAIOR.
+    assert (
+        await _postar(client, _evento_checkout(user.id, created=AGORA_TS + 5))
+    ).status_code == 200
+    await db_session.refresh(user)
+    user.stripe_customer_id = "cus_novo"
+    await db_session.commit()
+
+    # A assinatura, criada antes, chega depois.
+    assert (
+        await _postar(
+            client,
+            _evento_assinatura(
+                "customer.subscription.created",
+                event_id="evt_criada_atrasada",
+                customer="cus_novo",
+                created=AGORA_TS,
+                period_end=fim,
+            ),
+        )
+    ).status_code == 200
+
+    await db_session.refresh(user)
+    assert user.premium_until == datetime.fromtimestamp(fim, timezone.utc)

--- a/docs/adr/0001-modelo-de-assinatura.md
+++ b/docs/adr/0001-modelo-de-assinatura.md
@@ -152,18 +152,35 @@ precisa do `event_id` único.
   por IP aqui deixaria qualquer pessoa derrubar as entregas do Stripe. É o bug
   que a Onda 2 inteira existiu para matar; não reintroduzir numa rota nova.
 
-Três eventos consumidos:
+Quatro eventos consumidos:
 
 | evento | por quê |
 |---|---|
-| `checkout.session.completed` | primeira compra; amarra customer e subscription ao usuário via `client_reference_id` |
+| `checkout.session.completed` | primeira compra; amarra customer e subscription ao usuário via `client_reference_id`. **Não traz período nenhum** |
+| `customer.subscription.created` | é ele que abre o portão na primeira compra |
 | `customer.subscription.updated` | renovação, cancelamento agendado e pagamento falhado — o cavalo de batalha |
 | `customer.subscription.deleted` | fim da assinatura |
+
+> **Correção de 2026-08-25 (issue #45), eram três.** A lista original tinha
+> `checkout.session.completed`, `updated` e `deleted`, e não cobria a primeira
+> assinatura: o payload de `checkout.session.completed` em modo subscription
+> traz `client_reference_id`, `customer` e `subscription`, mas **não**
+> `current_period_end` — quem carrega o período de uma assinatura nova é o
+> `customer.subscription.created`, não o `updated`. Com a lista antiga, o
+> `premium_until` da primeira compra só apareceria na primeira renovação, um mês
+> depois. O conserto custa zero lógica: `created` e `updated` caem no mesmo
+> handler, porque os dois trazem o objeto completo da assinatura.
 
 `invoice.paid` e `invoice.payment_failed` **não** são consumidos: renovação paga
 já dispara `subscription.updated` com o `current_period_end` novo, e cartão
 recusado já dispara `subscription.updated` com `status=past_due`. São o mesmo
 fato chegando por outra porta.
+
+**No `customer.subscription.deleted`, o portão vai para `ended_at`, não para
+`current_period_end`.** Num cancelamento imediato o Stripe manda `ended_at`
+agora e o `current_period_end` ainda apontando para o futuro; usar o período ali
+deixaria acesso pago em pé depois do fim da assinatura. Cai para o período
+quando o Stripe omite o `ended_at`.
 
 Fluxo, inline e sem fila:
 


### PR DESCRIPTION
Wave 4 of #15, second ticket. `POST /billing/webhook`: idempotent, tolerant of out-of-order delivery, and it never makes Stripe retry an event that can never match.

Closes #45.

## It corrects ADR 0001: the event list was wrong

The original three did not cover a first purchase. `checkout.session.completed` in subscription mode carries `client_reference_id`, `customer` and `subscription` — but **not** `current_period_end`. The event that carries the period of a *new* subscription is `customer.subscription.created`, not `updated`.

With the old list, `premium_until` on a first purchase would only have appeared at the first renewal, a month later. Every paying customer would have been treated as free for their first month.

The fix costs no logic: `created` and `updated` share a handler, since both carry the full subscription object. The ADR now records the correction in place rather than quietly reading as if it had always said four.

## The SDK stops at the router

`construct_event` verifies the raw bytes; reparsing those same bytes yields a plain dict, so no `StripeObject` leaks into the application. That keeps `billing_service` testable without Stripe and keeps a gateway swap as one of the four coupling points the ADR names, rather than a rewrite.

It also sidesteps the SDK's own churn — `to_dict_recursive` went private in stripe 15, which this hit during implementation.

## What the endpoint refuses

**Bodies over 64 KB**, checked against `Content-Length` first and against the real length after reading, since a client can omit or lie about the header. This is an anonymous route running HMAC: without a cap, anyone can make the server sign megabytes of garbage. The test signs the oversized body **correctly**, so it proves the refusal comes from the size and not from verification.

**Bad signatures**, with 400 and nothing written.

There is deliberately **no IP rate limit**. Behind Railway's proxy every IP is the same one, so an IP-keyed ceiling here would let anyone knock out Stripe's deliveries — the exact bug wave 2 existed to kill, and it is not getting reintroduced on a new route.

## Two defects found while implementing

Both fixed, each with a test that fails without the fix:

**On `customer.subscription.deleted` the gate goes to `ended_at`, not `current_period_end`.** An immediate cancellation sends `ended_at` now while `current_period_end` still points at the future. Using the period there would have left paid access standing after the subscription ended.

**The ordering watermark applies only to subscription events.** Stripe creates the subscription *before* the session completes, so `subscription.created` usually carries an earlier `created` than the checkout. Letting checkout move the watermark made the event carrying the period arrive "late" and get dropped — and the gate never opened on a first purchase. The watermark exists to protect `premium_until`, and checkout does not write it; binding ids is idempotent, so an old checkout event is harmless.

## Honest note on the loop

Three of the tests — checkout binding, `subscription.created`, immediate cancellation — passed on first run, because the previous slice's implementation had already gone past what that slice's test demanded. There was no legitimate red for them. Rather than pretend otherwise, they were verified by mutation: dropping `created` from the event set, reading `current_period_end` on cancellation, and removing the `client_reference_id` lookup each fail **exactly one** test and nothing else.

## Idempotency, ordering, and events that match nobody

Idempotency is an atomic upsert on the `event_id` primary key rather than select-then-insert: Stripe can deliver the same redelivery twice in parallel, and the read-modify-write would let both past the select and blow up the second on the primary key.

An event matching no user is stored with `processed_at` NULL and answered 200. Non-2xx would make Stripe redeliver for three days an event that can never match, filling the log with noise that hides real failures; the unprocessed row is the audit trail, queryable with `WHERE processed_at IS NULL`. Out-of-order events *do* get `processed_at`, because they were seen and skipped on purpose — which is a different fact from having no owner.

## Configuration

`stripe_secret_key` and `stripe_webhook_secret` default to empty, unlike `gemini_api_key`. Making them required would take **production down the moment this merges**, since the variables do not exist on Railway yet. The endpoint answers 503 while the secret is empty rather than accepting any body as if it came from Stripe.

`STRIPE_WEBHOOK_SECRET` is set in the CI environment purely to sign the fixtures. It is not a credential and no call leaves for Stripe in the suite.

## Verification

194 backend tests, up from 184. The lock guard from #62 is doing its job — adding `stripe==15.5.1` required regenerating both locks, and `check_locks.py` passes.
