### PR TITLE
v2 Wave 4: cancel at Stripe before deleting the account

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -276,7 +276,12 @@ nunca esgota o próprio balde).
   também esbarra na curva de atraso por conta (teto global subiu de 5/min
   para 60/min, mas cada tentativa repetida no mesmo email entra na fila).
 - Exclusão de conta apaga o Mongo antes do Postgres, sem transação distribuída.
-  Falha no commit do SQL deixaria a conta viva sem os dados de IA.
+  Falha no commit do SQL deixaria a conta viva sem os dados de IA. Desde a
+  issue #47 são **três** sistemas: o Stripe vem primeiro e recusa dele **aborta
+  a exclusão inteira** (502, nada apagado). A ordem vem da assimetria das
+  falhas — exclusão que falhou é recuperável, cartão cobrado por conta que não
+  existe mais vira chargeback sem botão de cancelar. A janela entre Mongo e
+  Postgres continua aberta e continua aceita.
 - `/docs` fica público: todos os endpoints por trás dele exigem autenticação, e
   a documentação navegável é um ativo para o portfólio.
 - Usuários criados antes da migration `b2c3d4e5f6a7` têm `privacy_accepted_at`

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -21,6 +21,7 @@ from app.services.auth_service import (
     _DUMMY_HASH,
 )
 from app.services.account_service import delete_account, export_data
+from app.services.billing_service import GatewayCancelFailed
 from app.services.plan_service import AI_TRIAL
 from app.services.throttle_service import check_throttle, record_failure, record_success
 
@@ -278,4 +279,17 @@ async def delete_my_account(
     if not password_ok:
         raise HTTPException(status_code=401, detail="Senha incorreta")
 
-    await delete_account(current_user, db)
+    try:
+        await delete_account(current_user, db)
+    except GatewayCancelFailed as erro:
+        # Assinatura viva e o Stripe recusou o cancelamento: NADA é apagado.
+        # Falha de exclusão é recuperável (a pessoa tenta de novo); cartão
+        # cobrado por conta inexistente não é.
+        logger.error("falha ao cancelar assinatura no gateway: %s", erro)
+        raise HTTPException(
+            status_code=502,
+            detail=(
+                "Não foi possível cancelar sua assinatura agora, então nada foi "
+                "excluído. Tente novamente em alguns minutos."
+            ),
+        )

--- a/backend/app/services/account_service.py
+++ b/backend/app/services/account_service.py
@@ -15,6 +15,7 @@ from app.database import ai_insights_collection, chat_history_collection
 from app.models.sql_models import (
     User, Wallet, Transaction, RecurringTransaction, Goal,
 )
+from app.services.billing_service import cancel_subscription
 
 
 def _row_to_dict(obj) -> dict:
@@ -28,11 +29,25 @@ async def _scoped(db: AsyncSession, model, user_id) -> list[dict]:
 
 
 async def delete_account(user: User, db: AsyncSession) -> None:
-    """Apaga DE VERDADE todos os dados do usuário (Postgres + Mongo).
+    """Apaga DE VERDADE todos os dados do usuário (Stripe + Postgres + Mongo).
 
-    Ordem: Mongo primeiro (sem cascade), Postgres por último (cascade cuida das
-    tabelas filhas, incluindo refresh_tokens — sessões ficam invalidadas).
+    Ordem: **Stripe primeiro**, e recusa dele aborta a exclusão INTEIRA; depois
+    Mongo (sem cascade); Postgres por último (cascade cuida das tabelas filhas,
+    incluindo refresh_tokens — sessões ficam invalidadas).
+
+    A ordem vem da assimetria dos modos de falha, não de gosto: exclusão que
+    falhou é recuperável, basta tentar de novo. Cartão sendo cobrado por uma
+    conta que não existe mais NÃO é — vira chargeback e a pessoa não tem nem
+    onde clicar para cancelar. A LGPD dá direito à exclusão, e uma falha
+    temporária com mensagem honesta não fere isso; continuar cobrando em
+    silêncio, sim.
+
+    Levanta GatewayCancelFailed quando o Stripe recusa. Quem traduz para HTTP
+    é o router.
     """
+    if user.stripe_subscription_id:
+        await cancel_subscription(user.stripe_subscription_id)
+
     user_id = str(user.id)
     await ai_insights_collection.delete_many({"user_id": user_id})
     await chat_history_collection.delete_many({"user_id": user_id})

--- a/backend/app/services/billing_service.py
+++ b/backend/app/services/billing_service.py
@@ -12,6 +12,8 @@ import logging
 import uuid
 from datetime import datetime, timezone
 
+import stripe
+
 from sqlalchemy import select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -176,3 +178,21 @@ async def _marcar_processado(event_id: str, db: AsyncSession) -> None:
     if linha is not None:
         linha.processed_at = datetime.now(timezone.utc)
     await db.commit()
+
+
+class GatewayCancelFailed(Exception):
+    """O gateway recusou o cancelamento. Quem traduz para HTTP é o router —
+    service neste repo não conhece HTTP."""
+
+
+async def cancel_subscription(subscription_id: str) -> None:
+    """Cancela a assinatura no Stripe.
+
+    Única saída para o Stripe neste ticket, e é ela que os testes stubam. Usa
+    a API assíncrona do SDK em vez de `asyncio.to_thread`: a versão síncrona
+    faria uma chamada HTTP bloqueante travar o event loop.
+    """
+    try:
+        await stripe.Subscription.cancel_async(subscription_id)
+    except Exception as erro:  # noqa: BLE001 — rede, credencial ou 4xx do Stripe
+        raise GatewayCancelFailed(str(erro)) from erro

--- a/backend/tests/test_account.py
+++ b/backend/tests/test_account.py
@@ -82,3 +82,87 @@ async def test_delete_account_wipes_postgres_and_mongo(make_auth_client, client,
     # Postgres: a conta sumiu → login com as mesmas credenciais falha.
     login = await client.post("/auth/login", json={"email": email, "password": "secret123"})
     assert login.status_code == 401
+
+
+async def _dar_assinatura(client, db_session, ac, subscription_id="sub_1"):
+    """Marca o usuário autenticado como assinante, direto no banco."""
+    from sqlalchemy import select
+    from app.models.sql_models import User
+
+    me = (await ac.get("/auth/me")).json()
+    user = (await db_session.execute(select(User).where(User.id == me["id"]))).scalar_one()
+    user.stripe_customer_id = "cus_1"
+    user.stripe_subscription_id = subscription_id
+    await db_session.commit()
+    return me
+
+
+@pytest.mark.asyncio
+async def test_deleting_a_subscriber_cancels_at_stripe_first(make_auth_client, db_session, mongo, monkeypatch):
+    import app.services.account_service as acc
+
+    alice = await make_auth_client("Alice")
+    await _dar_assinatura(None, db_session, alice, "sub_da_alice")
+
+    cancelados = []
+
+    async def _falso_cancel(subscription_id):
+        cancelados.append(subscription_id)
+
+    monkeypatch.setattr(acc, "cancel_subscription", _falso_cancel)
+
+    res = await alice.request(
+        "DELETE", "/auth/me", json={"confirm": True, "password": "secret123"}
+    )
+    assert res.status_code == 204
+    assert cancelados == ["sub_da_alice"]
+
+
+@pytest.mark.asyncio
+async def test_a_refusal_from_stripe_aborts_the_whole_deletion(make_auth_client, client, db_session, mongo, monkeypatch):
+    # Assimetria dos modos de falha: exclusão que falhou é recuperável, basta
+    # tentar de novo; cartão cobrado por conta que não existe mais vira
+    # chargeback e a pessoa não tem nem onde clicar para cancelar.
+    import app.services.account_service as acc
+    from app.services.billing_service import GatewayCancelFailed
+
+    alice = await make_auth_client("Alice")
+    me = await _dar_assinatura(None, db_session, alice)
+    user_id, email = me["id"], me["email"]
+    await mongo["chat_history"].insert_one({"user_id": user_id, "session_id": "s1", "messages": []})
+
+    async def _cancel_que_falha(subscription_id):
+        # GatewayCancelFailed é o contrato da fronteira: o cancel_subscription
+        # real embrulha qualquer erro do Stripe nele. Um stub que levanta outra
+        # coisa estaria testando um contrato que não existe.
+        raise GatewayCancelFailed("stripe fora do ar")
+
+    monkeypatch.setattr(acc, "cancel_subscription", _cancel_que_falha)
+
+    res = await alice.request(
+        "DELETE", "/auth/me", json={"confirm": True, "password": "secret123"}
+    )
+    assert res.status_code == 502
+
+    # NADA foi apagado: nem o Mongo (que vem primeiro no fluxo antigo)...
+    assert await mongo["chat_history"].count_documents({"user_id": user_id}) == 1
+    # ...nem o Postgres.
+    login = await client.post("/auth/login", json={"email": email, "password": "secret123"})
+    assert login.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_deleting_a_user_without_a_subscription_calls_no_gateway(make_auth_client, mongo, monkeypatch):
+    import app.services.account_service as acc
+
+    alice = await make_auth_client("Alice")
+
+    async def _nao_deveria_ser_chamado(subscription_id):
+        raise AssertionError("usuário sem assinatura não pode falar com o Stripe")
+
+    monkeypatch.setattr(acc, "cancel_subscription", _nao_deveria_ser_chamado)
+
+    res = await alice.request(
+        "DELETE", "/auth/me", json={"confirm": True, "password": "secret123"}
+    )
+    assert res.status_code == 204


### PR DESCRIPTION
Wave 4 of #15, third ticket.

Closes #47.

`delete_account` now spans three systems, and Stripe goes **first**: a refusal from it aborts the whole deletion with 502 and nothing at all is removed.

## The order is the ticket

It comes from the asymmetry of the failure modes, not from taste.

A failed deletion is recoverable — the person retries. A card charged for an account that no longer exists is not: it becomes a chargeback, and they have nowhere left to click to stop it. LGPD grants a right to deletion, and a temporary failure with an honest message does not breach that; silently continuing to bill does.

## The boundary

`cancel_subscription` is the single outbound call and the one thing the tests stub. Two details worth naming:

- It uses the SDK's **async** API rather than `asyncio.to_thread`. The synchronous version would block the event loop on an HTTP call.
- Any error from Stripe is wrapped in `GatewayCancelFailed`, so the service stays free of HTTP — no service in this repository raises `HTTPException` — and the router maps that **one** exception to 502, rather than catching broadly and swallowing real bugs along with gateway failures.

A user with no `stripe_subscription_id` talks to no gateway at all, asserted with a stub that fails the test if it is ever called.

## Verified by mutation, not by the tests merely passing

- Dropping the cancel call fails both the "cancels first" and the "aborts the deletion" tests.
- Moving the cancel to **after** the Mongo delete still fails the abort test — and that is the whole point of the ticket. With the wrong order, a Stripe refusal leaves the account alive with its AI data already gone: the user loses data *and* keeps being billed.

## One test was corrected rather than the code

Its stub raised `RuntimeError` while the boundary contract is `GatewayCancelFailed`, so the endpoint answered 500 instead of 502. A stub that violates the contract of the thing it replaces is testing a contract that does not exist.

Worth saying plainly: the safety property holds either way. **Any** exception out of that call aborts the deletion, so nothing is ever removed on a gateway failure — only the status code differed.

## Documentation

`AGENTS.md` now records that deletion spans three systems, and that the pre-existing Mongo-before-Postgres window is still open and still accepted. This ticket adds a third system in front of both, in the only order whose failure is recoverable; it does not close that older gap.

197 backend tests, up from 194.
