### PR TITLE
v2 Wave 6: the paywall flag, one wallet helper, and the refusal contract

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,3 +38,6 @@ ACME_EMAIL=seu-email@exemplo.com
 # Stripe (ADR 0001). Vazio = billing desligado; o webhook responde 503.
 STRIPE_SECRET_KEY=
 STRIPE_WEBHOOK_SECRET=whsec_test_local_only_not_a_real_secret
+
+# Paywall da v2 (ADR 0002). Desligado = app se comporta como antes.
+PAYWALL_ENABLED=false

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -28,6 +28,12 @@ class Settings(BaseSettings):
     stripe_secret_key: str = ""
     stripe_webhook_secret: str = ""
 
+    # Flag de rollout do paywall (ADR 0002). Default DESLIGADO: o merge não muda
+    # nada em produção, e o paywall acende por variável de ambiente quando o
+    # dono decidir. Lido SÓ dentro dos helpers de enforcement — um `if` num
+    # lugar não dá pra esquecer, oito dão.
+    paywall_enabled: bool = False
+
     model_config = SettingsConfigDict(env_file="../.env", extra="ignore")
 
     @property

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -8,6 +8,8 @@ from fastapi.responses import JSONResponse
 from slowapi import _rate_limit_exceeded_handler
 from slowapi.errors import RateLimitExceeded
 from app.routers import auth, wallets, transactions, ai, recurring, goals, dashboard, billing
+from app.services.plan_service import PlanRefused
+from app.services.wallet_service import WalletNotFound
 from app.config import get_settings
 from app.limiter import limiter
 
@@ -42,6 +44,26 @@ app = FastAPI(
 # Rate limiting (anti brute-force). Respostas 429 passam pelo CORS normalmente.
 app.state.limiter = limiter
 app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
+
+
+# ADR 0002: os services não conhecem HTTP (nenhum levanta HTTPException). Estes
+# dois handlers são a única tradução, num lugar só — assim qualquer chamador
+# futuro do wallet_service já recebe o status certo sem try/except por router.
+@app.exception_handler(PlanRefused)
+async def _plan_refused_handler(request: Request, exc: PlanRefused) -> JSONResponse:
+    # `detail` em objeto de propósito: o frontend faz switch no `code`, que é
+    # contrato e nunca é reescrito. Header próprio exigiria expose_headers no
+    # CORS — a armadilha que este repo já pisou com o X-Total-Count.
+    return JSONResponse(
+        status_code=403, content={"detail": {"code": exc.code, "message": exc.message}}
+    )
+
+
+@app.exception_handler(WalletNotFound)
+async def _wallet_not_found_handler(request: Request, exc: WalletNotFound) -> JSONResponse:
+    # Inexistente e "de outro dono" respondem igual: distinguir viraria oráculo
+    # de ids alheios.
+    return JSONResponse(status_code=404, content={"detail": "Carteira não encontrada"})
 
 
 # Request-id + captura de exceções não tratadas. Registrado ANTES do CORS para que

--- a/backend/app/routers/recurring.py
+++ b/backend/app/routers/recurring.py
@@ -7,6 +7,7 @@ from app.dependencies import get_db, get_current_user
 from app.models.sql_models import User, Wallet, RecurringTransaction
 from app.schemas.recurring import RecurringCreate, RecurringUpdate, RecurringResponse
 from app.services.recurring_service import compute_initial_next_run, materialize_due_recurring
+from app.services.wallet_service import get_owned_wallet
 
 router = APIRouter(prefix="/recurring", tags=["Recurring"])
 
@@ -25,15 +26,6 @@ async def _get_owned_recurring(
         raise HTTPException(status_code=404, detail="Recorrência não encontrada")
     return rec
 
-
-async def _get_owned_wallet(wallet_id: UUID, user: User, db: AsyncSession) -> Wallet:
-    """Carteira do usuário, ou 404. Sem lock: aqui só validamos ownership."""
-    wallet = (await db.execute(
-        select(Wallet).where(Wallet.id == wallet_id, Wallet.user_id == user.id)
-    )).scalar_one_or_none()
-    if not wallet:
-        raise HTTPException(status_code=404, detail="Carteira não encontrada")
-    return wallet
 
 
 
@@ -60,7 +52,7 @@ async def create_recurring(
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
-    await _get_owned_wallet(payload.wallet_id, current_user, db)
+    await get_owned_wallet(payload.wallet_id, current_user, db, for_write=True)
 
     next_run = compute_initial_next_run(
         payload.frequency, payload.day_of_month, payload.weekday

--- a/backend/app/routers/transactions.py
+++ b/backend/app/routers/transactions.py
@@ -8,6 +8,7 @@ from app.dependencies import get_db, get_current_user
 from app.models.sql_models import User, Transaction, TransactionType, Wallet
 from app.schemas.transaction import TransactionCreate, TransactionUpdate, TransactionResponse
 from app.services.transaction_service import apply_delta, revert_delta
+from app.services.wallet_service import get_owned_wallet
 from app.services.goal_service import current_month_range
 
 router = APIRouter(prefix="/transactions", tags=["Transactions"])
@@ -22,29 +23,6 @@ router = APIRouter(prefix="/transactions", tags=["Transactions"])
 # com um update movendo transação de B para A.
 # Se isso aparecer em produção, ordenar os locks de carteira por UUID nos DOIS
 # caminhos — ordenar só aqui não desfaz o ciclo.
-async def _get_owned_wallet(
-    wallet_id: UUID,
-    user: User,
-    db: AsyncSession,
-    *,
-    for_update: bool = False,
-    required: bool = True,
-) -> Optional[Wallet]:
-    """Carteira do usuário, com lock opcional (with_for_update) p/ mutar saldo.
-
-    Espelha o padrão de `_get_owned_goal` em goals.py. Com required=True (padrão)
-    levanta 404 se não for do usuário; required=False devolve None (usado para a
-    carteira de origem no update, cujo efeito antigo é revertido de forma tolerante).
-    """
-    stmt = select(Wallet).where(Wallet.id == wallet_id, Wallet.user_id == user.id)
-    if for_update:
-        stmt = stmt.with_for_update()
-    wallet = (await db.execute(stmt)).scalar_one_or_none()
-    if wallet is None and required:
-        raise HTTPException(status_code=404, detail="Carteira não encontrada")
-    return wallet
-
-
 async def _get_owned_transaction(transaction_id: UUID, user: User, db: AsyncSession) -> Transaction:
     """Transação do usuário, sempre com lock (FOR UPDATE).
 
@@ -124,7 +102,9 @@ async def create_transaction(
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
-    wallet = await _get_owned_wallet(payload.wallet_id, current_user, db, for_update=True)
+    wallet = await get_owned_wallet(
+        payload.wallet_id, current_user, db, for_update=True, for_write=True
+    )
     apply_delta(wallet, payload.type, payload.amount)
 
     transaction = Transaction(user_id=current_user.id, **payload.model_dump())
@@ -156,15 +136,28 @@ async def update_transaction(
 
     # Carteira de origem (onde o efeito antigo está aplicado). Tolerante a None:
     # preserva o comportamento defensivo anterior.
-    old_wallet = await _get_owned_wallet(
-        transaction.wallet_id, current_user, db, for_update=True, required=False
+    #
+    # `for_write` depende de a transação FICAR ou SAIR (ADR 0002): continuar numa
+    # carteira bloqueada é escrever nela, e é recusado; sair dela é drenar, e é
+    # permitido. Sem essa saída, quem virou free escolheria entre pagar e
+    # destruir histórico, já que excluir carteira apaga as transações por cascade.
+    mesma_carteira = new_wallet_id == transaction.wallet_id
+    old_wallet = await get_owned_wallet(
+        transaction.wallet_id,
+        current_user,
+        db,
+        for_update=True,
+        required=False,
+        for_write=mesma_carteira,
     )
 
-    # Carteira de destino (pode ser a mesma)
-    if new_wallet_id == transaction.wallet_id:
+    # Carteira de destino (pode ser a mesma). Destino é SEMPRE escrita.
+    if mesma_carteira:
         new_wallet = old_wallet
     else:
-        new_wallet = await _get_owned_wallet(new_wallet_id, current_user, db, for_update=True)
+        new_wallet = await get_owned_wallet(
+            new_wallet_id, current_user, db, for_update=True, for_write=True
+        )
 
     # 1) Reverte o efeito antigo (usa os valores AINDA não alterados da transação)
     if old_wallet:
@@ -191,7 +184,9 @@ async def delete_transaction(
 ):
     transaction = await _get_owned_transaction(transaction_id, current_user, db)
 
-    wallet = await _get_owned_wallet(
+    # Sem for_write: apagar transação de dentro de carteira bloqueada drena, e
+    # drenar é permitido (ADR 0002).
+    wallet = await get_owned_wallet(
         transaction.wallet_id, current_user, db, for_update=True, required=False
     )
     if wallet:

--- a/backend/app/routers/wallets.py
+++ b/backend/app/routers/wallets.py
@@ -5,18 +5,9 @@ from uuid import UUID
 from app.dependencies import get_db, get_current_user
 from app.models.sql_models import User, Wallet
 from app.schemas.wallet import WalletCreate, WalletUpdate, WalletResponse
+from app.services.wallet_service import ensure_can_create_wallet, get_owned_wallet
 
 router = APIRouter(prefix="/wallets", tags=["Wallets"])
-
-
-async def _get_owned_wallet(wallet_id: UUID, user: User, db: AsyncSession) -> Wallet:
-    """Carteira do usuário, ou 404. Mesmo molde de `_get_owned_goal` em goals.py."""
-    wallet = (await db.execute(
-        select(Wallet).where(Wallet.id == wallet_id, Wallet.user_id == user.id)
-    )).scalar_one_or_none()
-    if not wallet:
-        raise HTTPException(status_code=404, detail="Carteira não encontrada")
-    return wallet
 
 
 @router.get("/", response_model=list[WalletResponse]) 
@@ -41,6 +32,7 @@ async def create_wallet(
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
+    await ensure_can_create_wallet(current_user, db)
     wallet = Wallet(user_id=current_user.id, **payload.model_dump())
     db.add(wallet)
     await db.commit()
@@ -54,7 +46,7 @@ async def update_wallet(
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db)
 ):
-    wallet = await _get_owned_wallet(wallet_id, current_user, db)
+    wallet = await get_owned_wallet(wallet_id, current_user, db, for_write=True)
 
     for field, value in payload.model_dump(exclude_none=True).items():
         setattr(wallet, field, value)
@@ -69,7 +61,10 @@ async def delete_wallet(
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
-    wallet = await _get_owned_wallet(wallet_id, current_user, db)
+    # Sem for_write: excluir carteira bloqueada é PERMITIDO de propósito. É a
+    # única saída de quem tem 5 carteiras e virou free — recusar transformaria o
+    # teto numa armadilha em vez de um limite (ADR 0002).
+    wallet = await get_owned_wallet(wallet_id, current_user, db)
 
     await db.delete(wallet)
     await db.commit()

--- a/backend/app/services/plan_service.py
+++ b/backend/app/services/plan_service.py
@@ -11,6 +11,7 @@ produção omite e pega o relógio.
 
 from datetime import datetime, timedelta, timezone
 
+from app.config import get_settings
 from app.models.sql_models import User
 
 # 72 horas EXATAS a partir de `premium_until`, não dias de calendário:
@@ -48,3 +49,37 @@ def wallet_cap_applies(user: User, now: datetime | None = None) -> bool:
     if user.premium_until is None:
         return True
     return now >= user.premium_until + GRACE
+
+
+class PlanRefused(Exception):
+    """Uma regra de plano recusou a operação.
+
+    Carrega o `code` do contrato do ADR 0002 — `WALLET_LIMIT_REACHED`,
+    `WALLET_READ_ONLY`, `AI_REQUIRES_PREMIUM`. Quem traduz para 403 é o handler
+    registrado no main; service neste repo não conhece HTTP.
+
+    O `code` é contrato e NUNCA é reescrito; `message` é livre.
+    """
+
+    def __init__(self, code: str, message: str):
+        self.code = code
+        self.message = message
+        super().__init__(message)
+
+
+# --- Os dois helpers de enforcement -----------------------------------------
+# São os ÚNICOS lugares que leem `paywall_enabled`. Com o flag desligado eles
+# reportam liberado, e é de propósito: eles precisam dizer o que a API VAI
+# FAZER, não o que a tabela de faixas diz. Se reportassem a faixa real com o
+# paywall apagado, a tela bloquearia IA e carteiras que o backend aceita — um
+# paywall que atrapalha o usuário sem cobrar de ninguém.
+
+
+def ai_gate_open(user: User, now: datetime | None = None) -> bool:
+    """IA liberada de verdade, considerando o flag de rollout."""
+    return not get_settings().paywall_enabled or ai_allowed(user, now)
+
+
+def wallet_cap_active(user: User, now: datetime | None = None) -> bool:
+    """Teto de carteiras valendo de verdade, considerando o flag de rollout."""
+    return get_settings().paywall_enabled and wallet_cap_applies(user, now)

--- a/backend/app/services/wallet_service.py
+++ b/backend/app/services/wallet_service.py
@@ -1,0 +1,112 @@
+"""Resolução de carteira com ownership e teto de plano (ADR 0002, issue #86).
+
+Este módulo existe para que o teto seja **impossível de esquecer**. Antes havia
+três cópias de `_get_owned_wallet` (wallets, transactions, recurring) com
+assinaturas diferentes, e três lugares para lembrar de uma regra é exatamente o
+mecanismo pelo qual alguém esquece. Agora quem quiser uma carteira passa por
+aqui, e passar por aqui já roda a regra.
+
+Dependency do FastAPI não serviria: em `POST /transactions` e `POST /recurring`
+o `wallet_id` chega no CORPO, e dependency lê path e query. Cobriria só as rotas
+`/{wallet_id}` — justamente as que menos importam.
+"""
+
+from uuid import UUID
+
+from sqlalchemy import func, select, tuple_
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import aliased
+
+from app.models.sql_models import User, Wallet
+from app.services.plan_service import PlanRefused, wallet_cap_active
+
+# Decisão travada do #15: gratuito = 2 carteiras, e as 2 MAIS ANTIGAS nunca são
+# bloqueadas.
+LIMITE_FREE = 2
+
+
+class WalletNotFound(Exception):
+    """Carteira inexistente ou de outro dono. Vira 404 no handler do main.
+
+    Os dois casos respondem igual de propósito: dizer "existe, mas não é sua"
+    transformaria a rota num oráculo de ids alheios.
+    """
+
+
+def _anteriores_subquery():
+    """Quantas carteiras do mesmo dono são mais antigas que esta.
+
+    **Desvio consciente do ADR 0002**, que dizia `row_number() over (...)`: o
+    Postgres recusa `FOR UPDATE` junto de window function ("FOR UPDATE is not
+    allowed with window functions"), e a carteira PRECISA de lock quando o
+    saldo vai mudar. Uma subquery escalar correlacionada entrega a mesma
+    informação, com o mesmo desempate, na mesma viagem, e convive com o lock.
+
+    O desempate por `id` não é enfeite: `created_at` empata (o seed de demo cria
+    carteiras na mesma transação), e ordem instável faria o conjunto bloqueado
+    mudar entre requisições — a pessoa escreveria numa carteira e levaria 403 na
+    seguinte, sem nada ter mudado.
+    """
+    outra = aliased(Wallet)
+    return (
+        select(func.count())
+        .select_from(outra)
+        .where(outra.user_id == Wallet.user_id)
+        .where(tuple_(outra.created_at, outra.id) < tuple_(Wallet.created_at, Wallet.id))
+        .scalar_subquery()
+    )
+
+
+async def get_owned_wallet(
+    wallet_id: UUID,
+    user: User,
+    db: AsyncSession,
+    *,
+    for_update: bool = False,
+    required: bool = True,
+    for_write: bool = False,
+) -> Wallet | None:
+    """Carteira do usuário, com o teto aplicado quando `for_write`.
+
+    - `for_update`: trava a linha (`FOR UPDATE`) para mutar saldo com segurança.
+    - `required=False`: devolve None em vez de levantar, usado na carteira de
+      origem de um update, cujo efeito antigo é revertido de forma tolerante.
+    - `for_write`: liga o teto. Leitura NUNCA é bloqueada — carteira excedente
+      continua visível e continua contando em todo total.
+    """
+    stmt = (
+        select(Wallet, _anteriores_subquery())
+        .where(Wallet.id == wallet_id, Wallet.user_id == user.id)
+    )
+    if for_update:
+        # `of=Wallet`: sem isso o Postgres tentaria travar o alias da subquery.
+        stmt = stmt.with_for_update(of=Wallet)
+
+    linha = (await db.execute(stmt)).first()
+    if linha is None:
+        if required:
+            raise WalletNotFound()
+        return None
+
+    wallet, anteriores = linha
+    if for_write and anteriores >= LIMITE_FREE and wallet_cap_active(user):
+        raise PlanRefused(
+            "WALLET_READ_ONLY",
+            "Esta carteira está somente-leitura no plano gratuito. "
+            "Ela continua visível e contando nos seus totais.",
+        )
+    return wallet
+
+
+async def ensure_can_create_wallet(user: User, db: AsyncSession) -> None:
+    """Recusa a criação quando o usuário já está no teto."""
+    if not wallet_cap_active(user):
+        return
+    quantas = await db.scalar(
+        select(func.count()).select_from(Wallet).where(Wallet.user_id == user.id)
+    )
+    if quantas >= LIMITE_FREE:
+        raise PlanRefused(
+            "WALLET_LIMIT_REACHED",
+            f"O plano gratuito permite {LIMITE_FREE} carteiras.",
+        )

--- a/backend/tests/test_paywall_wallets.py
+++ b/backend/tests/test_paywall_wallets.py
@@ -1,0 +1,288 @@
+"""Teto de carteiras do ADR 0002 (issue #86).
+
+Free = 2 carteiras. As 2 MAIS ANTIGAS nunca são bloqueadas; as demais ficam
+somente-leitura, mas continuam visíveis e continuam contando nos totais.
+Vocabulário em CONTEXT.md.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import select
+
+from app.config import get_settings
+from app.models.sql_models import User, Wallet
+
+BASE = datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+
+@pytest.fixture
+def paywall_ligado():
+    # O flag nasce desligado; ligar por teste é o que prova que desligado o app
+    # se comporta como antes (o resto da suíte roda com ele off).
+    settings = get_settings()
+    antes = settings.paywall_enabled
+    settings.paywall_enabled = True
+    yield
+    settings.paywall_enabled = antes
+
+
+async def _tres_carteiras(ac, db_session) -> list[Wallet]:
+    """Três carteiras com created_at distinto e crescente: [antiga, meio, nova]."""
+    me = (await ac.get("/auth/me")).json()
+    user = (await db_session.execute(select(User).where(User.id == me["id"]))).scalar_one()
+    carteiras = []
+    for i, nome in enumerate(("Antiga", "Meio", "Nova")):
+        w = Wallet(user_id=user.id, name=nome, balance=100, created_at=BASE + timedelta(days=i))
+        db_session.add(w)
+        carteiras.append(w)
+    await db_session.commit()
+    for w in carteiras:
+        await db_session.refresh(w)
+    return carteiras
+
+
+@pytest.mark.asyncio
+async def test_a_free_user_cannot_write_to_the_wallet_past_the_cap(
+    make_auth_client, db_session, paywall_ligado
+):
+    alice = await make_auth_client("Alice")
+    _antiga, _meio, nova = await _tres_carteiras(alice, db_session)
+
+    res = await alice.post(
+        "/transactions/",
+        json={
+            "wallet_id": str(nova.id),
+            "type": "EXPENSE",
+            "amount": 10,
+            "category": "Alimentação",
+            "date": "2026-08-26",
+        },
+    )
+    assert res.status_code == 403, res.text
+    assert res.json()["detail"]["code"] == "WALLET_READ_ONLY"
+
+
+async def _nova_transacao(ac, wallet_id, valor=10):
+    return await ac.post(
+        "/transactions/",
+        json={
+            "wallet_id": str(wallet_id),
+            "type": "EXPENSE",
+            "amount": valor,
+            "category": "Alimentação",
+            "date": "2026-08-26",
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_the_two_oldest_wallets_stay_writable(make_auth_client, db_session, paywall_ligado):
+    alice = await make_auth_client("Alice")
+    antiga, meio, _nova = await _tres_carteiras(alice, db_session)
+
+    assert (await _nova_transacao(alice, antiga.id)).status_code == 201
+    assert (await _nova_transacao(alice, meio.id)).status_code == 201
+
+
+@pytest.mark.asyncio
+async def test_a_blocked_wallet_is_still_visible_and_still_counts(
+    make_auth_client, db_session, paywall_ligado
+):
+    # Decisão travada do #15: carteira excedente é somente-leitura mas CONTINUA
+    # contando em todo total. Filtrar na query teria quebrado isto.
+    alice = await make_auth_client("Alice")
+    await _tres_carteiras(alice, db_session)
+
+    lista = await alice.get("/wallets/")
+    assert lista.status_code == 200
+    assert len(lista.json()) == 3
+
+
+@pytest.mark.asyncio
+async def test_a_free_user_cannot_create_a_third_wallet(
+    make_auth_client, db_session, paywall_ligado
+):
+    alice = await make_auth_client("Alice")
+    await _tres_carteiras(alice, db_session)
+
+    res = await alice.post("/wallets/", json={"name": "Quarta", "balance": 0})
+    assert res.status_code == 403
+    assert res.json()["detail"]["code"] == "WALLET_LIMIT_REACHED"
+
+
+@pytest.mark.asyncio
+async def test_renaming_a_blocked_wallet_is_refused(make_auth_client, db_session, paywall_ligado):
+    alice = await make_auth_client("Alice")
+    _antiga, _meio, nova = await _tres_carteiras(alice, db_session)
+
+    res = await alice.put(f"/wallets/{nova.id}", json={"name": "Outro nome"})
+    assert res.status_code == 403
+    assert res.json()["detail"]["code"] == "WALLET_READ_ONLY"
+
+
+@pytest.mark.asyncio
+async def test_deleting_a_blocked_wallet_is_always_allowed(
+    make_auth_client, db_session, paywall_ligado
+):
+    # A saída de quem tem 5 carteiras e virou free. Recusar transformaria o teto
+    # numa armadilha.
+    alice = await make_auth_client("Alice")
+    _antiga, _meio, nova = await _tres_carteiras(alice, db_session)
+
+    assert (await alice.delete(f"/wallets/{nova.id}")).status_code == 204
+
+
+@pytest.mark.asyncio
+async def test_a_transaction_can_be_drained_out_of_a_blocked_wallet(
+    make_auth_client, db_session, paywall_ligado
+):
+    # Excluir carteira apaga as transações por cascade. Sem drenagem, a escolha
+    # do usuário seria pagar ou destruir histórico.
+    alice = await make_auth_client("Alice")
+    antiga, _meio, nova = await _tres_carteiras(alice, db_session)
+
+    # A transação nasce ANTES do paywall valer para ela: criada direto no banco.
+    from app.models.sql_models import Transaction, TransactionType
+    import datetime as dt
+
+    t = Transaction(
+        user_id=(await alice.get("/auth/me")).json()["id"],
+        wallet_id=nova.id,
+        type=TransactionType.EXPENSE,
+        amount=10,
+        category="Alimentação",
+        date=dt.date(2026, 8, 26),
+    )
+    db_session.add(t)
+    await db_session.commit()
+    await db_session.refresh(t)
+
+    mover = await alice.put(f"/transactions/{t.id}", json={"wallet_id": str(antiga.id)})
+    assert mover.status_code == 200, mover.text
+
+
+@pytest.mark.asyncio
+async def test_a_transaction_cannot_be_moved_into_a_blocked_wallet(
+    make_auth_client, db_session, paywall_ligado
+):
+    alice = await make_auth_client("Alice")
+    antiga, _meio, nova = await _tres_carteiras(alice, db_session)
+
+    criada = await _nova_transacao(alice, antiga.id)
+    assert criada.status_code == 201
+
+    mover = await alice.put(
+        f"/transactions/{criada.json()['id']}", json={"wallet_id": str(nova.id)}
+    )
+    assert mover.status_code == 403
+    assert mover.json()["detail"]["code"] == "WALLET_READ_ONLY"
+
+
+@pytest.mark.asyncio
+async def test_a_premium_user_has_no_cap_at_all(make_auth_client, db_session, paywall_ligado):
+    from datetime import datetime as dt, timedelta as td, timezone as tz
+
+    alice = await make_auth_client("Alice")
+    _antiga, _meio, nova = await _tres_carteiras(alice, db_session)
+
+    me = (await alice.get("/auth/me")).json()
+    user = (await db_session.execute(select(User).where(User.id == me["id"]))).scalar_one()
+    user.premium_until = dt.now(tz.utc) + td(days=30)
+    await db_session.commit()
+
+    assert (await _nova_transacao(alice, nova.id)).status_code == 201
+    assert (await alice.post("/wallets/", json={"name": "Quarta", "balance": 0})).status_code == 201
+
+
+@pytest.mark.asyncio
+async def test_wallets_created_in_the_same_instant_get_a_stable_order(
+    make_auth_client, db_session, paywall_ligado
+):
+    # created_at empata (o seed de demo cria carteiras na mesma transação). Sem o
+    # desempate por id, o conjunto bloqueado mudaria entre requisições: escreve
+    # numa carteira agora, 403 na próxima, sem nada ter mudado.
+    alice = await make_auth_client("Alice")
+    me = (await alice.get("/auth/me")).json()
+    user = (await db_session.execute(select(User).where(User.id == me["id"]))).scalar_one()
+
+    empatadas = [Wallet(user_id=user.id, name=f"W{i}", balance=0, created_at=BASE) for i in range(3)]
+    db_session.add_all(empatadas)
+    await db_session.commit()
+    for w in empatadas:
+        await db_session.refresh(w)
+
+    # Duas escritas seguidas na MESMA carteira têm que dar o mesmo resultado.
+    por_id = sorted(empatadas, key=lambda w: str(w.id))
+    primeira = await _nova_transacao(alice, por_id[0].id)
+    segunda = await _nova_transacao(alice, por_id[0].id)
+    assert primeira.status_code == segunda.status_code == 201
+
+    bloqueada_1 = await _nova_transacao(alice, por_id[2].id)
+    bloqueada_2 = await _nova_transacao(alice, por_id[2].id)
+    assert bloqueada_1.status_code == bloqueada_2.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_with_the_flag_off_nothing_is_blocked(make_auth_client, db_session):
+    # Sem a fixture paywall_ligado: é o estado de produção no merge deste ticket.
+    alice = await make_auth_client("Alice")
+    _antiga, _meio, nova = await _tres_carteiras(alice, db_session)
+
+    assert (await _nova_transacao(alice, nova.id)).status_code == 201
+    assert (await alice.post("/wallets/", json={"name": "Quarta", "balance": 0})).status_code == 201
+    assert (await alice.put(f"/wallets/{nova.id}", json={"name": "Ok"})).status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_editing_a_transaction_that_stays_in_a_blocked_wallet_is_refused(
+    make_auth_client, db_session, paywall_ligado
+):
+    # Ficar na carteira bloqueada é escrever nela. É o outro lado da regra
+    # direcional: sair dela é drenar e passa, ficar e mexer no valor não.
+    from app.models.sql_models import Transaction, TransactionType
+    import datetime as dt
+
+    alice = await make_auth_client("Alice")
+    _antiga, _meio, nova = await _tres_carteiras(alice, db_session)
+
+    t = Transaction(
+        user_id=(await alice.get("/auth/me")).json()["id"],
+        wallet_id=nova.id,
+        type=TransactionType.EXPENSE,
+        amount=10,
+        category="Alimentação",
+        date=dt.date(2026, 8, 26),
+    )
+    db_session.add(t)
+    await db_session.commit()
+    await db_session.refresh(t)
+
+    res = await alice.put(f"/transactions/{t.id}", json={"amount": 99})
+    assert res.status_code == 403
+    assert res.json()["detail"]["code"] == "WALLET_READ_ONLY"
+
+
+@pytest.mark.asyncio
+async def test_a_transaction_can_be_deleted_from_inside_a_blocked_wallet(
+    make_auth_client, db_session, paywall_ligado
+):
+    from app.models.sql_models import Transaction, TransactionType
+    import datetime as dt
+
+    alice = await make_auth_client("Alice")
+    _antiga, _meio, nova = await _tres_carteiras(alice, db_session)
+
+    t = Transaction(
+        user_id=(await alice.get("/auth/me")).json()["id"],
+        wallet_id=nova.id,
+        type=TransactionType.EXPENSE,
+        amount=10,
+        category="Alimentação",
+        date=dt.date(2026, 8, 26),
+    )
+    db_session.add(t)
+    await db_session.commit()
+    await db_session.refresh(t)
+
+    assert (await alice.delete(f"/transactions/{t.id}")).status_code == 204

--- a/docs/adr/0002-onde-o-paywall-e-aplicado.md
+++ b/docs/adr/0002-onde-o-paywall-e-aplicado.md
@@ -52,8 +52,16 @@ carteira junto.
 
 ### A posição sai da mesma consulta
 
-`row_number() over (order by created_at, id)` na consulta que já resolve a
-carteira. Custo: zero viagem a mais.
+A posição sai da consulta que já resolve a carteira. Custo: zero viagem a mais.
+
+> **Correção de 2026-08-26 (issue #86), era `row_number()`.** O Postgres recusa
+> `FOR UPDATE` junto de window function — "FOR UPDATE is not allowed with window
+> functions", verificado no banco — e a carteira **precisa** de lock quando o
+> saldo vai mudar. A intenção (posição na mesma consulta, mesmo desempate)
+> continua; o mecanismo virou uma **subquery escalar correlacionada** contando
+> quantas carteiras do mesmo dono são mais antigas, que convive com o lock e
+> entrega a mesma informação. `anteriores < 2` significa "está entre as 2 mais
+> antigas".
 
 O `, id` no desempate não é enfeite. `wallets.created_at` **empata** — o seed de
 demo cria carteiras na mesma transação — e ordem instável faria o conjunto


### PR DESCRIPTION
Wave 6 of #15, first ticket: the wallet half of [ADR 0002](https://github.com/DigoDuck/Norby/blob/main/docs/adr/0002-onde-o-paywall-e-aplicado.md).

Closes #86.

**The flag defaults off, so this merge changes nothing in production.**

## One helper, and that is the point

The three copies of `_get_owned_wallet` become one service helper with the cap inside it. That is not tidiness: three places to remember a rule **is** the mechanism by which someone forgets it. Now anyone who wants a wallet goes through the helper, and going through the helper runs the rule — you cannot skip the cap without also losing the wallet.

A FastAPI dependency could not do this, and the reason is concrete: `POST /transactions` and `POST /recurring` carry `wallet_id` in the **body**, and dependencies read path and query.

## A correction to ADR 0002 — the mechanism, not the intent

The ADR specified `row_number() over (order by created_at, id)`. Postgres refuses it:

```
ERROR:  FOR UPDATE is not allowed with window functions
```

Verified directly against the database. The wallet **needs** the lock whenever a balance changes, so the window function was never going to work on the write path. A **correlated scalar subquery** counting older wallets gives the same answer, with the same tiebreak, in the same round trip, and coexists with `FOR UPDATE`. `anteriores < 2` means "among the two oldest".

The ADR now records the correction in place.

## The tiebreak is load-bearing

`created_at` ties — the demo seed creates wallets in one transaction — and without `, id` the blocked set would change between requests: write to a wallet now, 403 on the next call, with nothing having changed. There is a test that posts **twice** to the same wallet and asserts both calls agree, in both directions.

## The write rule is directional

| action | result |
|---|---|
| staying in a blocked wallet and editing | refused — that is a write |
| leaving it | allowed — that is draining |
| deleting a transaction from inside it | allowed — also draining |
| deleting the wallet itself | allowed |

Deleting a wallet cascades its transactions, so without a drain path the user chooses between **paying and destroying history**. None of it leaks the cap, because value can never be **added** to a blocked wallet.

## Services still do not know about HTTP

`PlanRefused` and `WalletNotFound` are domain exceptions, mapped once by two handlers in `main.py`. Any future caller of the helper gets the right status without a `try/except` in every router, and no service raises `HTTPException` — the convention this repository already had.

`PlanRefused` carries the `code`, so the AI ticket (#87) reuses the same handler.

## Verification

Mutation, not just green tests. Each kills **exactly one** test:

- dropping the `id` tiebreak → the stable-order test fails
- making the cap ignore the flag → the flag-off test fails
- making a transaction that stays in a blocked wallet count as a non-write → the edit-in-place test fails

And the real proof the refactor changed no behaviour: **the entire existing suite passes untouched with the flag off**. 210 backend tests, up from 197.

## Not in this ticket

AI generation is #87, recurring materialization is #88, and the `plan` object plus the frontend's handling of an object `detail` is #89 — until that one lands, a paywall refusal renders through `apiErrorMessage`'s fallback rather than showing its message.
