### PR TITLE
v2 Wave 6: gate AI generation behind a dependency

### DIFF
--- a/backend/app/dependencies.py
+++ b/backend/app/dependencies.py
@@ -6,6 +6,7 @@ from sqlalchemy import select
 from jose import JWTError, jwt
 from app.database import AsyncSessionLocal
 from app.models.sql_models import User
+from app.services.plan_service import PlanRefused, ai_gate_open
 from app.config import get_settings
 
 settings = get_settings()
@@ -48,3 +49,26 @@ async def get_current_user( # Autenticação
     if user is None:
         raise credentials_exception
     return user
+
+async def require_ai_access(current_user: User = Depends(get_current_user)) -> User:
+    """Portão da IA (ADR 0002). Substitui o `get_current_user` nas rotas que GERAM.
+
+    Dependency, e não checagem dentro da rota, por dois motivos. O primeiro é de
+    desenho: a checagem só precisa do usuário, que é o que dependency faz bem, e
+    é onde este app já coloca autorização. O segundo é concreto e vale registrar
+    — o `/ai/insight` embrulha o corpo inteiro num `except Exception` que degrada
+    para 200 com "IA temporariamente indisponível". Uma recusa levantada lá
+    dentro seria ENGOLIDA e o usuário free veria um erro de indisponibilidade em
+    vez do motivo real. Dependency roda antes do corpo, então escapa disso.
+
+    Dentro do `ai_service` também não: o service passaria a conhecer plano, e
+    qualquer chamador futuro que não passe por aquela função fura o portão sem
+    ninguém notar.
+    """
+    if not ai_gate_open(current_user):
+        raise PlanRefused(
+            "AI_REQUIRES_PREMIUM",
+            "A IA do Norby faz parte do plano pago. Seus dados e seu histórico "
+            "continuam aqui.",
+        )
+    return current_user

--- a/backend/app/routers/ai.py
+++ b/backend/app/routers/ai.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 from datetime import datetime, timezone
 from uuid import UUID, uuid4
 from sqlalchemy.ext.asyncio import AsyncSession
-from app.dependencies import get_db, get_current_user
+from app.dependencies import get_db, get_current_user, require_ai_access
 from app.limiter import limiter, user_key
 from app.models.sql_models import User
 from app.services.ai_service import get_or_generate_insight, chat_with_ai
@@ -27,7 +27,7 @@ CHAT_SESSIONS_LIMIT = 20  # nº de sessões de chat recentes listadas
 @limiter.limit("30/minute", key_func=user_key)
 async def get_dashboard_insight(
     request: Request,
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_ai_access),
     db: AsyncSession = Depends(get_db),
 ):
     try:
@@ -53,7 +53,7 @@ async def get_dashboard_insight(
 async def chat(
     request: Request,
     payload: ChatMessage,
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_ai_access),
     db: AsyncSession = Depends(get_db),
 ): # Chat com o Gemini que lê os dados financeiros do usuário
     session_id = str(payload.session_id) if payload.session_id else str(uuid4())

--- a/backend/tests/test_paywall_ai.py
+++ b/backend/tests/test_paywall_ai.py
@@ -1,0 +1,124 @@
+"""Portão de IA do ADR 0002 (issue #87).
+
+Só a GERAÇÃO é bloqueada. Ler conversa que a pessoa já teve continua aberto:
+não custa token de Gemini (o custo já foi pago) e o export da LGPD devolve
+exatamente esse conteúdo — bloquear a tela enquanto o export entrega o mesmo
+dado seria incoerente.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import select
+
+from app.config import get_settings
+from app.models.sql_models import User
+
+
+@pytest.fixture
+def paywall_ligado():
+    settings = get_settings()
+    antes = settings.paywall_enabled
+    settings.paywall_enabled = True
+    yield
+    settings.paywall_enabled = antes
+
+
+async def _fora_do_trial(ac, db_session) -> User:
+    """Usuário free de verdade: cadastro dá 7 dias de trial, então empurramos
+    a data para o passado."""
+    me = (await ac.get("/auth/me")).json()
+    user = (await db_session.execute(select(User).where(User.id == me["id"]))).scalar_one()
+    user.ai_trial_ends_at = datetime.now(timezone.utc) - timedelta(days=1)
+    await db_session.commit()
+    return user
+
+
+@pytest.mark.asyncio
+async def test_a_free_user_past_the_trial_cannot_generate_an_insight(
+    make_auth_client, db_session, mongo, paywall_ligado
+):
+    alice = await make_auth_client("Alice")
+    await _fora_do_trial(alice, db_session)
+
+    res = await alice.get("/ai/insight")
+    assert res.status_code == 403, res.text
+    assert res.json()["detail"]["code"] == "AI_REQUIRES_PREMIUM"
+
+
+@pytest.mark.asyncio
+async def test_a_free_user_past_the_trial_cannot_chat(
+    make_auth_client, db_session, mongo, paywall_ligado
+):
+    alice = await make_auth_client("Alice")
+    await _fora_do_trial(alice, db_session)
+
+    res = await alice.post("/ai/chat", json={"message": "e aí?"})
+    assert res.status_code == 403
+    assert res.json()["detail"]["code"] == "AI_REQUIRES_PREMIUM"
+
+
+@pytest.mark.asyncio
+async def test_a_free_user_still_reads_their_own_chat_history(
+    make_auth_client, db_session, mongo, paywall_ligado
+):
+    # O ponto do ticket: o custo do Gemini já foi pago quando a conversa foi
+    # gerada. Bloquear a leitura não economiza nada e contradiz o export da LGPD.
+    import uuid as uuid_mod
+
+    alice = await make_auth_client("Alice")
+    user = await _fora_do_trial(alice, db_session)
+    sessao = str(uuid_mod.uuid4())  # a rota de detalhe tipa o path como UUID
+    await mongo["chat_history"].insert_one(
+        {
+            "user_id": str(user.id),
+            "session_id": sessao,
+            "messages": [{"role": "user", "content": "oi"}],
+            "created_at": datetime.now(timezone.utc),
+        }
+    )
+
+    lista = await alice.get("/ai/chat/sessions")
+    assert lista.status_code == 200, lista.text
+    # Presença da sessão, não contagem: o Mongo não é limpo entre testes, então
+    # `== 1` seria frágil ao que outro teste tenha escrito.
+    assert sessao in [s["session_id"] for s in lista.json()]
+
+    detalhe = await alice.get(f"/ai/chat/sessions/{sessao}")
+    assert detalhe.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_a_user_inside_the_trial_still_generates(
+    make_auth_client, db_session, mongo, paywall_ligado
+):
+    # Cadastro concede 7 dias; não mexemos na data.
+    alice = await make_auth_client("Alice")
+
+    res = await alice.get("/ai/insight")
+    assert res.status_code != 403
+
+
+@pytest.mark.asyncio
+async def test_a_premium_user_generates_even_with_the_trial_long_gone(
+    make_auth_client, db_session, mongo, paywall_ligado
+):
+    alice = await make_auth_client("Alice")
+    user = await _fora_do_trial(alice, db_session)
+    user.premium_until = datetime.now(timezone.utc) + timedelta(days=30)
+    await db_session.commit()
+
+    res = await alice.get("/ai/insight")
+    assert res.status_code != 403
+
+
+@pytest.mark.asyncio
+async def test_with_the_flag_off_a_free_user_still_reaches_the_ai(
+    make_auth_client, db_session, mongo
+):
+    # Sem a fixture: estado de produção no merge deste ticket.
+    alice = await make_auth_client("Alice")
+    await _fora_do_trial(alice, db_session)
+
+    res = await alice.get("/ai/insight")
+    assert res.status_code != 403


### PR DESCRIPTION
Wave 6 of #15, second ticket: the AI half of [ADR 0002](https://github.com/DigoDuck/Norby/blob/main/docs/adr/0002-onde-o-paywall-e-aplicado.md).

Closes #87.

**The flag is still off by default, so this merge changes nothing in production.**

## Only generation

A dependency on the two routes that generate — `GET /ai/insight` and `POST /ai/chat`. The two history routes stay open.

Reading conversations the user already had costs no Gemini tokens; the cost was paid when they were generated. And blocking the screen while `GET /auth/me/export` hands back exactly that content under LGPD would be incoherent — the data is theirs either way.

## Why a dependency, with a reason beyond the design argument

The design argument is in the ADR: the check only needs the user, which is what dependencies do well, and it is where this app already puts authorization.

The concrete one is worth recording. `/ai/insight` wraps its **whole body** in an `except Exception` that degrades to `200` with `"IA temporariamente indisponível"`. A refusal raised in there would be **swallowed**, and a free user would see an availability error instead of the real reason. A dependency runs before the body and escapes that entirely.

Not inside `ai_service` either: the service would learn about plans, and any future caller not going through that function would walk through the gate unnoticed.

## Verified by mutation

Each kills exactly the right test:

- reverting the two routes to `get_current_user` → both refusal tests fail
- extending the gate to the history route → the "reads stay open" test fails

## A pre-existing fragility the mutation surfaced

Not introduced here, and **not fixed here**, but it should be visible rather than buried.

Under the first mutation the chat route becomes reachable, and the history test starts failing — but only when the file runs as a whole. It passes in isolation. The cause is in the harness: the `mongo` fixture rebinds the collections `account_service` uses, but not the ones the AI router holds, and those are bound at import time to the event loop of whichever test touched them first. So any test that actually reaches the chat route poisons the ones after it.

In the shipped code the gate refuses before the route gets there, so it does not bite today. But #21 and #25 will write more AI tests, and this is the shape of bug that shows up as a mystifying flake. It deserves its own change with its own verification, not a silent ride-along in a paywall ticket.

## One assertion corrected while investigating

The history test asserted a session **count**, and Mongo is not cleaned between tests, so it now asserts the session is **present**. The count was brittle to anything another test had written.

216 backend tests, up from 210.

## Still open in this wave

#88 recurring materialization, and #89 the `plan` object plus the frontend's handling of an object `detail` — until that one lands, a paywall refusal renders through `apiErrorMessage`'s fallback rather than showing its message. Both need to be on `main` before the flag is ever switched on.
