### PR TITLE
v2 Wave 6: recurring materialization skips blocked wallets and says so

### DIFF
--- a/backend/app/routers/recurring.py
+++ b/backend/app/routers/recurring.py
@@ -5,7 +5,9 @@ from uuid import UUID
 
 from app.dependencies import get_db, get_current_user
 from app.models.sql_models import User, Wallet, RecurringTransaction
-from app.schemas.recurring import RecurringCreate, RecurringUpdate, RecurringResponse
+from app.schemas.recurring import (
+    RecurringCreate, RecurringUpdate, RecurringResponse, RecurringRunResponse,
+)
 from app.services.recurring_service import compute_initial_next_run, materialize_due_recurring
 from app.services.wallet_service import get_owned_wallet
 
@@ -95,10 +97,10 @@ async def delete_recurring(
     await db.commit()
 
 
-@router.post("/run", response_model=dict[str, int])
+@router.post("/run", response_model=RecurringRunResponse)
 async def run_recurring(
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
-    generated = await materialize_due_recurring(db, current_user)
-    return {"generated": generated}
+    resultado = await materialize_due_recurring(db, current_user)
+    return {"generated": resultado.generated, "skipped": resultado.skipped}

--- a/backend/app/schemas/recurring.py
+++ b/backend/app/schemas/recurring.py
@@ -51,3 +51,18 @@ class RecurringResponse(BaseModel):
     created_at: datetime
 
     model_config = ConfigDict(from_attributes=True)
+
+
+class RecurringSkipped(BaseModel):
+    """Uma recorrência que a rodada NÃO materializou, e por quê (ADR 0002)."""
+
+    recurring_id: UUID
+    wallet_id: UUID
+    code: str
+
+
+class RecurringRunResponse(BaseModel):
+    generated: int
+    # Lista, não contador: a tela precisa dizer QUAL recorrência parou e em qual
+    # carteira. Um número só transformaria o aviso em enigma.
+    skipped: list[RecurringSkipped] = []

--- a/backend/app/services/recurring_service.py
+++ b/backend/app/services/recurring_service.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timezone, timedelta
+from typing import NamedTuple
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -7,6 +8,8 @@ from app.models.sql_models import (
     User, Wallet, RecurringTransaction, RecurrenceFrequency, Transaction
 )
 from app.services.transaction_service import apply_delta
+from app.services.plan_service import PlanRefused
+from app.services.wallet_service import get_owned_wallet
 
 
 def add_one_month(d: datetime) -> datetime:
@@ -40,7 +43,18 @@ def compute_initial_next_run(frequency, day_of_month, weekday, now=None) -> date
     return candidate
 
 
-async def materialize_due_recurring(db: AsyncSession, user: User) -> int:
+class Materializacao(NamedTuple):
+    """O que a rodada fez, e o que ela deixou de fazer.
+
+    `skipped` existe porque parar em silêncio é pior que vazar o paywall: seria
+    a pessoa descobrindo em março que o aluguel não é lançado desde janeiro.
+    """
+
+    generated: int
+    skipped: list[dict]
+
+
+async def materialize_due_recurring(db: AsyncSession, user: User) -> Materializacao:
     now = datetime.now(timezone.utc)
     templates = (await db.execute(
         select(RecurringTransaction).where(
@@ -51,12 +65,29 @@ async def materialize_due_recurring(db: AsyncSession, user: User) -> int:
     )).scalars().all()
 
     generated = 0
+    skipped: list[dict] = []
     for tpl in templates:
-        wallet = (await db.execute(
-            select(Wallet).where(
-                Wallet.id == tpl.wallet_id, Wallet.user_id == user.id
-            ).with_for_update()
-        )).scalar_one_or_none()
+        # Passa pelo helper do ADR 0002 em vez de reimplementar a regra: assim
+        # existe UM lugar decidindo o que é carteira bloqueada, e a recorrência
+        # não pode divergir das escritas manuais. `required=False` preserva a
+        # tolerância antiga a carteira sumida.
+        try:
+            wallet = await get_owned_wallet(
+                tpl.wallet_id, user, db, for_update=True, required=False, for_write=True
+            )
+        except PlanRefused as recusa:
+            # O template NÃO é desativado nem apagado. Quem assinar, ou drenar e
+            # apagar uma carteira, volta a materializar sozinho — e as ocorrências
+            # puladas entram na próxima rodada, porque a materialização é guiada
+            # por data, não por execução.
+            skipped.append(
+                {
+                    "recurring_id": str(tpl.id),
+                    "wallet_id": str(tpl.wallet_id),
+                    "code": recusa.code,
+                }
+            )
+            continue
 
         while tpl.next_run_date <= now:
             db.add(Transaction(
@@ -74,4 +105,4 @@ async def materialize_due_recurring(db: AsyncSession, user: User) -> int:
             generated += 1
 
     await db.commit()
-    return generated
+    return Materializacao(generated=generated, skipped=skipped)

--- a/backend/tests/test_paywall_recurring.py
+++ b/backend/tests/test_paywall_recurring.py
@@ -1,0 +1,148 @@
+"""Recorrência apontando para carteira bloqueada (ADR 0002, issue #88).
+
+`materialize_due_recurring` cria transação e mexe em saldo SOZINHO, em toda
+navegação — o AppLayout chama `/recurring/run` no mount de toda rota protegida.
+Uma recorrência numa carteira bloqueada é escrita automática numa carteira
+bloqueada, acontecendo sem ninguém clicar.
+
+Ela é pulada E DITA. Parar em silêncio seria a pessoa descobrindo em março que
+o aluguel não é lançado desde janeiro.
+"""
+
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+
+import pytest
+from sqlalchemy import select
+
+from app.config import get_settings
+from app.models.sql_models import (
+    RecurrenceFrequency,
+    RecurringTransaction,
+    Transaction,
+    TransactionType,
+    User,
+    Wallet,
+)
+
+BASE = datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+
+@pytest.fixture
+def paywall_ligado():
+    settings = get_settings()
+    antes = settings.paywall_enabled
+    settings.paywall_enabled = True
+    yield
+    settings.paywall_enabled = antes
+
+
+async def _cenario(ac, db_session):
+    """Free com 3 carteiras e uma recorrência VENCIDA na bloqueada (a mais nova)."""
+    me = (await ac.get("/auth/me")).json()
+    user = (await db_session.execute(select(User).where(User.id == me["id"]))).scalar_one()
+
+    carteiras = [
+        Wallet(user_id=user.id, name=n, balance=Decimal("100.00"), created_at=BASE + timedelta(days=i))
+        for i, n in enumerate(("Antiga", "Meio", "Nova"))
+    ]
+    db_session.add_all(carteiras)
+    await db_session.commit()
+    for w in carteiras:
+        await db_session.refresh(w)
+
+    bloqueada = carteiras[2]
+    tpl = RecurringTransaction(
+        user_id=user.id,
+        wallet_id=bloqueada.id,
+        type=TransactionType.EXPENSE,
+        amount=Decimal("10.00"),
+        category="Moradia",
+        description="Aluguel",
+        frequency=RecurrenceFrequency.MONTHLY,
+        day_of_month=1,
+        next_run_date=datetime.now(timezone.utc) - timedelta(days=1),
+    )
+    db_session.add(tpl)
+    await db_session.commit()
+    await db_session.refresh(tpl)
+    return user, carteiras, tpl
+
+
+@pytest.mark.asyncio
+async def test_a_recurring_on_a_blocked_wallet_is_skipped_and_reported(
+    make_auth_client, db_session, paywall_ligado
+):
+    alice = await make_auth_client("Alice")
+    user, carteiras, tpl = await _cenario(alice, db_session)
+    bloqueada = carteiras[2]
+
+    res = await alice.post("/recurring/run")
+    assert res.status_code == 200, res.text
+    corpo = res.json()
+
+    assert corpo["generated"] == 0
+    # Pular em silêncio é o defeito que este ticket existe para evitar.
+    assert len(corpo["skipped"]) == 1
+    pulada = corpo["skipped"][0]
+    assert pulada["recurring_id"] == str(tpl.id)
+    assert pulada["wallet_id"] == str(bloqueada.id)
+    assert pulada["code"] == "WALLET_READ_ONLY"
+
+    # Nada foi escrito: nem transação, nem saldo, nem avanço da data.
+    txs = (
+        await db_session.execute(select(Transaction).where(Transaction.user_id == user.id))
+    ).scalars().all()
+    assert txs == []
+    await db_session.refresh(bloqueada)
+    assert bloqueada.balance == Decimal("100.00")
+    await db_session.refresh(tpl)
+    assert tpl.next_run_date < datetime.now(timezone.utc)
+
+
+@pytest.mark.asyncio
+async def test_a_recurring_on_a_writable_wallet_still_materializes(
+    make_auth_client, db_session, paywall_ligado
+):
+    alice = await make_auth_client("Alice")
+    user, carteiras, tpl = await _cenario(alice, db_session)
+
+    # Move o template para a carteira mais antiga, que nunca é bloqueada.
+    tpl.wallet_id = carteiras[0].id
+    await db_session.commit()
+
+    corpo = (await alice.post("/recurring/run")).json()
+    assert corpo["generated"] >= 1
+    assert corpo["skipped"] == []
+
+
+@pytest.mark.asyncio
+async def test_the_template_is_not_deactivated_and_resumes_after_upgrading(
+    make_auth_client, db_session, paywall_ligado
+):
+    # O template não é apagado nem desativado: quem assina (ou drena e apaga uma
+    # carteira) volta a materializar sozinho, e as ocorrências puladas entram na
+    # próxima rodada, porque a materialização é guiada por data e não por execução.
+    alice = await make_auth_client("Alice")
+    user, _carteiras, tpl = await _cenario(alice, db_session)
+
+    assert (await alice.post("/recurring/run")).json()["generated"] == 0
+    await db_session.refresh(tpl)
+    assert tpl.active is True
+
+    user.premium_until = datetime.now(timezone.utc) + timedelta(days=30)
+    await db_session.commit()
+
+    depois = (await alice.post("/recurring/run")).json()
+    assert depois["generated"] >= 1
+    assert depois["skipped"] == []
+
+
+@pytest.mark.asyncio
+async def test_with_the_flag_off_nothing_is_ever_skipped(make_auth_client, db_session):
+    alice = await make_auth_client("Alice")
+    await _cenario(alice, db_session)
+
+    corpo = (await alice.post("/recurring/run")).json()
+    assert corpo["generated"] >= 1
+    assert corpo["skipped"] == []

--- a/backend/tests/test_recurring.py
+++ b/backend/tests/test_recurring.py
@@ -84,7 +84,7 @@ async def test_materialize_generates_due_and_updates_balance(db_session):
     db_session.add(rec)
     await db_session.commit()
 
-    generated = await materialize_due_recurring(db_session, user)
+    generated, _ = await materialize_due_recurring(db_session, user)
 
     assert generated >= 3  # 3 semanas vencidas (catch-up)
     txs = (await db_session.execute(
@@ -109,8 +109,8 @@ async def test_materialize_is_idempotent(db_session):
     db_session.add(rec)
     await db_session.commit()
 
-    first = await materialize_due_recurring(db_session, user)
-    second = await materialize_due_recurring(db_session, user)
+    first, _ = await materialize_due_recurring(db_session, user)
+    second, _ = await materialize_due_recurring(db_session, user)
     assert first >= 1
     assert second == 0
 
@@ -126,7 +126,7 @@ async def test_materialize_skips_inactive(db_session):
     )
     db_session.add(rec)
     await db_session.commit()
-    assert await materialize_due_recurring(db_session, user) == 0
+    assert (await materialize_due_recurring(db_session, user)).generated == 0
 
 
 # ---------------------------------------------------------------------------

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1343,25 +1343,39 @@
       }
     },
     "node_modules/@humanfs/core": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
-      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
       "dev": true,
       "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
       "engines": {
         "node": ">=18.18.0"
       }
     },
     "node_modules/@humanfs/node": {
-      "version": "0.16.7",
-      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
-      "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@humanfs/core": "^0.19.1",
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
         "@humanwhocodes/retry": "^0.4.0"
       },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18.0"
       }
@@ -2401,9 +2415,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.12",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.12.tgz",
-      "integrity": "sha512-qyq26DxfY4awP2gIRXhhLWfwzwI+N5Nxk6iQi8EFizIaWIjqicQTE4sLnZZVdeKPRcVNoJOkkpfzoIYuvCKaIQ==",
+      "version": "2.11.21",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.21.tgz",
+      "integrity": "sha512-uh8vpY/1/YyFkunIDFH/12p7/7VdPKA1hejMVEbdkEaWnUz0Hesvx5EbiU6XxjyHZIOju+ZMbQJkRh+es3/spQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -2451,9 +2465,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
-      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+      "version": "4.28.9",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.9.tgz",
+      "integrity": "sha512-EWazOblFYUvlGZcfGhPUPmYh3nikUxBVb+y9MJun5f3hBi812X+8MSQTujLBtgK3cf51fJWbWfOjyeO954d+Eg==",
       "dev": true,
       "funding": [
         {
@@ -2471,11 +2485,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.9.0",
-        "caniuse-lite": "^1.0.30001759",
-        "electron-to-chromium": "^1.5.263",
-        "node-releases": "^2.0.27",
-        "update-browserslist-db": "^1.2.0"
+        "baseline-browser-mapping": "^2.11.20",
+        "caniuse-lite": "^1.0.30001810",
+        "electron-to-chromium": "^1.5.420",
+        "node-releases": "^2.0.54",
+        "update-browserslist-db": "^1.3.2"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -2518,9 +2532,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001781",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001781.tgz",
-      "integrity": "sha512-RdwNCyMsNBftLjW6w01z8bKEvT6e/5tpPVEgtn22TiLGlstHOVecsX2KHFkD5e/vRnIE4EGzpuIODb3mtswtkw==",
+      "version": "1.0.30001810",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001810.tgz",
+      "integrity": "sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==",
       "dev": true,
       "funding": [
         {
@@ -2994,9 +3008,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.328",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.328.tgz",
-      "integrity": "sha512-QNQ5l45DzYytThO21403XN3FvK0hOkWDG8viNf6jqS42msJ8I4tGDSpBCgvDRRPnkffafiwAym2X2eHeGD2V0w==",
+      "version": "1.5.422",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.422.tgz",
+      "integrity": "sha512-UvA/32XqrLDdZSn7Jllo1AYNcWji/G0d5M0GTViE7KoGBiMunw3a34Sb2KO4ZZyrSEhqsxFoVhWWJshdyfKqJA==",
       "dev": true,
       "license": "ISC"
     },
@@ -4610,11 +4624,14 @@
       "license": "MIT"
     },
     "node_modules/node-releases": {
-      "version": "2.0.36",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
-      "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
+      "version": "2.0.54",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.54.tgz",
+      "integrity": "sha512-YHs7BmmcsdAI5Ozuf8JZo6PT0mv2GIWC9vMfvUC3dp65M8hn7Ux8CPL+2oBI7juNuj9d0ndhTcznq2ODBps9cQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -4960,9 +4977,9 @@
       }
     },
     "node_modules/postcss-selector-parser": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
-      "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.4.tgz",
+      "integrity": "sha512-bIoJLOmjCO1S9XdY/DcnR5hJxvrDir1PbGChrzXG3vw0/FOliy/fA3dmdhQ441kah4gKv+TwckGzex6wNS5cnQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5777,9 +5794,9 @@
       "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
-      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.2.tgz",
+      "integrity": "sha512-UQ+MSxlhRm1bzjhU+DcuXfjFO1FzNtqhK5+9Yvlp90ItDLk5vT932A0rFu619nf7RVS+Y/VeaUW1jaRDqZ8VJw==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
Wave 6 of #15, third ticket, from [ADR 0002](https://github.com/DigoDuck/Norby/blob/main/docs/adr/0002-onde-o-paywall-e-aplicado.md).

Closes #88.

**The flag is still off by default.**

## The hole this closes

`materialize_due_recurring` creates transactions and mutates balances **by itself**, and `AppLayout` calls `/recurring/run` on mount of every protected route. A template pointing at a blocked wallet is therefore an automatic write into a blocked wallet, happening with nobody clicking anything — the most valuable writes in the app would have been the ones ignoring the cap.

## It reuses the helper rather than re-deciding

The materialization goes through the same `get_owned_wallet` the manual writes use, with `for_write=True`, and catches the refusal. That is deliberate: **one place decides what "blocked" means**, so recurring can never drift from the rest of the app. Catching rather than propagating is right because the run is a batch — one blocked template must not fail the whole request.

## Skipping silently was never an option

It is how someone finds out in March that rent has not posted since January, and silent data loss is the defect class waves 1 and 2 existed to eliminate.

`/recurring/run` now returns `skipped` alongside `generated`, **as a list rather than a counter**: the screen has to say *which* template stopped and in *which* wallet. A bare number turns the warning into a riddle.

```json
{"generated": 0, "skipped": [{"recurring_id": "...", "wallet_id": "...", "code": "WALLET_READ_ONLY"}]}
```

## The template is not deactivated

Whoever subscribes — or drains and deletes a wallet so the blocked one comes back under the cap — resumes materializing on their own, and the **skipped occurrences are generated on the next run**, because materialization is driven by dates rather than by runs. There is a test that upgrades the user mid-scenario and asserts exactly that.

Deactivating the template would have been the tempting shortcut and would have quietly destroyed something the user set up.

## Verified by mutation

- making the materialization ignore the cap → the skip test **and** the resume test fail
- skipping without recording → the reporting assertions fail

Each kills only what it should.

## Signature change

`materialize_due_recurring` now returns a `NamedTuple` instead of a bare `int`, so three existing call sites in the tests unpack it. That is an intentional contract change, not refactor drift.

## Verification

220 backend tests, up from 216. Frontend untouched and still green — the new field is additive, so the existing `recurringApi.run` caller is unaffected.

## Still open in this wave

#89, the `plan` object plus the frontend's handling of an object `detail`. Until it lands, a paywall refusal renders through `apiErrorMessage`'s fallback rather than showing its message, and the screen has no way to render this `skipped` list. Both belong on `main` before the flag is ever switched on.
