### PR TITLE
feat(paywall): expose the plan object and render refusal messages

### DIFF
--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -1,10 +1,11 @@
 import re
 
-from pydantic import BaseModel, ConfigDict, EmailStr, Field, field_validator
+from pydantic import BaseModel, ConfigDict, EmailStr, Field, field_validator, model_validator
 from uuid import UUID
 from datetime import datetime
 
 from app.schemas.common import PersonName
+from app.services.plan_service import ai_gate_open, wallet_cap_active
 
 class UserRegister(BaseModel):
     name: PersonName
@@ -49,13 +50,61 @@ class UserUpdate(BaseModel):
     name: PersonName | None = None
     email: EmailStr | None = None
     
+class PlanResponse(BaseModel):
+    """O plano como o frontend precisa vê-lo (ADR 0002).
+
+    Os DOIS BOOLEANOS são a autoridade: eles dizem o que a API vai fazer.
+    Sem eles a tela reimplementa a carência de 72h e passa a discordar do
+    backend sobre quem é premium. O resto é exibição, para o que booleano não
+    conta: "termina em 12/09" precisa de `premium_until` JUNTO de
+    `cancel_at_period_end` para não dizer "renova" quando é "acaba", e
+    "pagamento recusado" só existe no `subscription_status`.
+    """
+
+    ai_allowed: bool
+    wallet_cap_applies: bool
+    premium_until: datetime | None
+    ai_trial_ends_at: datetime | None
+    subscription_status: str | None
+    cancel_at_period_end: bool
+
+
 class UserResponse(BaseModel):
     id: UUID
     name: str
     email: str
     created_at: datetime
+    plan: PlanResponse
 
     model_config = ConfigDict(from_attributes=True)
+
+    @model_validator(mode="before")
+    @classmethod
+    def _deriva_o_plano(cls, data):
+        """`plan` não é coluna: sai dos helpers de enforcement a cada resposta.
+
+        Aqui, e não em cada rota, porque são quatro (cadastro, login, GET e PUT
+        /auth/me) e esquecer uma deixaria a tela sem plano justamente no login.
+        Os booleanos vêm de `ai_gate_open`/`wallet_cap_active`, não dos
+        predicados crus: com o flag desligado eles reportam LIBERADO, que é o
+        que a API de fato faz.
+        """
+        if isinstance(data, dict) or not hasattr(data, "premium_until"):
+            return data  # já é corpo pronto (ou um UserResponse revalidado)
+        return {
+            "id": data.id,
+            "name": data.name,
+            "email": data.email,
+            "created_at": data.created_at,
+            "plan": {
+                "ai_allowed": ai_gate_open(data),
+                "wallet_cap_applies": wallet_cap_active(data),
+                "premium_until": data.premium_until,
+                "ai_trial_ends_at": data.ai_trial_ends_at,
+                "subscription_status": data.subscription_status,
+                "cancel_at_period_end": data.cancel_at_period_end,
+            },
+        }
 
 class Token(BaseModel):
     access_token: str

--- a/backend/tests/test_plan_object.py
+++ b/backend/tests/test_plan_object.py
@@ -1,0 +1,222 @@
+"""O objeto `plan` que o frontend lê (ADR 0002, issue #89).
+
+Os DOIS BOOLEANOS são a autoridade: eles dizem o que a API vai fazer, não o
+que a tabela de faixas diz. Sem eles a tela reimplementa a carência de 72h e
+passa a discordar do backend sobre quem é premium.
+
+O resto do objeto é exibição: "termina em 12/09" precisa de `premium_until`
+JUNTO de `cancel_at_period_end` para não dizer "renova" quando é "acaba", e
+"pagamento recusado" só existe no `subscription_status`.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import select
+
+from app.config import get_settings
+from app.models.sql_models import User
+
+CHAVES = {
+    "ai_allowed",
+    "wallet_cap_applies",
+    "premium_until",
+    "ai_trial_ends_at",
+    "subscription_status",
+    "cancel_at_period_end",
+}
+
+
+@pytest.fixture
+def paywall_ligado():
+    settings = get_settings()
+    antes = settings.paywall_enabled
+    settings.paywall_enabled = True
+    yield
+    settings.paywall_enabled = antes
+
+
+async def _user(ac, db_session, **campos) -> User:
+    me = (await ac.get("/auth/me")).json()
+    user = (await db_session.execute(select(User).where(User.id == me["id"]))).scalar_one()
+    for campo, valor in campos.items():
+        setattr(user, campo, valor)
+    await db_session.commit()
+    return user
+
+
+async def _plan(ac) -> dict:
+    res = await ac.get("/auth/me")
+    assert res.status_code == 200, res.text
+    return res.json()["plan"]
+
+
+@pytest.mark.asyncio
+async def test_the_plan_object_carries_exactly_the_six_fields_of_the_adr(
+    make_auth_client, db_session, paywall_ligado
+):
+    alice = await make_auth_client("Alice")
+    assert set(await _plan(alice)) == CHAVES
+
+
+# --- As quatro faixas, com o flag LIGADO -------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_user_inside_the_ai_trial_has_ai_but_still_has_the_wallet_cap(
+    make_auth_client, db_session, paywall_ligado
+):
+    # O trial concede SÓ IA. Se ele também levantasse o teto, a tela ofereceria
+    # a 3ª carteira durante 7 dias e ela sumiria depois.
+    alice = await make_auth_client("Alice")
+    plan = await _plan(alice)
+    assert plan["ai_allowed"] is True
+    assert plan["wallet_cap_applies"] is True
+
+
+@pytest.mark.asyncio
+async def test_a_free_user_past_the_trial_has_neither(
+    make_auth_client, db_session, paywall_ligado
+):
+    alice = await make_auth_client("Alice")
+    await _user(alice, db_session, ai_trial_ends_at=datetime.now(timezone.utc) - timedelta(days=1))
+    plan = await _plan(alice)
+    assert plan["ai_allowed"] is False
+    assert plan["wallet_cap_applies"] is True
+
+
+@pytest.mark.asyncio
+async def test_active_premium_has_ai_and_no_cap(
+    make_auth_client, db_session, paywall_ligado
+):
+    alice = await make_auth_client("Alice")
+    await _user(
+        alice,
+        db_session,
+        ai_trial_ends_at=datetime.now(timezone.utc) - timedelta(days=90),
+        premium_until=datetime.now(timezone.utc) + timedelta(days=30),
+    )
+    plan = await _plan(alice)
+    assert plan["ai_allowed"] is True
+    assert plan["wallet_cap_applies"] is False
+
+
+@pytest.mark.asyncio
+async def test_inside_the_grace_period_ai_is_already_gone_but_the_cap_is_not_back(
+    make_auth_client, db_session, paywall_ligado
+):
+    # A faixa que o frontend NÃO conseguiria derivar sem errar: venceu há uma
+    # hora, a IA parou na hora, e as carteiras extras seguem abertas por 72h.
+    alice = await make_auth_client("Alice")
+    await _user(
+        alice,
+        db_session,
+        ai_trial_ends_at=datetime.now(timezone.utc) - timedelta(days=90),
+        premium_until=datetime.now(timezone.utc) - timedelta(hours=1),
+    )
+    plan = await _plan(alice)
+    assert plan["ai_allowed"] is False
+    assert plan["wallet_cap_applies"] is False
+
+
+@pytest.mark.asyncio
+async def test_after_the_grace_period_the_cap_is_back(
+    make_auth_client, db_session, paywall_ligado
+):
+    alice = await make_auth_client("Alice")
+    await _user(
+        alice,
+        db_session,
+        ai_trial_ends_at=datetime.now(timezone.utc) - timedelta(days=90),
+        premium_until=datetime.now(timezone.utc) - timedelta(hours=73),
+    )
+    assert (await _plan(alice))["wallet_cap_applies"] is True
+
+
+# --- Com o flag DESLIGADO ----------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_with_the_flag_off_the_booleans_report_permissive(
+    make_auth_client, db_session
+):
+    # Estado de produção no merge deste ticket. Reportar a faixa real aqui faria
+    # a tela bloquear IA e carteira que o backend aceita normalmente — paywall
+    # que atrapalha sem cobrar de ninguém.
+    alice = await make_auth_client("Alice")
+    await _user(alice, db_session, ai_trial_ends_at=datetime.now(timezone.utc) - timedelta(days=1))
+    plan = await _plan(alice)
+    assert plan["ai_allowed"] is True
+    assert plan["wallet_cap_applies"] is False
+
+
+@pytest.mark.asyncio
+async def test_with_the_flag_off_the_dates_are_still_the_truth(
+    make_auth_client, db_session
+):
+    # Só os PORTÕES mentem em favor do usuário. Data e status são exibição, e a
+    # tela do #25 vai contar com eles para dizer "vence em".
+    alice = await make_auth_client("Alice")
+    vencimento = datetime.now(timezone.utc) - timedelta(days=10)
+    await _user(
+        alice, db_session, premium_until=vencimento, subscription_status="past_due",
+        cancel_at_period_end=True,
+    )
+    plan = await _plan(alice)
+    assert plan["subscription_status"] == "past_due"
+    assert plan["cancel_at_period_end"] is True
+    assert plan["premium_until"] is not None
+    assert plan["premium_until"].startswith(vencimento.strftime("%Y-%m-%d"))
+
+
+# --- Os outros dois lugares por onde o usuário viaja --------------------------
+
+
+@pytest.mark.asyncio
+async def test_register_and_login_carry_the_plan_too(client, db_session):
+    # O app guarda o usuário do login; sem o plan aqui a tela ficaria sem plano
+    # até o primeiro /auth/me.
+    corpo = {
+        "name": "Bob", "email": "bob_plan@test.com",
+        "password": "secret123", "accept_privacy": True,
+    }
+    cadastro = await client.post("/auth/register", json=corpo)
+    assert cadastro.status_code == 201, cadastro.text
+    assert set(cadastro.json()["user"]["plan"]) == CHAVES
+
+    login = await client.post(
+        "/auth/login", json={"email": corpo["email"], "password": corpo["password"]}
+    )
+    assert set(login.json()["user"]["plan"]) == CHAVES
+
+
+# --- O booleano concorda com o que a API faz ---------------------------------
+# O ponto do objeto inteiro. Um booleano que discorda do enforcement é pior que
+# booleano nenhum: a tela ou esconde o que funciona, ou oferece o que leva 403.
+
+
+@pytest.mark.asyncio
+async def test_ai_allowed_false_matches_a_real_403_from_the_ai_route(
+    make_auth_client, db_session, mongo, paywall_ligado
+):
+    alice = await make_auth_client("Alice")
+    await _user(alice, db_session, ai_trial_ends_at=datetime.now(timezone.utc) - timedelta(days=1))
+
+    assert (await _plan(alice))["ai_allowed"] is False
+    res = await alice.get("/ai/insight")
+    assert res.status_code == 403
+    assert res.json()["detail"]["code"] == "AI_REQUIRES_PREMIUM"
+
+
+@pytest.mark.asyncio
+async def test_wallet_cap_applies_true_matches_a_real_403_on_the_third_wallet(
+    make_auth_client, db_session, paywall_ligado
+):
+    alice = await make_auth_client("Alice")
+    assert (await _plan(alice))["wallet_cap_applies"] is True
+
+    for nome in ("Primeira", "Segunda"):
+        assert (await alice.post("/wallets/", json={"name": nome, "balance": "0.00"})).status_code == 201
+    terceira = await alice.post("/wallets/", json={"name": "Terceira", "balance": "0.00"})
+    assert terceira.status_code == 403
+    assert terceira.json()["detail"]["code"] == "WALLET_LIMIT_REACHED"

--- a/frontend/src/lib/utils.js
+++ b/frontend/src/lib/utils.js
@@ -69,6 +69,11 @@ export function apiErrorMessage(err, fallback) {
   if (Array.isArray(detail) && detail.length) {
     return "Verifique os dados informados: algum valor é inválido ou longo demais.";
   }
+  // Recusa de plano (ADR 0002): {"code": ..., "message": ...}. Sem este ramo o
+  // objeto cai no fallback e a tela mostra um erro genérico no lugar do motivo.
+  // O `code` é o contrato, para a UI decidir o que oferecer; a `message` é o
+  // que se lê, e nunca serve como identificador — ela pode ser reescrita.
+  if (typeof detail?.message === "string" && detail.message) return detail.message;
   return fallback;
 }
 

--- a/frontend/src/lib/utils.test.js
+++ b/frontend/src/lib/utils.test.js
@@ -28,6 +28,30 @@ describe("apiErrorMessage", () => {
     expect(typeof apiErrorMessage(err, "fallback")).toBe("string");
   });
 
+  it("shows the message of an object detail, which is how a paywall refusal arrives", () => {
+    // Contrato do ADR 0002: 403 com detail em objeto. Antes deste ramo a
+    // mensagem sumia e toda recusa de plano virava erro genérico.
+    const err = {
+      response: {
+        data: {
+          detail: {
+            code: "WALLET_READ_ONLY",
+            message: "Esta carteira está em somente-leitura no plano gratuito.",
+          },
+        },
+      },
+    };
+    expect(apiErrorMessage(err, "fallback")).toBe(
+      "Esta carteira está em somente-leitura no plano gratuito."
+    );
+  });
+
+  it("never returns the code as if it were the message", () => {
+    // A `message` é o que se lê; o `code` é identificador e não vai para a tela.
+    const err = { response: { data: { detail: { code: "AI_REQUIRES_PREMIUM" } } } };
+    expect(apiErrorMessage(err, "fallback")).toBe("fallback");
+  });
+
   it("falls back when there is no response (network failure)", () => {
     expect(apiErrorMessage(new Error("boom"), "sem conexão")).toBe("sem conexão");
     expect(apiErrorMessage({ response: { data: {} } }, "fallback")).toBe("fallback");


### PR DESCRIPTION
Wave 6 of #15, last ticket, from [ADR 0002](https://github.com/DigoDuck/Norby/blob/main/docs/adr/0002-onde-o-paywall-e-aplicado.md).

Closes #89. **The flag is still off by default.**

This is the read side: how the app learns the plan, and how a refusal reaches the screen. The three enforcement tickets before it are useless without it — a paywall the user cannot see is a paywall that only produces confusion.

## The two booleans are the authority

```
plan: {ai_allowed, wallet_cap_applies, premium_until,
       ai_trial_ends_at, subscription_status, cancel_at_period_end}
```

They come from `ai_gate_open`/`wallet_cap_active`, **never from the raw predicates**. The difference is the whole point: with the flag off they report **permissive**, because they must describe what the API will actually do, not what the tier table says. Reporting the true tier would make the screen block AI and wallets that the backend accepts normally — a paywall that gets in the user's way without charging anyone.

The rest of the object is display, for what a boolean cannot carry: "ends on 12/09" needs `premium_until` **together with** `cancel_at_period_end` so it never says "renews" when it means "ends", and "payment declined" exists only in `subscription_status`.

There is one tier the frontend could not derive on its own without getting it wrong, and it has its own test: **one hour past due**, AI is already gone and the extra wallets are still open for 72h.

## The derivation is in one place

A model validator on `UserResponse`, not at the call sites. There are four of them — register, login, `GET /auth/me`, `PUT /auth/me` — and forgetting one would leave the screen with no plan exactly at login. Same reasoning as the wallet helper in #86: one place that is already mandatory beats four places to remember.

`TokenPair` is deliberately untouched, as the ADR states.

## The refusal message was disappearing

`apiErrorMessage` understood `detail` as a string (business errors) or an array (422). The 403 contract sends an **object**, which fell through to the generic fallback — so every refusal this wave produces would have rendered as "algo deu errado".

The `code` is the contract and stays an identifier the UI switches on; it never reaches the screen. The `message` is what gets read and is free to be reworded. There is a test asserting the code is **not** returned as if it were the message.

## Verified by mutation

- booleans from the raw predicates instead of the flag-aware helpers → only the flag-off test fails, which is exactly right: with the flag on the two are equivalent
- `ai_allowed` inverted → 6 tests fail
- object branch removed from `apiErrorMessage` → the refusal test fails
- branch returning `code` instead of `message` → 2 tests fail

## Two tests cross-check the boolean against enforcement

`ai_allowed: false` is asserted in the same scenario as a real 403 from `/ai/insight`, and `wallet_cap_applies: true` alongside a real 403 on the third wallet. A boolean that disagrees with enforcement is worse than no boolean: the screen either hides what works or offers what leads to a 403.

## Verification

229 backend tests, up from 220. 126 frontend, up from 124.

## What this does not do

Rendering the paywall — where the upgrade call to action lives, how a blocked wallet looks in the list, how the `skipped` list from #88 is shown — is **#25**, with the screen in hand.

## Wave 6 closes here

The flag can now be switched on without the screen lying or going silent. What is still missing before that is worth doing: **#48** (lazy reconciliation) and **#46** (Checkout and Portal), and #46 is still blocked by **#26** — confirming in the Stripe dashboard that an `individual` account can create the recurring BRL 20.00 price. That is the one unverified assumption under both ADRs.
