### PR TITLE
feat(billing): lazy reconciliation for a missed webhook

### DIFF
--- a/backend/app/dependencies.py
+++ b/backend/app/dependencies.py
@@ -6,6 +6,7 @@ from sqlalchemy import select
 from jose import JWTError, jwt
 from app.database import AsyncSessionLocal
 from app.models.sql_models import User
+from app.services.billing_service import reconcile_subscription
 from app.services.plan_service import PlanRefused, ai_gate_open
 from app.config import get_settings
 
@@ -48,6 +49,15 @@ async def get_current_user( # Autenticação
     user = result.scalar_one_or_none()
     if user is None:
         raise credentials_exception
+
+    # Reconciliação preguiçosa (issue #48): pega carona na requisição, como o
+    # `materialize_due_recurring` — este projeto não tem agendador e este
+    # ticket não adiciona um. Aqui, e não nos leitores de plano, porque este é
+    # o único ponto por onde a linha do usuário entra numa requisição
+    # autenticada: os leitores (`ai_gate_open`, `wallet_cap_active`, o objeto
+    # `plan`) são funções puras, sem sessão. No caso comum é uma comparação de
+    # colunas já carregadas, sem rede: quem não tem assinatura não paga nada.
+    await reconcile_subscription(user, db)
     return user
 
 async def require_ai_access(current_user: User = Depends(get_current_user)) -> User:

--- a/backend/app/services/billing_service.py
+++ b/backend/app/services/billing_service.py
@@ -10,7 +10,7 @@ quatro pontos de acoplamento que o ADR nomeia.
 
 import logging
 import uuid
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 import stripe
 
@@ -18,6 +18,7 @@ from sqlalchemy import select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.config import get_settings
 from app.models.sql_models import StripeWebhookEvent, User
 
 logger = logging.getLogger("norby.billing")
@@ -41,6 +42,38 @@ def _instante(epoch: int | None) -> datetime | None:
     return datetime.fromtimestamp(epoch, timezone.utc) if epoch else None
 
 
+def _chave() -> str:
+    """A chave secreta, lida a cada chamada e não no import.
+
+    Nada no app configurava `stripe.api_key`: ele estava `None`, então a
+    primeira chamada real ao gateway falharia por autenticação. Isso já valia
+    para o `cancel_subscription` — quem tivesse assinatura não conseguiria
+    excluir a conta, porque a recusa do gateway ABORTA a exclusão de propósito.
+    """
+    return get_settings().stripe_secret_key
+
+
+def _periodo_fim(obj: dict) -> datetime | None:
+    """Até quando está pago.
+
+    O campo SAIU do topo da assinatura: na versão de API que o SDK 15 fixa
+    (2026-07-29.dahlia) `current_period_end` mora em cada ITEM. Ler só o topo
+    devolveria None e apagaria o `premium_until` de quem paga — o portão
+    inteiro do ADR 0001. O topo vem primeiro porque conta com versão antiga
+    fixada no endpoint ainda manda ali, e `max` porque assinatura com vários
+    itens (que a nossa não tem) está paga até o item que vai mais longe.
+    """
+    topo = obj.get("current_period_end")
+    if topo:
+        return _instante(topo)
+    fins = [
+        item.get("current_period_end")
+        for item in ((obj.get("items") or {}).get("data") or [])
+        if item.get("current_period_end")
+    ]
+    return _instante(max(fins)) if fins else None
+
+
 def _projecao(evento: dict) -> dict:
     """Só os campos que este handler lê — nunca o payload cru.
 
@@ -55,7 +88,7 @@ def _projecao(evento: dict) -> dict:
         "stripe_created": _instante(evento.get("created")),
         "customer_id": obj.get("customer"),
         "subscription_id": obj.get("subscription") if tipo == EVENTO_CHECKOUT else obj.get("id"),
-        "current_period_end": _instante(obj.get("current_period_end")),
+        "current_period_end": _periodo_fim(obj),
         "status": obj.get("status"),
         "cancel_at_period_end": obj.get("cancel_at_period_end"),
         "received_at": datetime.now(timezone.utc),
@@ -193,6 +226,104 @@ async def cancel_subscription(subscription_id: str) -> None:
     faria uma chamada HTTP bloqueante travar o event loop.
     """
     try:
-        await stripe.Subscription.cancel_async(subscription_id)
+        await stripe.Subscription.cancel_async(subscription_id, api_key=_chave())
     except Exception as erro:  # noqa: BLE001 — rede, credencial ou 4xx do Stripe
         raise GatewayCancelFailed(str(erro)) from erro
+
+
+# --- Reconciliação preguiçosa (issue #48) ------------------------------------
+# O modelo já falha FECHADO: evento perdido só deixa acesso vencer, nunca
+# concede. Isto não é proteção de receita — existe para a única direção que
+# machuca quem paga: pagou, o evento se perdeu, e o app diz que não é premium.
+
+# Depois destes o Stripe não tem mais nada a dizer sobre a assinatura, então
+# perguntar de novo só gastaria rede.
+STATUS_TERMINAIS = frozenset({"canceled", "incomplete_expired"})
+
+# Janela entre duas consultas sobre a MESMA pessoa. Sem ela, quem está em
+# `past_due` com o período já vencido casa com o gatilho para sempre e carrega
+# uma chamada de rede em toda requisição.
+# ponytail: cache em processo, que basta para um worker de uvicorn (ver
+# start.sh). Vira coluna `plan_synced_at` no dia em que rodar com --workers > 1
+# ou mais de uma instância.
+JANELA_CONSULTA = timedelta(minutes=15)
+_ULTIMA_CONSULTA: dict[uuid.UUID, datetime] = {}
+
+
+async def fetch_subscription(subscription_id: str) -> dict:
+    """Lê a assinatura no gateway. Saída de rede, e é ela que os testes stubam.
+
+    Devolve dict puro: o resto do módulo trata evento como dado, não como
+    objeto do SDK, e é isso que mantém a troca de gateway localizada.
+    """
+    sub = await stripe.Subscription.retrieve_async(subscription_id, api_key=_chave())
+    return dict(sub)
+
+
+def precisa_reconciliar(user: User, now: datetime | None = None) -> bool:
+    """Gatilho estreito de propósito.
+
+    Reconciliar em toda requisição colocaria o Stripe no caminho quente de
+    todo mundo, e reconciliar quem não tem assinatura seria uma chamada que só
+    pode voltar vazia. `premium_until` NULO entra junto do vencido: é o caso do
+    `customer.subscription.created` perdido, em que a pessoa pagou e ficaria
+    travada para sempre — o ticket dizia só `<= now`, e essa é uma ampliação
+    deliberada.
+    """
+    if not user.stripe_subscription_id:
+        return False
+    if user.subscription_status in STATUS_TERMINAIS:
+        return False
+    return user.premium_until is None or user.premium_until <= (
+        now or datetime.now(timezone.utc)
+    )
+
+
+async def reconcile_subscription(user: User, db: AsyncSession) -> bool:
+    """Pergunta ao gateway e atualiza as colunas. Nunca levanta.
+
+    Falha do Stripe é registrada e a requisição segue com o estado que temos:
+    reconciliação que dá 500 é PIOR que coluna velha, porque a coluna velha já
+    está na direção segura.
+    """
+    if not precisa_reconciliar(user):
+        return False
+
+    agora = datetime.now(timezone.utc)
+    for antigo in [k for k, v in _ULTIMA_CONSULTA.items() if agora - v >= JANELA_CONSULTA]:
+        del _ULTIMA_CONSULTA[antigo]
+    if user.id in _ULTIMA_CONSULTA:
+        return False
+    _ULTIMA_CONSULTA[user.id] = agora
+
+    try:
+        sub = await fetch_subscription(user.stripe_subscription_id)
+    except Exception as erro:  # noqa: BLE001 — rede, credencial ou 4xx do Stripe
+        logger.warning(
+            "stripe: reconciliação falhou para o usuário %s: %s", user.id, erro
+        )
+        return False
+
+    # O mesmo `_aplicar` do webhook, e não uma segunda escrita paralela: duas
+    # rotas escrevendo as mesmas colunas divergem, e a divergência aqui é
+    # acesso pago errado. O tipo sintetizado escolhe o ramo certo — assinatura
+    # terminada tem `ended_at`, que é a única data que vale num cancelamento
+    # imediato.
+    tipo = (
+        "customer.subscription.deleted"
+        if sub.get("status") in STATUS_TERMINAIS
+        else "customer.subscription.updated"
+    )
+    evento = {"id": f"reconcile:{user.stripe_subscription_id}", "type": tipo,
+              "data": {"object": sub}}
+    _aplicar(user, evento, _projecao(evento))
+
+    # `stripe_event_at` NÃO se move aqui. Ela é a marca d'água de ORDEM dos
+    # eventos, e carimbá-la com o nosso relógio faria um webhook legítimo que
+    # chegasse logo depois entrar como atrasado por diferença de relógio. O
+    # preço é o inverso: um evento antigo entregue depois desta leitura ainda
+    # pode sobrescrevê-la — mas só na direção segura, e a requisição seguinte
+    # reconcilia de novo.
+    await db.commit()
+    logger.info("stripe: assinatura de %s reconciliada (%s)", user.id, sub.get("status"))
+    return True

--- a/backend/tests/test_billing_reconcile.py
+++ b/backend/tests/test_billing_reconcile.py
@@ -1,0 +1,224 @@
+"""Reconciliação preguiçosa de webhook perdido (issue #48, ADR 0001).
+
+O modelo já falha FECHADO: webhook perdido só consegue deixar o acesso vencer,
+nunca conceder. Então isto não é proteção de receita — existe para a única
+direção que machuca quem paga: a pessoa pagou, o evento se perdeu, e o app diz
+que ela não é premium.
+
+Sem agendador: pega carona na requisição, mesmo padrão do
+`materialize_due_recurring`.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import select
+
+import app.services.billing_service as billing
+from app.config import get_settings
+from app.models.sql_models import User
+
+
+@pytest.fixture(autouse=True)
+def sem_memoria_entre_testes():
+    # A guarda de repetição é um cache em processo; sem limpar, um teste
+    # herdaria a consulta do anterior.
+    billing._ULTIMA_CONSULTA.clear()
+    yield
+    billing._ULTIMA_CONSULTA.clear()
+
+
+@pytest.fixture
+def paywall_ligado():
+    settings = get_settings()
+    antes = settings.paywall_enabled
+    settings.paywall_enabled = True
+    yield
+    settings.paywall_enabled = antes
+
+
+def _assinatura(status: str = "active", *, dias: int = 30, ended_at: int | None = None) -> dict:
+    """A forma MODERNA do objeto: `current_period_end` mora no ITEM.
+
+    O SDK 15 fixa a versão de API 2026-07-29.dahlia, onde o campo não existe
+    mais no topo da assinatura.
+    """
+    fim = int((datetime.now(timezone.utc) + timedelta(days=dias)).timestamp())
+    sub = {
+        "id": "sub_1",
+        "customer": "cus_1",
+        "status": status,
+        "cancel_at_period_end": False,
+        "items": {"data": [{"id": "si_1", "current_period_end": fim}]},
+    }
+    if ended_at is not None:
+        sub["ended_at"] = ended_at
+    return sub
+
+
+def _stub(monkeypatch, resposta, chamadas: list):
+    async def _fake(subscription_id: str) -> dict:
+        chamadas.append(subscription_id)
+        if isinstance(resposta, Exception):
+            raise resposta
+        return resposta
+
+    monkeypatch.setattr(billing, "fetch_subscription", _fake)
+
+
+async def _assinante_vencido(ac, db_session, **campos) -> User:
+    me = (await ac.get("/auth/me")).json()
+    user = (await db_session.execute(select(User).where(User.id == me["id"]))).scalar_one()
+    user.stripe_customer_id = "cus_1"
+    user.stripe_subscription_id = "sub_1"
+    user.subscription_status = "active"
+    user.premium_until = datetime.now(timezone.utc) - timedelta(days=2)
+    for campo, valor in campos.items():
+        setattr(user, campo, valor)
+    await db_session.commit()
+    return user
+
+
+@pytest.mark.asyncio
+async def test_a_paying_user_whose_webhook_was_lost_gets_access_back(
+    make_auth_client, db_session, monkeypatch, paywall_ligado
+):
+    alice = await make_auth_client("Alice")
+    user = await _assinante_vencido(alice, db_session)
+    chamadas = []
+    _stub(monkeypatch, _assinatura("active"), chamadas)
+
+    plan = (await alice.get("/auth/me")).json()["plan"]
+
+    assert chamadas == ["sub_1"]
+    assert plan["ai_allowed"] is True
+    assert plan["wallet_cap_applies"] is False
+    await db_session.refresh(user)
+    assert user.premium_until > datetime.now(timezone.utc)
+
+
+@pytest.mark.asyncio
+async def test_a_user_who_never_had_a_period_is_reconciled_too(
+    make_auth_client, db_session, monkeypatch
+):
+    # O caso mais doloroso: o checkout amarrou os ids e o
+    # `customer.subscription.created` se perdeu, então `premium_until` é NULL.
+    # A condição do ticket ("premium_until <= now") não pega NULL, e sem esta
+    # ampliação a pessoa pagaria e ficaria travada para sempre.
+    alice = await make_auth_client("Alice")
+    user = await _assinante_vencido(alice, db_session, premium_until=None, subscription_status=None)
+    chamadas = []
+    _stub(monkeypatch, _assinatura("active"), chamadas)
+
+    await alice.get("/auth/me")
+
+    assert chamadas == ["sub_1"]
+    await db_session.refresh(user)
+    assert user.premium_until is not None
+    assert user.premium_until > datetime.now(timezone.utc)
+
+
+@pytest.mark.asyncio
+async def test_a_free_user_never_pays_for_a_stripe_call(
+    make_auth_client, db_session, monkeypatch
+):
+    alice = await make_auth_client("Alice")
+    chamadas = []
+    _stub(monkeypatch, _assinatura(), chamadas)
+
+    assert (await alice.get("/auth/me")).status_code == 200
+    assert chamadas == []
+
+
+@pytest.mark.asyncio
+async def test_a_stripe_failure_is_logged_and_the_request_still_succeeds(
+    make_auth_client, db_session, monkeypatch, caplog
+):
+    # Reconciliação que dá 500 é PIOR que coluna velha: a coluna velha já está
+    # na direção segura.
+    alice = await make_auth_client("Alice")
+    user = await _assinante_vencido(alice, db_session)
+    vencido = user.premium_until
+    _stub(monkeypatch, RuntimeError("stripe fora do ar"), [])
+
+    with caplog.at_level("WARNING", logger="norby.billing"):
+        res = await alice.get("/auth/me")
+
+    assert res.status_code == 200
+    assert any("stripe" in r.message.lower() for r in caplog.records)
+    await db_session.refresh(user)
+    assert user.premium_until == vencido
+
+
+@pytest.mark.asyncio
+async def test_a_subscription_that_really_ended_is_not_asked_about_again(
+    make_auth_client, db_session, monkeypatch
+):
+    # A armadilha do gatilho: sem parar, quem cancelou de verdade continuaria
+    # casando com a condição e faria uma chamada ao Stripe em TODA requisição,
+    # para sempre. A própria reconciliação grava o status terminal que a desliga.
+    alice = await make_auth_client("Alice")
+    user = await _assinante_vencido(alice, db_session)
+    fim = int((datetime.now(timezone.utc) - timedelta(days=1)).timestamp())
+    chamadas = []
+    _stub(monkeypatch, _assinatura("canceled", ended_at=fim), chamadas)
+
+    await alice.get("/auth/me")
+    await db_session.refresh(user)
+    assert user.subscription_status == "canceled"
+    # `ended_at` manda, não o período: cancelamento imediato deixa o período
+    # apontando para o futuro e usá-lo daria acesso pago depois do fim.
+    assert user.premium_until < datetime.now(timezone.utc)
+
+    billing._ULTIMA_CONSULTA.clear()  # nem com a janela zerada
+    await alice.get("/auth/me")
+    assert chamadas == ["sub_1"]
+
+
+@pytest.mark.asyncio
+async def test_a_still_lapsed_subscription_is_not_asked_about_on_every_request(
+    make_auth_client, db_session, monkeypatch
+):
+    # `past_due` não é terminal: o Stripe ainda vai retentar. Sem a janela, cada
+    # requisição desta pessoa carregaria uma chamada de rede no caminho quente.
+    alice = await make_auth_client("Alice")
+    await _assinante_vencido(alice, db_session)
+    chamadas = []
+    _stub(monkeypatch, _assinatura("past_due", dias=-3), chamadas)
+
+    for _ in range(3):
+        assert (await alice.get("/auth/me")).status_code == 200
+
+    assert chamadas == ["sub_1"]
+
+
+@pytest.mark.asyncio
+async def test_both_gateway_calls_carry_the_secret_key(monkeypatch):
+    """Nada no app configurava `stripe.api_key` — ele era `None`.
+
+    Não é achado desta feature: o `cancel_subscription` já estava assim, e ele
+    roda na EXCLUSÃO DE CONTA, onde a recusa do gateway aborta a exclusão de
+    propósito. Ou seja, quem tivesse assinatura não conseguiria excluir a conta.
+    Invisível até hoje só porque ninguém tem assinatura ainda (#26).
+    """
+    settings = get_settings()
+    antes = settings.stripe_secret_key
+    settings.stripe_secret_key = "sk_test_xyz"
+    recebidas = {}
+
+    async def _retrieve(subscription_id, **kwargs):
+        recebidas["retrieve"] = kwargs.get("api_key")
+        return {"id": subscription_id}
+
+    async def _cancel(subscription_id, **kwargs):
+        recebidas["cancel"] = kwargs.get("api_key")
+
+    monkeypatch.setattr(billing.stripe.Subscription, "retrieve_async", _retrieve)
+    monkeypatch.setattr(billing.stripe.Subscription, "cancel_async", _cancel)
+    try:
+        await billing.fetch_subscription("sub_1")
+        await billing.cancel_subscription("sub_1")
+    finally:
+        settings.stripe_secret_key = antes
+
+    assert recebidas == {"retrieve": "sk_test_xyz", "cancel": "sk_test_xyz"}

--- a/backend/tests/test_billing_webhook.py
+++ b/backend/tests/test_billing_webhook.py
@@ -318,3 +318,27 @@ async def test_checkout_arriving_first_does_not_block_the_subscription_that_open
 
     await db_session.refresh(user)
     assert user.premium_until == datetime.fromtimestamp(fim, timezone.utc)
+
+
+@pytest.mark.asyncio
+async def test_the_period_end_is_read_from_the_item_when_it_is_not_at_the_top(
+    client, db_session
+):
+    """A versão de API que o SDK 15 fixa (2026-07-29.dahlia) NÃO tem mais
+    `current_period_end` no topo da assinatura — o campo mora em cada item.
+
+    Ler só o topo devolveria None e apagaria o `premium_until` de quem paga, que
+    é o portão inteiro do ADR 0001. O topo continua sendo lido primeiro porque
+    conta com versão antiga fixada no endpoint ainda manda ali.
+    """
+    user = await _usuario_com_customer(client, db_session, email="itens@test.com")
+    fim = AGORA_TS + 30 * 86400
+
+    evento = _evento_assinatura(event_id="evt_itens")
+    del evento["data"]["object"]["current_period_end"]
+    evento["data"]["object"]["items"] = {"data": [{"id": "si_1", "current_period_end": fim}]}
+
+    assert (await _postar(client, evento)).status_code == 200
+
+    await db_session.refresh(user)
+    assert user.premium_until == datetime.fromtimestamp(fim, timezone.utc)

--- a/docs/adr/0001-modelo-de-assinatura.md
+++ b/docs/adr/0001-modelo-de-assinatura.md
@@ -41,6 +41,17 @@ que sim, e a seção "Acoplamento" abaixo diz exatamente o que muda se não for.
 `users.premium_until` guarda o `current_period_end` do Stripe e é **a única
 coluna que a autorização lê**.
 
+> **Correção de 2026-09-04 (issue #48): o campo mudou de lugar no Stripe.**
+> Na versão de API que o SDK 15 fixa (`2026-07-29.dahlia`) `current_period_end`
+> **não existe mais no topo da assinatura** — ele mora em cada item
+> (`items.data[].current_period_end`). O código lia só o topo, então uma conta
+> com versão moderna devolveria `None` e **apagaria o `premium_until` de quem
+> paga**: o portão nunca abriria. Isso estava em `main` desde o #45 e passou
+> despercebido porque as fixtures de teste foram escritas na forma antiga.
+> A leitura agora tenta o topo primeiro (conta com versão antiga fixada no
+> endpoint ainda manda ali) e cai para os itens. Fica num helper só, o mesmo
+> que o webhook e a reconciliação usam.
+
 O Stripe não move `current_period_end` quando o cartão falha — ele continua
 tentando cobrar dentro do período já pago. Logo a data, sozinha, já responde
 "essa pessoa tem acesso agora". Três consequências caem de graça:
@@ -201,6 +212,14 @@ para trás.
 
 ### Chamadas de saída ao Stripe — três
 
+> **Correção de 2026-09-04 (issue #48): a chave nunca chegava ao SDK.**
+> Nada no app atribuía `stripe.api_key`, que ficava `None` — a primeira chamada
+> real de saída falharia por autenticação. O `stripe_secret_key` existia no
+> `Settings` e não era usado por ninguém. O efeito mais grave não era nesta
+> feature: **quem tivesse assinatura não conseguiria excluir a conta**, porque
+> a recusa do gateway aborta a exclusão de propósito (ver a seção abaixo). As
+> saídas passam a receber `api_key` explicitamente, por chamada.
+
 - criar sessão de **Checkout hospedado** (`client_reference_id = user.id`)
 - criar sessão de **Customer Portal**
 - cancelar assinatura — só a área de admin (#23)
@@ -245,6 +264,33 @@ Não existe scheduler neste projeto; o padrão é o mesmo do
 desenho já falha fechado, a reconciliação não existe para proteger receita —
 existe para consertar a única direção que machuca cliente pagante: pagou, o
 webhook se perdeu, e o app diz que ele não é premium.
+
+> **Ajustes de 2026-09-04, na implementação (issue #48).** Três, todos com
+> teste:
+>
+> 1. **`premium_until` NULO entra no gatilho**, não só o vencido. É o caso do
+>    `customer.subscription.created` perdido: o checkout amarrou os ids e o
+>    período nunca chegou. Sem isso, quem pagou ficaria travado para sempre —
+>    exatamente a dor que a reconciliação existe para curar.
+> 2. **Status terminal não é consultado de novo.** `canceled` e
+>    `incomplete_expired` casariam com o gatilho para sempre (vencido, com
+>    `subscription_id` preenchido) e fariam uma chamada de rede em **toda**
+>    requisição daquela pessoa. A própria reconciliação grava o status que a
+>    desliga, então ela se auto-limita.
+> 3. **Uma janela de 15 minutos por usuário**, porque `past_due` com período
+>    vencido não é terminal e cairia na mesma repetição durante todo o
+>    cronograma de retry do Stripe. É cache em processo, o que basta para um
+>    worker de uvicorn; vira coluna `plan_synced_at` no dia em que rodar com
+>    mais de um.
+>
+> Onde ela dispara: no `get_current_user`, e não nos leitores de plano. Eles
+> (`ai_gate_open`, `wallet_cap_active`, o objeto `plan`) são funções puras sem
+> sessão, e o `get_current_user` é o único ponto por onde a linha do usuário
+> entra numa requisição autenticada.
+>
+> A marca d'água `stripe_event_at` **não se move** na reconciliação: carimbá-la
+> com o nosso relógio faria um webhook legítimo chegando logo depois entrar
+> como atrasado por diferença de relógio.
 
 ### Testes de billing sem falar com o Stripe
 


### PR DESCRIPTION
Wave 4 leftover of #15, unblocked by #20. From [ADR 0001](https://github.com/DigoDuck/Norby/blob/main/docs/adr/0001-modelo-de-assinatura.md).

Closes #48.

## What it is for

The model already fails closed: a lost event can only let access lapse, never grant it. So this is **not** revenue protection. It exists for the one direction that hurts a paying customer — they paid, the event was lost, and the app tells them they are not premium.

It rides along on the request, the same pattern as `materialize_due_recurring`. No scheduler here, and this does not add one.

## Where it runs, and why there

`get_current_user`. Not in the plan readers: `ai_gate_open`, `wallet_cap_active` and the `plan` object are pure functions with no session, and `get_current_user` is the only point where the user row enters an authenticated request. In the common case it is a comparison of columns already loaded — **a user with no subscription pays nothing**, and there is a test that fails if a free user's request reaches the gateway.

## Three adjustments to the trigger the ticket describes

1. **A NULL `premium_until` is included**, not only a lapsed one. That is the lost `customer.subscription.created`: checkout wired the ids and the period never arrived. The ticket said `premium_until <= now`, which does not match NULL — and without the widening the person who paid stays stuck forever, which is the exact pain this feature exists to cure.
2. **A terminal status is never asked about again.** `canceled` would keep matching the trigger (lapsed, with a `subscription_id`) and put a network call on **every** request from that person, forever. The reconciliation itself writes the status that switches it off, so it is self-limiting.
3. **A 15 minute window per user**, because `past_due` with an expired period is not terminal and would repeat for the whole Stripe retry schedule. It is an in-process cache — enough for one uvicorn worker (see `start.sh`), and it becomes a `plan_synced_at` column the day this runs with more than one. Marked with a `ponytail:` comment naming that ceiling.

A Stripe failure is logged and the request still succeeds: a reconciliation that 500s is worse than a stale column, because the stale column is already the safe direction.

The reconciliation reuses `_aplicar`, the webhook's writer, instead of a second write path. Two paths writing the same columns drift, and drift here means wrong paid access.

`stripe_event_at` deliberately does **not** move: stamping the ordering watermark with our clock would make a legitimate webhook arriving right after look late because of clock skew.

## Two defects found on the way

Both were already on `main`, and both are invisible only because no Stripe account exists yet (#26). Neither belongs to this feature; both block it.

### `current_period_end` is not at the top of a subscription any more

In the API version the SDK pins — `2026-07-29.dahlia`, verified in the container — the field **does not exist** on the subscription. It lives on each item, `items.data[].current_period_end`.

The webhook path read only the top level. Against a real modern account that returns `None`, so `premium_until` would be **wiped for a paying customer** and the gate would never open. It is the core of ADR 0001 and it went unnoticed because the test fixtures were written in the old shape.

Fixed in one helper that both the webhook and the reconciliation use: top level first (an endpoint pinned to an old version still sends it there), items as the fallback. There is a webhook test with the modern payload that fails without the fix.

### `stripe.api_key` was never assigned

Nothing in the app set it — it was `None`, and `stripe_secret_key` sat in `Settings` unused. The worst consequence is not here: **a subscriber could not delete their account**, because a gateway refusal aborts the deletion on purpose (ADR 0001 says so, and it is the right call). The key now travels explicitly on each outbound call, with a test asserting both of them carry it.

## Verified by mutation

Five, each killing only what it should:

- no terminal-status guard → the "not asked again" test fails
- no window → the "not on every request" test fails
- period read only at the top level → 3 tests fail, including the webhook one
- no subscription check in the trigger → 5 fail, including the free user
- Stripe failure propagating instead of being logged → the failure test fails

## Verification

239 backend tests, up from 231. ADR 0001 carries all three corrections, dated.

## What is left before the flag can be switched on

**#46** (Checkout and Portal), still blocked by **#26**. And #26 got heavier with this PR: whoever sets the account up now also has to confirm the API version pinned on the webhook endpoint, because that is what decides which of the two payload shapes actually arrives.
