### PR TITLE
chore(ai): bound the Gemini calls and move to the maintained SDK

### DIFF
--- a/backend/app/services/ai_service.py
+++ b/backend/app/services/ai_service.py
@@ -1,4 +1,5 @@
-import google.generativeai as genai
+from google import genai
+from google.genai import types
 from datetime import datetime, timezone
 from sqlalchemy import select, func
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -8,7 +9,6 @@ from app.services.dashboard_service import _income_expense, top_expense_categori
 from app.services.goal_service import current_month_range
 from app.services.score_service import compute_financial_score
 from app.config import get_settings
-import asyncio
 import hashlib
 import json
 import logging
@@ -19,8 +19,56 @@ logger = logging.getLogger(__name__)
 MAX_CHAT_HISTORY_MESSAGES = 10
 
 settings = get_settings()
-genai.configure(api_key=settings.gemini_api_key)
-model = genai.GenerativeModel("models/gemini-3.5-flash-lite")
+
+# SDK MANTIDO (issue #40). O `google-generativeai` foi arquivado em novembro de
+# 2025, sem correção de bug nem de segurança, e o modelo daqui é posterior a
+# essa data. A troca também ENCOLHE o código: este cliente fala async nativo,
+# então os dois `asyncio.to_thread` que existiam para não travar o event loop
+# saíram junto.
+client = genai.Client(api_key=settings.gemini_api_key)
+MODELO = "gemini-3.5-flash-lite"
+
+# Teto de saída POR CHAMADA. Sem ele uma única chamada não tem limite de custo.
+# É outra coisa do teto diário em desenho no #21: aquele limita quanto a pessoa
+# gasta por dia, este limita o quão ruim UMA chamada consegue ser. Os valores
+# são folgados de propósito — o JSON do insight tem ~100 tokens e a resposta do
+# chat é curta —, porque truncar a saída só troca custo por resposta quebrada.
+MAX_TOKENS_INSIGHT = 512
+MAX_TOKENS_CHAT = 1024
+
+
+async def _gerar_json(prompt: str) -> str:
+    """Saída de rede da geração de insight. É ela que os testes stubam.
+
+    `response_mime_type` força JSON puro (sem cercas de markdown), o que torna
+    o parse confiável mesmo num modelo pequeno como o Lite.
+    """
+    resposta = await client.aio.models.generate_content(
+        model=MODELO,
+        contents=prompt,
+        config=types.GenerateContentConfig(
+            response_mime_type="application/json",
+            max_output_tokens=MAX_TOKENS_INSIGHT,
+        ),
+    )
+    return resposta.text or ""
+
+
+async def _responder_chat(historico: list, mensagem: str) -> str:
+    """Saída de rede do chat. A outra que os testes stubam."""
+    chat = client.aio.chats.create(model=MODELO, history=historico)
+    resposta = await chat.send_message(
+        mensagem,
+        config=types.GenerateContentConfig(max_output_tokens=MAX_TOKENS_CHAT),
+    )
+    if not resposta.text:
+        # Vazia, bloqueada por safety filter ou truncada antes do primeiro
+        # token. Levantar preserva o 503 claro da rota: devolver "" gravaria
+        # uma bolha VAZIA no histórico como se a IA tivesse respondido. O SDK
+        # antigo levantava sozinho aqui; este devolve None, então a guarda
+        # passa a ser nossa.
+        raise ValueError("resposta vazia do Gemini")
+    return resposta.text
 
 async def _get_user_financial_summary(db: AsyncSession, user_id: str) -> dict:
     """Resumo do mês corrente, reusando os agregados do dashboard.
@@ -115,24 +163,17 @@ async def get_or_generate_insight(db: AsyncSession, user_id: str) -> dict:
     # A IA pode falhar na chamada (API/rede/quota) ou devolver texto não-JSON,
     # vazio ou bloqueado por safety filter — qualquer uma dessas falhas não
     # pode derrubar o score determinístico já calculado.
-    response = None
+    bruto = ""
     try:
-        # Chamada bloqueante do SDK -> offload p/ thread pra não travar o event loop
-        # response_mime_type força JSON puro na saída (sem cercas de markdown),
-        # o que torna o parse confiável mesmo num modelo pequeno como o Lite.
-        response = await asyncio.to_thread(
-            model.generate_content,
-            prompt,
-            generation_config={"response_mime_type": "application/json"},
-        )
-        data = json.loads(response.text)
+        bruto = await _gerar_json(prompt)
+        data = json.loads(bruto)
         summary_text = data["summary_text"]
         suggested_action = data["suggested_action"]
     except Exception:
         # Nunca logar o texto cru: ele é a leitura financeira do usuário e pode
         # conter valores e categorias. Tipo da exceção + tamanho bastam para
         # diagnosticar um parse quebrado.
-        raw_len = len(getattr(response, "text", "") or "")
+        raw_len = len(bruto)
         logger.exception(
             "Resposta da IA inválida ao gerar insight (user=%s, chars=%d)",
             user_id, raw_len,
@@ -197,11 +238,6 @@ async def chat_with_ai(db: AsyncSession, user_id: str, message: str, history: li
         if not content:
             continue
         role = "user" if msg.get("role") == "user" else "model"
-        chat_history.append({"role": role, "parts": [content]})
-        
-    chat = model.start_chat(history=chat_history)
-    # Chamada bloqueante do SDK -> offload p/ thread
-    response = await asyncio.to_thread(
-        chat.send_message, f"{system_context}\n\nUsuário: {message}"
-    )
-    return response.text
+        chat_history.append(types.Content(role=role, parts=[types.Part(text=content)]))
+
+    return await _responder_chat(chat_history, f"{system_context}\n\nUsuário: {message}")

--- a/backend/requirements-dev.lock
+++ b/backend/requirements-dev.lock
@@ -8,6 +8,7 @@ annotated-types==0.7.0
     # via pydantic
 anyio==4.14.2
     # via
+    #   google-genai
     #   httpx
     #   starlette
     #   watchfiles
@@ -38,7 +39,6 @@ colorama==0.4.6 ; sys_platform == 'win32'
     # via
     #   click
     #   pytest
-    #   tqdm
     #   uvicorn
 cryptography==50.0.0
     # via
@@ -51,6 +51,8 @@ defusedxml==0.7.1
     # via py-serializable
 deprecated==1.3.1
     # via limits
+distro==1.9.0
+    # via google-genai
 dnspython==2.8.0
     # via
     #   email-validator
@@ -63,57 +65,24 @@ fastapi==0.141.1
     # via -r requirements.txt
 filelock==3.32.0
     # via cachecontrol
-google-ai-generativelanguage==0.6.15
-    # via google-generativeai
-google-api-core==2.25.2 ; python_full_version >= '3.14'
-    # via
-    #   google-ai-generativelanguage
-    #   google-api-python-client
-    #   google-generativeai
-google-api-core==2.32.0 ; python_full_version < '3.14'
-    # via
-    #   google-ai-generativelanguage
-    #   google-api-python-client
-    #   google-generativeai
-google-api-python-client==2.198.0
-    # via google-generativeai
 google-auth==2.56.2
-    # via
-    #   google-ai-generativelanguage
-    #   google-api-core
-    #   google-api-python-client
-    #   google-auth-httplib2
-    #   google-generativeai
-google-auth-httplib2==0.4.0
-    # via google-api-python-client
-google-generativeai==0.8.6
+    # via google-genai
+google-genai==2.22.0
     # via -r requirements.txt
-googleapis-common-protos==1.75.0
-    # via
-    #   google-api-core
-    #   grpcio-status
 greenlet==3.5.3
     # via sqlalchemy
-grpcio==1.82.1
-    # via
-    #   google-api-core
-    #   grpcio-status
-grpcio-status==1.71.2
-    # via google-api-core
 h11==0.16.0
     # via
     #   httpcore
     #   uvicorn
 httpcore==1.0.9
     # via httpx
-httplib2==0.32.0
-    # via
-    #   google-api-python-client
-    #   google-auth-httplib2
 httptools==0.8.0
     # via uvicorn
-httpx==0.27.2
-    # via -r requirements-dev.txt
+httpx==0.28.1
+    # via
+    #   -r requirements-dev.txt
+    #   google-genai
 idna==3.18
     # via
     #   anyio
@@ -160,18 +129,6 @@ platformdirs==4.11.0
     # via pip-audit
 pluggy==1.6.0
     # via pytest
-proto-plus==1.28.1
-    # via
-    #   google-ai-generativelanguage
-    #   google-api-core
-protobuf==5.29.6
-    # via
-    #   google-ai-generativelanguage
-    #   google-api-core
-    #   google-generativeai
-    #   googleapis-common-protos
-    #   grpcio-status
-    #   proto-plus
 py-serializable==2.1.0
     # via cyclonedx-python-lib
 pyasn1==0.6.4
@@ -186,7 +143,7 @@ pycparser==3.0 ; implementation_name != 'PyPy'
 pydantic==2.13.4
     # via
     #   fastapi
-    #   google-generativeai
+    #   google-genai
     #   pydantic-settings
 pydantic-core==2.46.4
     # via pydantic
@@ -197,9 +154,7 @@ pygments==2.20.0
 pymongo==4.9.2
     # via motor
 pyparsing==3.3.2
-    # via
-    #   httplib2
-    #   pip-requirements-parser
+    # via pip-requirements-parser
 pytest==8.3.3
     # via
     #   -r requirements-dev.txt
@@ -218,7 +173,8 @@ pyyaml==6.0.3
 requests==2.34.2
     # via
     #   cachecontrol
-    #   google-api-core
+    #   google-auth
+    #   google-genai
     #   pip-audit
     #   stripe
 rich==15.0.0
@@ -230,7 +186,7 @@ six==1.17.0
 slowapi==0.1.10
     # via -r requirements.txt
 sniffio==1.3.1
-    # via httpx
+    # via google-genai
 sortedcontainers==2.4.0
     # via cyclonedx-python-lib
 sqlalchemy==2.0.36
@@ -241,20 +197,19 @@ starlette==1.3.1
     # via fastapi
 stripe==15.5.1
     # via -r requirements.txt
+tenacity==9.1.4
+    # via google-genai
 tomli==2.4.1
     # via pip-audit
 tomli-w==1.2.0
     # via pip-audit
-tqdm==4.69.0
-    # via google-generativeai
 typing-extensions==4.16.0
     # via
     #   alembic
     #   anyio
     #   cyclonedx-python-lib
     #   fastapi
-    #   google-generativeai
-    #   grpcio
+    #   google-genai
     #   limits
     #   pydantic
     #   pydantic-core
@@ -267,8 +222,6 @@ typing-inspection==0.4.2
     #   fastapi
     #   pydantic
     #   pydantic-settings
-uritemplate==4.2.0
-    # via google-api-python-client
 urllib3==2.7.0
     # via requests
 uvicorn==0.30.6
@@ -278,6 +231,8 @@ uvloop==0.22.1 ; platform_python_implementation != 'PyPy' and sys_platform != 'c
 watchfiles==1.2.0
     # via uvicorn
 websockets==16.1.1
-    # via uvicorn
+    # via
+    #   google-genai
+    #   uvicorn
 wrapt==2.2.2
     # via deprecated

--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -2,5 +2,5 @@
 -r requirements.txt
 pytest==8.3.3
 pytest-asyncio==0.24.0
-httpx==0.27.2  # cliente de teste (AsyncClient); não é dep de produção
+httpx==0.28.1  # cliente de teste (AsyncClient); não é dep de produção
 pip-audit==2.10.1

--- a/backend/requirements.lock
+++ b/backend/requirements.lock
@@ -8,6 +8,8 @@ annotated-types==0.7.0
     # via pydantic
 anyio==4.14.2
     # via
+    #   google-genai
+    #   httpx
     #   starlette
     #   watchfiles
 asyncpg==0.30.0
@@ -17,7 +19,10 @@ bcrypt==3.2.2
     #   -r requirements.txt
     #   passlib
 certifi==2026.6.17
-    # via requests
+    # via
+    #   httpcore
+    #   httpx
+    #   requests
 cffi==2.1.0
     # via
     #   bcrypt
@@ -29,7 +34,6 @@ click==8.4.2
 colorama==0.4.6 ; sys_platform == 'win32'
     # via
     #   click
-    #   tqdm
     #   uvicorn
 cryptography==50.0.0
     # via
@@ -38,6 +42,8 @@ cryptography==50.0.0
     #   python-jose
 deprecated==1.3.1
     # via limits
+distro==1.9.0
+    # via google-genai
 dnspython==2.8.0
     # via
     #   email-validator
@@ -48,55 +54,27 @@ email-validator==2.3.0
     # via -r requirements.txt
 fastapi==0.141.1
     # via -r requirements.txt
-google-ai-generativelanguage==0.6.15
-    # via google-generativeai
-google-api-core==2.25.2 ; python_full_version >= '3.14'
-    # via
-    #   google-ai-generativelanguage
-    #   google-api-python-client
-    #   google-generativeai
-google-api-core==2.32.0 ; python_full_version < '3.14'
-    # via
-    #   google-ai-generativelanguage
-    #   google-api-python-client
-    #   google-generativeai
-google-api-python-client==2.198.0
-    # via google-generativeai
 google-auth==2.56.2
-    # via
-    #   google-ai-generativelanguage
-    #   google-api-core
-    #   google-api-python-client
-    #   google-auth-httplib2
-    #   google-generativeai
-google-auth-httplib2==0.4.0
-    # via google-api-python-client
-google-generativeai==0.8.6
+    # via google-genai
+google-genai==2.22.0
     # via -r requirements.txt
-googleapis-common-protos==1.75.0
-    # via
-    #   google-api-core
-    #   grpcio-status
 greenlet==3.5.3
     # via sqlalchemy
-grpcio==1.82.1
-    # via
-    #   google-api-core
-    #   grpcio-status
-grpcio-status==1.71.2
-    # via google-api-core
 h11==0.16.0
-    # via uvicorn
-httplib2==0.32.0
     # via
-    #   google-api-python-client
-    #   google-auth-httplib2
+    #   httpcore
+    #   uvicorn
+httpcore==1.0.9
+    # via httpx
 httptools==0.8.0
     # via uvicorn
+httpx==0.28.1
+    # via google-genai
 idna==3.18
     # via
     #   anyio
     #   email-validator
+    #   httpx
     #   requests
 limits==5.8.0
     # via slowapi
@@ -110,18 +88,6 @@ packaging==26.2
     # via limits
 passlib==1.7.4
     # via -r requirements.txt
-proto-plus==1.28.1
-    # via
-    #   google-ai-generativelanguage
-    #   google-api-core
-protobuf==5.29.6
-    # via
-    #   google-ai-generativelanguage
-    #   google-api-core
-    #   google-generativeai
-    #   googleapis-common-protos
-    #   grpcio-status
-    #   proto-plus
 pyasn1==0.6.4
     # via
     #   pyasn1-modules
@@ -134,7 +100,7 @@ pycparser==3.0 ; implementation_name != 'PyPy'
 pydantic==2.13.4
     # via
     #   fastapi
-    #   google-generativeai
+    #   google-genai
     #   pydantic-settings
 pydantic-core==2.46.4
     # via pydantic
@@ -142,8 +108,6 @@ pydantic-settings==2.15.0
     # via -r requirements.txt
 pymongo==4.9.2
     # via motor
-pyparsing==3.3.2
-    # via httplib2
 python-dotenv==1.2.3
     # via
     #   -r requirements.txt
@@ -155,7 +119,8 @@ pyyaml==6.0.3
     # via uvicorn
 requests==2.34.2
     # via
-    #   google-api-core
+    #   google-auth
+    #   google-genai
     #   stripe
 rsa==4.9.1
     # via python-jose
@@ -163,6 +128,8 @@ six==1.17.0
     # via ecdsa
 slowapi==0.1.10
     # via -r requirements.txt
+sniffio==1.3.1
+    # via google-genai
 sqlalchemy==2.0.36
     # via
     #   -r requirements.txt
@@ -171,15 +138,14 @@ starlette==1.3.1
     # via fastapi
 stripe==15.5.1
     # via -r requirements.txt
-tqdm==4.69.0
-    # via google-generativeai
+tenacity==9.1.4
+    # via google-genai
 typing-extensions==4.16.0
     # via
     #   alembic
     #   anyio
     #   fastapi
-    #   google-generativeai
-    #   grpcio
+    #   google-genai
     #   limits
     #   pydantic
     #   pydantic-core
@@ -192,8 +158,6 @@ typing-inspection==0.4.2
     #   fastapi
     #   pydantic
     #   pydantic-settings
-uritemplate==4.2.0
-    # via google-api-python-client
 urllib3==2.7.0
     # via requests
 uvicorn==0.30.6
@@ -203,6 +167,8 @@ uvloop==0.22.1 ; platform_python_implementation != 'PyPy' and sys_platform != 'c
 watchfiles==1.2.0
     # via uvicorn
 websockets==16.1.1
-    # via uvicorn
+    # via
+    #   google-genai
+    #   uvicorn
 wrapt==2.2.2
     # via deprecated

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -13,7 +13,7 @@ cryptography==50.0.0
 passlib[bcrypt]==1.7.4
 python-dotenv==1.2.3
 pydantic-settings==2.15.0
-google-generativeai==0.8.6
+google-genai==2.22.0
 email-validator==2.3.0
 bcrypt==3.2.2
 slowapi==0.1.10

--- a/backend/tests/test_ai.py
+++ b/backend/tests/test_ai.py
@@ -3,16 +3,20 @@ from decimal import Decimal
 
 import pytest
 
+from google.genai import chats as genai_chats
+
 import app.services.ai_service as ai
 from app.limiter import limiter
 from app.models.sql_models import User, Wallet
 
 
-class _FakeChat:
-    def send_message(self, _message):
-        class _Resp:
-            text = "resposta ok"
-        return _Resp()
+def _chat_que_registra(recebido: list):
+    """Stub da saída de rede do chat. Guarda o histórico que chegou, que é o
+    que este teste precisa inspecionar."""
+    async def _responder(historico, _mensagem):
+        recebido.extend(historico)
+        return "resposta ok"
+    return _responder
 
 
 @pytest.mark.asyncio
@@ -25,11 +29,15 @@ async def test_chat_survives_malformed_history_message(db_session, monkeypatch):
     await db_session.commit()
 
     # Não bate na API real do Gemini.
-    monkeypatch.setattr(ai.model, "start_chat", lambda history: _FakeChat())
+    recebido = []
+    monkeypatch.setattr(ai, "_responder_chat", _chat_que_registra(recebido))
 
     history = [{"foo": "bar"}, {"role": "user", "content": "oi"}]  # 1ª é malformada
     resp = await ai.chat_with_ai(db_session, str(user.id), "olá", history)
     assert resp == "resposta ok"
+    # A malformada foi pulada, e não virou uma Content vazia.
+    assert len(recebido) == 1
+    assert recebido[0].parts[0].text == "oi"
 
 
 class _FakeInsights:
@@ -60,10 +68,10 @@ async def test_insight_score_is_deterministic_not_from_llm(db_session, monkeypat
     monkeypatch.setattr(ai, "_get_user_financial_summary", _fake_summary)
     monkeypatch.setattr(ai, "ai_insights_collection", _FakeInsights())
 
-    class _Resp:
-        text = '{"summary_text": "a|b|c", "suggested_action": "faça X"}'
+    async def _resposta(_prompt):
+        return '{"summary_text": "a|b|c", "suggested_action": "faça X"}'
 
-    monkeypatch.setattr(ai.model, "generate_content", lambda _p, **_kw: _Resp())
+    monkeypatch.setattr(ai, "_gerar_json", _resposta)
 
     result = await ai.get_or_generate_insight(db_session, "user-1")
     assert result["score"] == 90
@@ -89,10 +97,10 @@ async def test_insight_returns_score_when_llm_text_fails(db_session, monkeypatch
     monkeypatch.setattr(ai, "_get_user_financial_summary", _fake_summary)
     monkeypatch.setattr(ai, "ai_insights_collection", _FakeInsights())
 
-    class _BadResp:
-        text = "desculpe, não consegui"
+    async def _nao_e_json(_prompt):
+        return "desculpe, não consegui"
 
-    monkeypatch.setattr(ai.model, "generate_content", lambda _p, **_kw: _BadResp())
+    monkeypatch.setattr(ai, "_gerar_json", _nao_e_json)
 
     result = await ai.get_or_generate_insight(db_session, "user-1")
     assert result["score"] == 90
@@ -118,10 +126,10 @@ async def test_insight_returns_score_when_llm_call_raises(db_session, monkeypatc
     monkeypatch.setattr(ai, "_get_user_financial_summary", _fake_summary)
     monkeypatch.setattr(ai, "ai_insights_collection", _FakeInsights())
 
-    def _boom(_p, **_kw):
+    async def _boom(_prompt):
         raise RuntimeError("gemini down")
 
-    monkeypatch.setattr(ai.model, "generate_content", _boom)
+    monkeypatch.setattr(ai, "_gerar_json", _boom)
 
     result = await ai.get_or_generate_insight(db_session, "user-1")
     assert result["score"] == 90
@@ -165,10 +173,10 @@ async def test_insight_recomputes_score_on_cache_hit(db_session, monkeypatch):
         ai, "ai_insights_collection", _FakeInsightsCacheHit(ai._summary_fingerprint(summary))
     )
     # Se reaproveitar o cache, o Gemini nem é chamado.
-    def _boom(_p, **_kw):
+    async def _boom(_prompt):
         raise AssertionError("não deve chamar o Gemini quando o fingerprint bate")
 
-    monkeypatch.setattr(ai.model, "generate_content", _boom)
+    monkeypatch.setattr(ai, "_gerar_json", _boom)
 
     result = await ai.get_or_generate_insight(db_session, "user-1")
     assert result["score"] == 90
@@ -214,10 +222,10 @@ async def test_insight_regenerates_text_when_data_changes(db_session, monkeypatc
     monkeypatch.setattr(ai, "_get_user_financial_summary", _fake_summary)
     monkeypatch.setattr(ai, "ai_insights_collection", fake)
 
-    class _Resp:
-        text = '{"summary_text": "novo|texto|fresco", "suggested_action": "nova ação"}'
+    async def _resposta(_prompt):
+        return '{"summary_text": "novo|texto|fresco", "suggested_action": "nova ação"}'
 
-    monkeypatch.setattr(ai.model, "generate_content", lambda _p, **_kw: _Resp())
+    monkeypatch.setattr(ai, "_gerar_json", _resposta)
 
     result = await ai.get_or_generate_insight(db_session, "user-1")
     assert result["score"] == 100
@@ -281,3 +289,53 @@ async def test_ai_rate_limit_is_per_user_not_per_ip(make_auth_client, monkeypatc
     finally:
         limiter.enabled = False
         limiter.reset()
+
+
+@pytest.mark.asyncio
+async def test_both_gemini_calls_carry_an_output_ceiling(monkeypatch):
+    """Nenhuma das duas chamadas limitava o tamanho da resposta, então uma
+    chamada sozinha não tinha teto de custo.
+
+    Independente do teto DIÁRIO em desenho no #21: aquele limita quanto a
+    pessoa gasta por dia, este limita o quão ruim UMA chamada consegue ser.
+    """
+    from types import SimpleNamespace
+
+    capturado = {}
+
+    async def _fake_generate(*, model, contents, config):
+        capturado["insight"] = config.max_output_tokens
+        return SimpleNamespace(text='{"summary_text": "a", "suggested_action": "b"}')
+
+    async def _fake_send(self, _mensagem, config=None):
+        capturado["chat"] = config.max_output_tokens
+        return SimpleNamespace(text="ok")
+
+    # `client.aio.chats` é uma property que devolve objeto NOVO a cada acesso,
+    # então stubar a instância pegaria uma cópia descartável. Stubando a classe,
+    # o `chats.create` de verdade roda e ainda valida o histórico tipado.
+    monkeypatch.setattr(ai.client.aio.models, "generate_content", _fake_generate)
+    monkeypatch.setattr(genai_chats.AsyncChat, "send_message", _fake_send)
+
+    assert await ai._gerar_json("prompt") == '{"summary_text": "a", "suggested_action": "b"}'
+    assert await ai._responder_chat([], "oi") == "ok"
+
+    assert capturado["insight"] == ai.MAX_TOKENS_INSIGHT > 0
+    assert capturado["chat"] == ai.MAX_TOKENS_CHAT > 0
+
+
+@pytest.mark.asyncio
+async def test_an_empty_chat_answer_raises_instead_of_being_stored(monkeypatch):
+    """O SDK antigo levantava quando a resposta vinha vazia ou bloqueada; este
+    devolve None. Sem a guarda, o "" chegaria à rota, seria GRAVADO no
+    histórico como mensagem da IA e viraria uma bolha vazia — em vez do 503
+    claro que a rota já sabe dar."""
+    from types import SimpleNamespace
+
+    async def _vazia(self, _mensagem, config=None):
+        return SimpleNamespace(text=None)
+
+    monkeypatch.setattr(genai_chats.AsyncChat, "send_message", _vazia)
+
+    with pytest.raises(ValueError):
+        await ai._responder_chat([], "oi")


### PR DESCRIPTION
Closes #40. Part of #15's execution backlog, surfaced by #18.

## The ceiling

Neither call set `max_output_tokens`, so **one call had no cost ceiling at all**. This is independent of the daily cap being designed in #21: that one limits what a person spends per day, this one limits how bad a single call can get.

`MAX_TOKENS_INSIGHT = 512`, `MAX_TOKENS_CHAT = 1024`. Deliberately generous — the insight JSON is around 100 tokens and a chat answer is short — because truncating the output only trades cost for a broken answer.

## The SDK

`google-generativeai` has been archived since November 2025, and the model this repo uses is newer than that.

The issue makes the migration **conditional**: verify `usage_metadata` first, because if it is not populated the daily cap has no input and the migration stops being optional. So I verified it against the real key before touching anything.

**It is populated**, on the archived SDK: `prompt_token_count`, `candidates_token_count`, `total_token_count`. So the migration was never forced.

I did it anyway, for a reason the ticket could not know: **the maintained client speaks async natively**, so both `asyncio.to_thread` offloads went away with it. The change removes code rather than adding it, and the deprecation warning stops printing on every test run.

## What the migration turned up

The new SDK returns `None` where the old one raised, for an answer that is empty or blocked by a safety filter.

Passed through, that empty string would be **stored in the chat history as an assistant message** and rendered as an empty bubble — instead of the clear 503 the route already knows how to give. Guarded, with a test that fails without it.

## Verified against the real API, not assumed

One minimal call per SDK, with the project's own key:

| | archived SDK 0.8.6 | google-genai 2.22.0 |
|---|---|---|
| model answers | yes | yes |
| `prompt/candidates/total_token_count` | yes | yes |
| `thoughts_token_count` | **absent** | present (`None` when unused) |
| native async | no | yes |

That last row matters for **#21**: a daily cap built on the archived SDK could not see thinking tokens at all. On a model that starts using them, the cap would undercount.

## Verified by mutation

- ceiling removed from the insight config → the ceiling test fails
- empty-answer guard removed → the empty-answer test fails

## Seams

`_gerar_json` and `_responder_chat` are the two network calls; the behavioural tests stub those, and one test asserts the ceiling at the SDK boundary itself. Same shape as `fetch_subscription` in billing.

The chat stub patches `AsyncChat.send_message` on the class rather than the instance, because `client.aio.chats` is a property that returns a fresh object on every access — patching the instance would have silently patched a throwaway.

## Dependencies

`httpx` moves to 0.28.1 because `google-genai` requires it. It is a dev-only dependency (the test client), and the `ASGITransport` usage is unchanged. Both locks regenerated; the lock guard from #62 passes.

## Verification

241 backend tests, up from 239. One warning instead of two — the archived-SDK notice is gone.

## Left for the owner

**Whether the production key is on the free or the paid Gemini tier.** The issue asks to capture it, and it is not readable from the API — it lives in the Google AI Studio console. #21 needs it to pick a number, so it is an owner task, like #26.
