### PR TITLE
feat(profile): profile photo, resized server-side and stored on the row

### DIFF
--- a/backend/alembic/versions/a1f4c9d2e7b3_add_user_photo.py
+++ b/backend/alembic/versions/a1f4c9d2e7b3_add_user_photo.py
@@ -1,0 +1,32 @@
+"""add user photo
+
+Revision ID: a1f4c9d2e7b3
+Revises: 154dd832e2d8
+Create Date: 2026-09-04
+
+Foto de perfil (issue #35). Duas colunas NULÁVEIS, sem backfill: quem já tem
+conta simplesmente segue sem foto, e a tela cai nas iniciais.
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "a1f4c9d2e7b3"
+down_revision = "154dd832e2d8"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("users", sa.Column("photo", sa.LargeBinary(), nullable=True))
+    op.add_column(
+        "users",
+        sa.Column("photo_updated_at", sa.DateTime(timezone=True), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    # Destrutivo por natureza: descer apaga as fotos. É o inverso exato do
+    # upgrade, e não há como preservar um dado que a coluna só guarda aqui.
+    op.drop_column("users", "photo_updated_at")
+    op.drop_column("users", "photo")

--- a/backend/app/models/sql_models.py
+++ b/backend/app/models/sql_models.py
@@ -5,7 +5,7 @@ from enum import Enum as PyEnum
 from typing import Optional, List
 
 from sqlalchemy import (
-    String, DateTime, Date, Numeric, ForeignKey,
+    String, DateTime, Date, Numeric, ForeignKey, LargeBinary,
     Enum, Integer, Boolean, CheckConstraint, Index, text
 )
 from sqlalchemy.dialects.postgresql import UUID
@@ -89,6 +89,20 @@ class User(Base):
     # e dois customer.subscription.updated invertidos empurrariam premium_until
     # para trás ou ressuscitariam um cancel_at_period_end velho.
     stripe_event_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+
+    # --- Foto de perfil (issue #35) -----------------------------------------
+    # Só o resultado do processamento mora aqui: 128x128 WebP, ~8 KB. Guardar o
+    # ORIGINAL é o que estoura o free tier do Neon, não o fato de ser bytea.
+    # `deferred`: sem isto TODA consulta de usuário — ou seja, toda requisição
+    # autenticada, via get_current_user — arrastaria o blob do banco à toa.
+    photo: Mapped[Optional[bytes]] = mapped_column(
+        LargeBinary, nullable=True, deferred=True
+    )
+    # Existe para o cliente saber DUAS coisas sem baixar nada: se há foto, e se
+    # a que ele tem em mãos envelheceu. Nulo significa "sem foto".
+    photo_updated_at: Mapped[Optional[datetime]] = mapped_column(
         DateTime(timezone=True), nullable=True
     )
 

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -4,7 +4,7 @@ from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends, HTTPException, status, Request
 from fastapi.encoders import jsonable_encoder
-from fastapi.responses import JSONResponse
+from fastapi.responses import JSONResponse, Response
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import func, select
@@ -21,6 +21,7 @@ from app.services.auth_service import (
     _DUMMY_HASH,
 )
 from app.services.account_service import delete_account, export_data
+from app.services.photo_service import MAX_BYTES, PhotoInvalid, PhotoTooLarge, processar_foto
 from app.services.billing_service import GatewayCancelFailed
 from app.services.plan_service import AI_TRIAL
 from app.services.throttle_service import check_throttle, record_failure, record_success
@@ -247,6 +248,115 @@ async def update_me(
         raise HTTPException(status_code=400, detail="Email já cadastrado")
     await db.refresh(current_user)
     return current_user
+
+
+# --- Foto de perfil (issue #35) ----------------------------------------------
+
+
+@router.put("/me/photo")
+# Processar imagem custa CPU, ao contrário das outras escritas deste router.
+# Chave por usuário porque atrás do proxy do Railway um teto por IP viraria um
+# balde único para todo mundo (ver "Rate limit atrás do proxy" no AGENTS.md).
+@limiter.limit("10/minute", key_func=user_key)
+async def upload_my_photo(
+    request: Request,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Recebe a imagem no corpo CRU, não em multipart.
+
+    O teto precisa valer ANTES de o servidor materializar o arquivo, e o
+    multipart do FastAPI só entrega o arquivo depois de já tê-lo despejado em
+    disco. Mesmo desenho do webhook do Stripe, pelo mesmo motivo. De quebra,
+    dispensa a dependência `python-multipart` e o frontend manda o File direto,
+    sem montar FormData.
+
+    O `Content-Type` declarado é ignorado de propósito: quem decide o formato é
+    o conteúdo, lido pelo Pillow.
+    """
+    declarado = request.headers.get("content-length")
+    if declarado and declarado.isdigit() and int(declarado) > MAX_BYTES:
+        raise HTTPException(status_code=413, detail="A imagem deve ter no máximo 2 MB")
+
+    # A segunda checagem cobre quem omite o header ou mente nele, e o
+    # `processar_foto` ainda repete o teto por ser função pública do service.
+    corpo = b""
+    async for pedaco in request.stream():
+        corpo += pedaco
+        if len(corpo) > MAX_BYTES:
+            raise HTTPException(status_code=413, detail="A imagem deve ter no máximo 2 MB")
+
+    try:
+        # Bloqueante (decodifica e reescala): vai para thread, como o bcrypt.
+        current_user.photo = await asyncio.to_thread(processar_foto, corpo)
+    except PhotoTooLarge as erro:
+        raise HTTPException(status_code=413, detail=str(erro))
+    except PhotoInvalid as erro:
+        raise HTTPException(status_code=400, detail=str(erro))
+
+    current_user.photo_updated_at = datetime.now(timezone.utc)
+    await db.commit()
+    return {"photo_updated_at": current_user.photo_updated_at}
+
+
+@router.get("/me/photo")
+async def get_my_photo(
+    request: Request,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Rota FECHADA, com token.
+
+    A tentação era abri-la, porque `<img src>` não manda header de autorização.
+    Mas foto de perfil é dado pessoal, e o frontend baixa uma vez com o token e
+    guarda como data URI — o que também evita mexer no `img-src` da CSP, que
+    `blob:` exigiria.
+    """
+    if not current_user.photo_updated_at:
+        raise HTTPException(status_code=404, detail="Sem foto de perfil")
+
+    # ETag pela DATA, não por hash dos bytes: ela já está carregada e muda a
+    # cada upload, que é exatamente quando o cache precisa cair. Hash exigiria
+    # LER o blob para responder 304, que é justamente o que o 304 evita.
+    # Microssegundos, não segundos: dois uploads no mesmo segundo gerariam o
+    # mesmo ETag e a pessoa continuaria vendo a foto antiga (o teste pegou).
+    etag = f'"{current_user.photo_updated_at.timestamp():.6f}"'
+    if request.headers.get("if-none-match") == etag:
+        # Sai ANTES de tocar no banco: o 304 é justamente a resposta que não
+        # deve custar a leitura do blob.
+        return Response(status_code=304, headers={"ETag": etag})
+
+    # SELECT só da coluna. Ler `current_user.photo` seria um lazy load do
+    # atributo deferido, e lazy load em sessão async estoura com MissingGreenlet
+    # — o `deferred` que evita carregar o blob em toda requisição obriga a
+    # buscá-lo explicitamente aqui.
+    foto = await db.scalar(select(User.photo).where(User.id == current_user.id))
+    if not foto:
+        raise HTTPException(status_code=404, detail="Sem foto de perfil")
+
+    return Response(
+        content=foto,
+        media_type="image/webp",
+        headers={
+            "ETag": etag,
+            # `private`: é foto de UMA pessoa, nenhum proxy compartilhado pode
+            # guardá-la. `must-revalidate` com max-age=0 troca o download por
+            # um 304 vazio quando nada mudou.
+            "Cache-Control": "private, max-age=0, must-revalidate",
+        },
+    )
+
+
+@router.delete("/me/photo", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_my_photo(
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    # Idempotente: apagar quem já não tem foto também devolve 204.
+    current_user.photo = None
+    current_user.photo_updated_at = None
+    await db.commit()
+
 
 @router.get("/me/export")
 async def export_my_data(

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -74,6 +74,10 @@ class UserResponse(BaseModel):
     name: str
     email: str
     created_at: datetime
+    # Só a DATA da foto, nunca os bytes: o blob desce por rota própria, com
+    # cache, em vez de ser rebaixado a passageiro de todo /auth/me. Nulo
+    # significa "sem foto", e é também a chave de cache do cliente.
+    photo_updated_at: datetime | None
     plan: PlanResponse
 
     model_config = ConfigDict(from_attributes=True)
@@ -96,6 +100,7 @@ class UserResponse(BaseModel):
             "name": data.name,
             "email": data.email,
             "created_at": data.created_at,
+            "photo_updated_at": data.photo_updated_at,
             "plan": {
                 "ai_allowed": ai_gate_open(data),
                 "wallet_cap_applies": wallet_cap_active(data),

--- a/backend/app/services/account_service.py
+++ b/backend/app/services/account_service.py
@@ -6,6 +6,7 @@ O dado do usuário vive em dois lugares:
 - MongoDB: ai_insights e chat_history, ligados por user_id (string). Não há
   cascade no Mongo — a remoção precisa ser explícita.
 """
+import base64
 from datetime import datetime, timezone
 
 from sqlalchemy import select
@@ -68,6 +69,11 @@ async def export_data(user: User, db: AsyncSession) -> dict:
         doc["_id"] = str(doc["_id"])
         chats.append(doc)
 
+    # SELECT explícito: `photo` é deferido no modelo (para não vir junto em
+    # toda requisição autenticada) e lê-lo pelo atributo dispararia lazy load,
+    # que em sessão async estoura.
+    foto = await db.scalar(select(User.photo).where(User.id == user.id))
+
     return {
         "exported_at": datetime.now(timezone.utc),
         "profile": {
@@ -75,6 +81,12 @@ async def export_data(user: User, db: AsyncSession) -> dict:
             "name": user.name,
             "email": user.email,
             "created_at": user.created_at,
+            # A foto é dado pessoal, e portabilidade que deixa dado de fora não
+            # é portabilidade. Base64 porque o dump é JSON; são ~8 KB, o que
+            # não muda o tamanho de um export de verdade.
+            "photo_webp_base64": (
+                base64.b64encode(foto).decode() if foto else None
+            ),
         },
         "wallets": await _scoped(db, Wallet, user.id),
         "transactions": await _scoped(db, Transaction, user.id),

--- a/backend/app/services/photo_service.py
+++ b/backend/app/services/photo_service.py
@@ -1,0 +1,74 @@
+"""Foto de perfil: valida, corta e encolhe (issue #35).
+
+Decisão travada no #15: aceita até 2 MB, redimensiona NO SERVIDOR para 128x128
+WebP (~8 KB) e guarda só o resultado. Guardar o ORIGINAL é o que estoura o free
+tier do Neon — não o fato de morar no Postgres.
+
+Função pura sobre bytes, sem sessão nem HTTP: quem traduz as recusas para
+status é o handler no main, como todo service deste repo.
+"""
+
+import io
+
+from PIL import Image, ImageOps, UnidentifiedImageError
+
+LADO = 128
+MAX_BYTES = 2 * 1024 * 1024
+
+# Teto de PIXELS, que é diferente do teto de bytes. Um PNG de poucos KB pode
+# decodificar para centenas de megapixels e derrubar o processo por memória
+# antes de qualquer validação nossa rodar — o teto de bytes não protege disso.
+# 40 MP passa folgado por qualquer foto de celular (48 MP é topo de linha).
+MAX_PIXELS = 40_000_000
+
+# Só o que dá para receber de um seletor de arquivo de verdade. O formato é
+# lido do CONTEÚDO pelo Pillow; o content-type declarado no upload não é levado
+# a sério em lugar nenhum, porque é campo controlado por quem envia.
+FORMATOS = frozenset({"PNG", "JPEG", "WEBP", "GIF", "BMP"})
+
+
+class PhotoTooLarge(Exception):
+    """Passou do teto de bytes."""
+
+
+class PhotoInvalid(Exception):
+    """Não é imagem, é formato que não aceitamos, ou é grande demais em pixels."""
+
+
+def processar_foto(dados: bytes) -> bytes:
+    """Bytes recebidos -> WebP quadrado de 128x128.
+
+    O teto de bytes é conferido ANTES de decodificar: decodificar primeiro para
+    depois reclamar do tamanho é exatamente o que um arquivo hostil quer.
+    """
+    if len(dados) > MAX_BYTES:
+        raise PhotoTooLarge(f"A imagem deve ter no máximo {MAX_BYTES // (1024 * 1024)} MB")
+
+    try:
+        img = Image.open(io.BytesIO(dados))
+        if img.format not in FORMATOS:
+            raise PhotoInvalid("Formato de imagem não aceito")
+        largura, altura = img.size
+        if largura * altura > MAX_PIXELS:
+            raise PhotoInvalid("Imagem grande demais")
+
+        # exif_transpose ANTES do corte: sem isso a foto de retrato tirada no
+        # celular sai deitada, porque a rotação vive só no EXIF.
+        img = ImageOps.exif_transpose(img)
+        # `fit` corta pelo centro em vez de achatar. Espremer um retrato para
+        # quadrado deforma o rosto, que é o único conteúdo que importa aqui.
+        img = ImageOps.fit(img.convert("RGB"), (LADO, LADO))
+    except Image.DecompressionBombError as erro:
+        # O Pillow tem teto próprio (~178 MP) e ele dispara ANTES do nosso, com
+        # um tipo que não é OSError nem ValueError. Sem este ramo a bomba virava
+        # 500 em vez de recusa limpa.
+        raise PhotoInvalid("Imagem grande demais") from erro
+    except (UnidentifiedImageError, OSError, ValueError) as erro:
+        raise PhotoInvalid("Não foi possível ler a imagem") from erro
+
+    saida = io.BytesIO()
+    # Sem `exif=`: o WebP sai limpo. Foto de celular carrega EXIF com GPS, que
+    # é dado pessoal que o usuário não sabe que está mandando e que nada aqui
+    # precisa. Só o primeiro quadro de um GIF animado sobrevive, de propósito.
+    img.save(saida, format="WEBP", quality=82, method=4)
+    return saida.getvalue()

--- a/backend/requirements-dev.lock
+++ b/backend/requirements-dev.lock
@@ -117,6 +117,8 @@ packaging==26.2
     #   pytest
 passlib==1.7.4
     # via -r requirements.txt
+pillow==12.3.0
+    # via -r requirements.txt
 pip==26.1.2
     # via pip-api
 pip-api==0.0.34
@@ -167,6 +169,8 @@ python-dotenv==1.2.3
     #   pydantic-settings
     #   uvicorn
 python-jose==3.5.0
+    # via -r requirements.txt
+python-multipart==0.0.32
     # via -r requirements.txt
 pyyaml==6.0.3
     # via uvicorn

--- a/backend/requirements.lock
+++ b/backend/requirements.lock
@@ -88,6 +88,8 @@ packaging==26.2
     # via limits
 passlib==1.7.4
     # via -r requirements.txt
+pillow==12.3.0
+    # via -r requirements.txt
 pyasn1==0.6.4
     # via
     #   pyasn1-modules
@@ -114,6 +116,8 @@ python-dotenv==1.2.3
     #   pydantic-settings
     #   uvicorn
 python-jose==3.5.0
+    # via -r requirements.txt
+python-multipart==0.0.32
     # via -r requirements.txt
 pyyaml==6.0.3
     # via uvicorn

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -21,3 +21,8 @@ slowapi==0.1.10
 # webhook: ela precisa ser timing-safe e checar a tolerância de timestamp
 # contra replay, e isso não é lugar para HMAC feito à mão.
 stripe==15.5.1
+
+# Foto de perfil (issue #35): redimensiona no servidor para 128x128 WebP.
+# python-multipart é o que o FastAPI usa para ler multipart/form-data.
+pillow==12.3.0
+python-multipart==0.0.32

--- a/backend/tests/test_photo.py
+++ b/backend/tests/test_photo.py
@@ -1,0 +1,262 @@
+"""Foto de perfil (issue #35).
+
+A decisão travada no #15: aceita até 2 MB, redimensiona NO SERVIDOR para
+128x128 WebP (~8 KB) e guarda o resultado como `bytea` na linha do usuário.
+Guardar o ORIGINAL é o que estoura o free tier do Neon — não o fato de morar
+no Postgres.
+"""
+
+import io
+
+import pytest
+from PIL import Image
+
+from app.services.photo_service import (
+    LADO,
+    MAX_BYTES,
+    PhotoInvalid,
+    PhotoTooLarge,
+    processar_foto,
+)
+
+
+def _imagem(formato="PNG", tamanho=(600, 400), cor=(200, 30, 30)) -> bytes:
+    buf = io.BytesIO()
+    Image.new("RGB", tamanho, cor).save(buf, format=formato)
+    return buf.getvalue()
+
+
+def test_a_photo_comes_back_as_a_square_webp():
+    saida = processar_foto(_imagem())
+    img = Image.open(io.BytesIO(saida))
+    assert img.format == "WEBP"
+    assert img.size == (LADO, LADO)
+
+
+def test_the_result_is_tiny_next_to_the_original():
+    # O ponto do redimensionamento no servidor: o que vai para o banco é ~8 KB,
+    # não os megabytes que o usuário enviou.
+    original = _imagem(tamanho=(2000, 2000))
+    saida = processar_foto(original)
+    assert len(saida) < len(original) / 10
+    assert len(saida) < 30 * 1024
+
+
+def test_a_rectangle_is_cropped_not_squashed():
+    """Achatar um retrato para quadrado deforma o rosto. Corta pelo centro.
+
+    Só conferir o TAMANHO da saída não testa isto — esmagar também devolve
+    128x128 (foi o que a primeira versão deste teste fazia). O sinal tem de ser
+    o conteúdo: uma faixa preta na ponta esquerda de uma imagem larga some no
+    corte central e sobrevive no esmagamento.
+    """
+    larga = Image.new("RGB", (1000, 250), (255, 255, 255))
+    larga.paste(Image.new("RGB", (250, 250), (0, 0, 0)), (0, 0))
+    buf = io.BytesIO()
+    larga.save(buf, format="PNG")
+
+    saida = Image.open(io.BytesIO(processar_foto(buf.getvalue()))).convert("RGB")
+    assert saida.size == (LADO, LADO)
+    # Canto esquerdo da saída: branco se cortou pelo centro, preto se esmagou.
+    assert min(saida.getpixel((4, LADO // 2))) > 200
+
+
+@pytest.mark.asyncio
+async def test_the_blob_does_not_ride_along_on_every_query(db_session):
+    """`photo` é deferido no modelo.
+
+    Sem isso, TODA requisição autenticada arrastaria o blob do Postgres, porque
+    o `get_current_user` faz `select(User)` a cada uma. É a razão de a coluna
+    existir deferida, e nada mais no código torna essa escolha visível.
+    """
+    from sqlalchemy import inspect as sa_inspect, select
+
+    from app.models.sql_models import User
+
+    user = User(name="Al", email="al_defer@t.com", password_hash="x")
+    db_session.add(user)
+    await db_session.commit()
+    db_session.expunge_all()
+
+    carregado = (
+        await db_session.execute(select(User).where(User.id == user.id))
+    ).scalar_one()
+    assert "photo" in sa_inspect(carregado).unloaded
+
+
+def test_something_that_is_not_an_image_is_refused():
+    with pytest.raises(PhotoInvalid):
+        processar_foto(b"isto aqui nao e uma imagem, e texto puro")
+
+
+def test_a_lying_content_type_does_not_help():
+    # A validação sniffa o conteúdo; o tipo declarado no upload não é levado a
+    # sério em lugar nenhum.
+    with pytest.raises(PhotoInvalid):
+        processar_foto(b"\x89PNG\r\n\x1a\n" + b"lixo" * 100)
+
+
+def test_oversize_is_refused_before_decoding():
+    # O teto vale sobre os BYTES RECEBIDOS. Decodificar primeiro para depois
+    # reclamar do tamanho é justamente o que um arquivo hostil quer.
+    with pytest.raises(PhotoTooLarge):
+        processar_foto(b"x" * (MAX_BYTES + 1))
+
+
+def test_a_decompression_bomb_is_refused():
+    # Um PNG de poucos KB pode virar um bitmap de centenas de megapixels.
+    bomba = io.BytesIO()
+    Image.new("L", (14000, 14000)).save(bomba, format="PNG")
+    dados = bomba.getvalue()
+    assert len(dados) < MAX_BYTES  # cabe no teto de bytes: o teto não basta
+    with pytest.raises(PhotoInvalid):
+        processar_foto(dados)
+
+
+def test_an_image_under_pillows_own_limit_but_over_ours_is_refused():
+    """O teto de 40 MP é NOSSO, e mais apertado que o do Pillow (~178 MP).
+
+    64 MP em RGB são ~190 MB de bitmap, que num container pequeno é OOM. Sem
+    este teste o teto podia ser removido sem nada ficar vermelho — o teste da
+    bomba acima passa pelo teto do Pillow, não pelo nosso.
+    """
+    grande = io.BytesIO()
+    Image.new("L", (8000, 8000)).save(grande, format="PNG")
+    with pytest.raises(PhotoInvalid):
+        processar_foto(grande.getvalue())
+
+
+def test_a_valid_image_in_a_format_we_do_not_accept_is_refused():
+    """A lista de formatos não é decoração.
+
+    O Pillow abre dezenas de formatos, alguns com decodificadores exóticos e
+    até com dependência externa (EPS chama o Ghostscript). Um TIFF perfeitamente
+    válido é a prova barata: nada aqui precisa dele, então ele não entra.
+    """
+    tiff = io.BytesIO()
+    Image.new("RGB", (100, 100), (1, 2, 3)).save(tiff, format="TIFF")
+    with pytest.raises(PhotoInvalid):
+        processar_foto(tiff.getvalue())
+
+
+def test_an_animated_gif_becomes_a_still_frame():
+    quadros = [Image.new("P", (200, 200), i) for i in (1, 2, 3)]
+    buf = io.BytesIO()
+    quadros[0].save(buf, format="GIF", save_all=True, append_images=quadros[1:])
+    saida = processar_foto(buf.getvalue())
+    img = Image.open(io.BytesIO(saida))
+    assert img.format == "WEBP"
+    assert getattr(img, "n_frames", 1) == 1
+
+
+def test_metadata_does_not_survive():
+    # Foto de celular carrega EXIF com GPS. Ela é dado pessoal que o usuário
+    # não sabe que está mandando, e nada aqui precisa dela.
+    buf = io.BytesIO()
+    img = Image.new("RGB", (300, 300))
+    exif = img.getexif()
+    exif[0x9003] = "2020:01:01 00:00:00"  # DateTimeOriginal
+    img.save(buf, format="JPEG", exif=exif)
+
+    saida = processar_foto(buf.getvalue())
+    assert not Image.open(io.BytesIO(saida)).getexif()
+
+
+# --- As rotas ----------------------------------------------------------------
+# Corpo CRU, não multipart: o teto tem de valer ANTES de o servidor materializar
+# o arquivo, e é o mesmo desenho que o webhook do Stripe já usa aqui.
+
+
+@pytest.mark.asyncio
+async def test_upload_then_serve_then_delete(make_auth_client):
+    alice = await make_auth_client("Alice")
+
+    assert (await alice.get("/auth/me")).json()["photo_updated_at"] is None
+    assert (await alice.get("/auth/me/photo")).status_code == 404
+
+    envio = await alice.put(
+        "/auth/me/photo", content=_imagem(), headers={"Content-Type": "image/png"}
+    )
+    assert envio.status_code == 200, envio.text
+    assert envio.json()["photo_updated_at"]
+
+    # A data viaja no payload do usuário; os BYTES nunca.
+    me = (await alice.get("/auth/me")).json()
+    assert me["photo_updated_at"]
+    assert "photo" not in me
+
+    servida = await alice.get("/auth/me/photo")
+    assert servida.status_code == 200
+    assert servida.headers["content-type"] == "image/webp"
+    assert Image.open(io.BytesIO(servida.content)).size == (LADO, LADO)
+
+    apagada = await alice.delete("/auth/me/photo")
+    assert apagada.status_code == 204
+    assert (await alice.get("/auth/me/photo")).status_code == 404
+    assert (await alice.get("/auth/me")).json()["photo_updated_at"] is None
+
+
+@pytest.mark.asyncio
+async def test_the_same_photo_is_not_downloaded_twice(make_auth_client):
+    # A foto é imutável até o próximo upload; sem ETag ela desceria inteira a
+    # cada carga de página, para nada.
+    alice = await make_auth_client("Alice")
+    await alice.put("/auth/me/photo", content=_imagem())
+
+    primeira = await alice.get("/auth/me/photo")
+    etag = primeira.headers["etag"]
+    assert etag
+
+    segunda = await alice.get("/auth/me/photo", headers={"If-None-Match": etag})
+    assert segunda.status_code == 304
+    assert segunda.content == b""
+
+
+@pytest.mark.asyncio
+async def test_a_new_upload_invalidates_the_cached_one(make_auth_client):
+    alice = await make_auth_client("Alice")
+    await alice.put("/auth/me/photo", content=_imagem(cor=(10, 10, 200)))
+    etag_antigo = (await alice.get("/auth/me/photo")).headers["etag"]
+
+    await alice.put("/auth/me/photo", content=_imagem(cor=(10, 200, 10)))
+    depois = await alice.get("/auth/me/photo", headers={"If-None-Match": etag_antigo})
+    assert depois.status_code == 200  # e não 304 com a foto velha
+
+
+@pytest.mark.asyncio
+async def test_junk_is_refused_with_a_message_not_a_500(make_auth_client):
+    alice = await make_auth_client("Alice")
+    res = await alice.put("/auth/me/photo", content=b"nao sou imagem")
+    assert res.status_code == 400
+    assert res.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_oversize_is_refused_by_the_route(make_auth_client):
+    alice = await make_auth_client("Alice")
+    res = await alice.put("/auth/me/photo", content=b"x" * (MAX_BYTES + 1))
+    assert res.status_code == 413
+
+
+@pytest.mark.asyncio
+async def test_the_photo_endpoint_requires_a_token(client, make_auth_client):
+    # `<img src>` não manda header de autorização, então a tentação seria abrir
+    # esta rota. Ela continua fechada, e o frontend baixa com o token.
+    alice = await make_auth_client("Alice")
+    await alice.put("/auth/me/photo", content=_imagem())
+    assert (await client.get("/auth/me/photo")).status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_the_photo_travels_in_the_lgpd_export(make_auth_client, mongo):
+    # Dado pessoal do usuário. O export é o direito de portabilidade: deixar a
+    # foto de fora entregaria um dump incompleto.
+    import base64
+
+    alice = await make_auth_client("Alice")
+    await alice.put("/auth/me/photo", content=_imagem())
+
+    dump = (await alice.get("/auth/me/export")).json()
+    assert dump["profile"]["photo_webp_base64"]
+    bruto = base64.b64decode(dump["profile"]["photo_webp_base64"])
+    assert Image.open(io.BytesIO(bruto)).format == "WEBP"

--- a/frontend/src/api/account.js
+++ b/frontend/src/api/account.js
@@ -6,4 +6,17 @@ export const accountApi = {
   // Exclui a conta de forma definitiva (LGPD). Exige confirmação + senha atual.
   deleteAccount: (password) =>
     api.delete("/auth/me", { data: { confirm: true, password } }),
+
+  // Foto de perfil (#35). O arquivo vai no corpo CRU, sem FormData: a rota
+  // recebe bytes justamente para poder cortar pelo tamanho antes de gravar
+  // qualquer coisa. O content-type declarado aqui é ignorado pelo servidor,
+  // que sniffa o conteúdo.
+  uploadPhoto: (file) =>
+    api.put("/auth/me/photo", file, {
+      headers: { "Content-Type": file.type || "application/octet-stream" },
+    }),
+  deletePhoto: () => api.delete("/auth/me/photo"),
+  // Blob porque a rota é FECHADA: `<img src>` não manda o token, então o
+  // download passa pelo axios e vira data URI no store.
+  photo: () => api.get("/auth/me/photo", { responseType: "blob" }),
 };

--- a/frontend/src/components/layout/AppLayout.jsx
+++ b/frontend/src/components/layout/AppLayout.jsx
@@ -1,10 +1,16 @@
 import { useEffect } from "react";
 import { Outlet } from "react-router-dom";
 import { recurringApi } from "@/api/recurring";
+import { accountApi } from "@/api/account";
+import { useAuthStore } from "@/store/authStore";
 import Sidebar from "./Sidebar";
 import MobileNav from "./MobileNav";
 
 export default function AppLayout() {
+  const user = useAuthStore((s) => s.user);
+  const photoFor = useAuthStore((s) => s.photoFor);
+  const setPhoto = useAuthStore((s) => s.setPhoto);
+
   // Materializa recorrências vencidas ao entrar na área autenticada.
   //
   // Aqui e não no App: o App roda o efeito de boot uma vez só, com deps vazias,
@@ -15,6 +21,45 @@ export default function AppLayout() {
   useEffect(() => {
     recurringApi.run().catch(() => {});
   }, []);
+
+  // Baixa a foto de perfil UMA vez por versão (issue #35).
+  //
+  // Aqui pelo mesmo motivo das recorrências: é o ponto que monta tanto no boot
+  // com token persistido quanto no login dentro da SPA. A rota é fechada, então
+  // a foto não pode ser um `<img src>` — vem por axios com o token e vira data
+  // URI no store, que o zustand persiste. `photoFor` é a versão que está em
+  // mãos: igual à do usuário significa nada a fazer, e é o que impede um
+  // download por montagem.
+  const marca = user?.photo_updated_at ?? null;
+  useEffect(() => {
+    if (!marca) {
+      if (photoFor) setPhoto(null, null); // foto removida em outro dispositivo
+      return;
+    }
+    if (marca === photoFor) return;
+
+    let vivo = true;
+    accountApi
+      .photo()
+      .then(
+        ({ data }) =>
+          new Promise((resolve, reject) => {
+            const leitor = new FileReader();
+            leitor.onload = () => resolve(leitor.result);
+            leitor.onerror = reject;
+            leitor.readAsDataURL(data);
+          }),
+      )
+      .then((dataUrl) => {
+        if (vivo) setPhoto(dataUrl, marca);
+      })
+      // Falhar em baixar a foto não pode atrapalhar nada: a tela cai nas
+      // iniciais, que é o mesmo estado de quem nunca enviou uma.
+      .catch(() => {});
+    return () => {
+      vivo = false;
+    };
+  }, [marca, photoFor, setPhoto]);
 
   return (
     <div className="relative min-h-screen w-full overflow-hidden bg-bg-base app-mesh">

--- a/frontend/src/components/layout/Sidebar.jsx
+++ b/frontend/src/components/layout/Sidebar.jsx
@@ -6,6 +6,7 @@ import NorbyMark from "../shared/Logo";
 import NorthStar from "../shared/NorthStar";
 import AiOrb from "../shared/AiOrb";
 import { mainItems, prefItems } from "./navItems";
+import Avatar from "@/components/shared/Avatar";
 
 // Item de navegação: ativo = moldura iridescente + acento no ícone, no label e
 // na estrela. O acento chapado segue reservado ao CTA primário (ver DESIGN.md);
@@ -93,9 +94,7 @@ export default function Sidebar() {
 
       {/* User */}
       <div className="flex items-center gap-3 pt-4 border-t border-line/[0.08] px-1">
-        <div className="w-8 h-8 rounded-full bg-accent-fill flex items-center justify-center text-xs font-bold text-accent-contrast">
-          {user?.name?.[0]?.toUpperCase() || "U"}
-        </div>
+        <Avatar name={user?.name} className="w-8 h-8" fallbackClassName="text-xs" />
         <div className="flex-1 min-w-0">
           <p className="text-sm font-medium text-content truncate">
             {user?.name || "Usuário"}

--- a/frontend/src/components/shared/Avatar.jsx
+++ b/frontend/src/components/shared/Avatar.jsx
@@ -1,0 +1,40 @@
+import { useAuthStore } from "@/store/authStore";
+import { cn } from "@/lib/utils";
+
+/**
+ * Foto de perfil, com a inicial do nome como fallback (issue #35).
+ *
+ * A foto vem do store como data URI, e não de uma `<img src="/auth/me/photo">`:
+ * a rota exige token e `<img>` não manda header de autorização. Quem baixa é o
+ * AppLayout, uma vez por mudança de `photo_updated_at`.
+ *
+ * `alt=""` é deliberado: nos dois lugares onde este componente aparece o nome
+ * está escrito ao lado, então descrever a imagem faria o leitor de tela dizer a
+ * mesma coisa duas vezes. Imagem decorativa quer alt vazio, não alt ausente.
+ */
+export default function Avatar({ name, className, fallbackClassName }) {
+  const photo = useAuthStore((s) => s.photo);
+  const inicial = name?.trim()?.[0]?.toUpperCase() || "U";
+
+  if (photo) {
+    return (
+      <img
+        src={photo}
+        alt=""
+        className={cn("rounded-full object-cover shrink-0", className)}
+      />
+    );
+  }
+
+  return (
+    <div
+      className={cn(
+        "rounded-full bg-accent-fill flex items-center justify-center font-bold text-accent-contrast shrink-0",
+        className,
+        fallbackClassName,
+      )}
+    >
+      {inicial}
+    </div>
+  );
+}

--- a/frontend/src/components/shared/Avatar.test.jsx
+++ b/frontend/src/components/shared/Avatar.test.jsx
@@ -1,0 +1,41 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import { useAuthStore } from "@/store/authStore";
+import Avatar from "./Avatar";
+
+const ESTADO = useAuthStore.getState();
+
+afterEach(() => useAuthStore.setState(ESTADO, true));
+
+describe("Avatar", () => {
+  it("falls back to the first letter of the name when there is no photo", () => {
+    useAuthStore.setState({ photo: null });
+    render(<Avatar name="diogo" />);
+    expect(screen.getByText("D")).toBeInTheDocument();
+  });
+
+  it("shows a U when there is no name either", () => {
+    useAuthStore.setState({ photo: null });
+    render(<Avatar name={undefined} />);
+    expect(screen.getByText("U")).toBeInTheDocument();
+  });
+
+  it("renders the photo from the store, not a URL the browser would fetch", () => {
+    // A rota é fechada e `<img src>` não manda o token: se algum dia isto virar
+    // um src apontando para /auth/me/photo, a foto some da tela em produção.
+    useAuthStore.setState({ photo: "data:image/webp;base64,AAAA" });
+    const { container } = render(<Avatar name="Diogo" />);
+    const img = container.querySelector("img");
+    expect(img.getAttribute("src")).toBe("data:image/webp;base64,AAAA");
+    expect(screen.queryByText("D")).not.toBeInTheDocument();
+  });
+
+  it("leaves the image out of the accessibility tree", () => {
+    // O nome está escrito ao lado nos dois usos; descrever a foto faria o
+    // leitor de tela repetir a mesma informação.
+    useAuthStore.setState({ photo: "data:image/webp;base64,AAAA" });
+    const { container } = render(<Avatar name="Diogo" />);
+    expect(container.querySelector("img").getAttribute("alt")).toBe("");
+  });
+});

--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -15,8 +15,14 @@ import { authApi } from "@/api/auth";
 import { accountApi } from "@/api/account";
 import { apiErrorMessage, shadcnInputCls } from "@/lib/utils";
 import ThemeToggle from "@/components/shared/ThemeToggle";
+import Avatar from "@/components/shared/Avatar";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+
+// Mesmo teto do backend (app/services/photo_service.py). Duplicado de
+// propósito: o servidor continua sendo quem decide, isto só evita a subida
+// inútil de um arquivo que já se sabe grande demais.
+const MAX_FOTO_BYTES = 2 * 1024 * 1024;
 
 // Header padrão de seção: ícone semântico + título.
 function SectionHead({ icon, children, danger }) {
@@ -45,12 +51,16 @@ export default function Settings() {
   // árvore sem duplicar id, que quebraria a associação label/campo.
   const nomeId = useId();
   const emailId = useId();
+  const fotoId = useId();
   const [form, setForm] = useState({
     name: user?.name || "",
     email: user?.email || "",
   });
   const [saved, setSaved] = useState(false);
   const [error, setError] = useState(null);
+
+  const [photoError, setPhotoError] = useState("");
+  const [uploadingPhoto, setUploadingPhoto] = useState(false);
 
   const [exporting, setExporting] = useState(false);
   const [confirmText, setConfirmText] = useState("");
@@ -61,6 +71,44 @@ export default function Settings() {
   async function handleLogout() {
     await authApi.logout();
     navigate("/");
+  }
+
+  async function handlePhotoChange(e) {
+    const file = e.target.files?.[0];
+    // Zera o input: sem isso, escolher o MESMO arquivo depois de um erro não
+    // dispara change de novo e a tela fica parecendo travada.
+    e.target.value = "";
+    if (!file) return;
+
+    setPhotoError("");
+    // O servidor recusa igual; conferir aqui só evita subir 20 MB para ouvir não.
+    if (file.size > MAX_FOTO_BYTES) {
+      setPhotoError("A imagem deve ter no máximo 2 MB.");
+      return;
+    }
+
+    setUploadingPhoto(true);
+    try {
+      const { data } = await accountApi.uploadPhoto(file);
+      // Guarda só a versão: quem baixa a foto processada (128x128 WebP) é o
+      // AppLayout. Mostrar o arquivo local seria mostrar um recorte diferente
+      // do que ficou salvo.
+      updateUser({ photo_updated_at: data.photo_updated_at });
+    } catch (err) {
+      setPhotoError(apiErrorMessage(err, "Não foi possível enviar a foto."));
+    } finally {
+      setUploadingPhoto(false);
+    }
+  }
+
+  async function handlePhotoRemove() {
+    setPhotoError("");
+    try {
+      await accountApi.deletePhoto();
+      updateUser({ photo_updated_at: null });
+    } catch (err) {
+      setPhotoError(apiErrorMessage(err, "Não foi possível remover a foto."));
+    }
   }
 
   async function handleExport() {
@@ -145,16 +193,50 @@ export default function Settings() {
         <SectionHead icon={User}>Perfil</SectionHead>
 
         <div className="flex items-center gap-4 mb-6">
-          <div className="w-16 h-16 rounded-full bg-accent-fill flex items-center justify-center text-2xl font-bold text-accent-contrast shrink-0">
-            {user?.name?.[0]?.toUpperCase() || "U"}
-          </div>
-          <div>
+          <Avatar name={user?.name} className="w-16 h-16" fallbackClassName="text-2xl" />
+          <div className="min-w-0">
             <p className="font-semibold text-content">{user?.name}</p>
             <p className="text-sm text-content-2">
               {memberSince ? `Membro desde ${memberSince}` : user?.email}
             </p>
+
+            <div className="flex flex-wrap items-center gap-3 mt-2">
+              {/* Label + input escondido: o input de arquivo nativo não é
+                  estilizável, e trocá-lo por um <button> que clica nele por JS
+                  quebraria o teclado. O label já é o rótulo acessível. */}
+              <label
+                htmlFor={fotoId}
+                className="text-xs font-medium text-accent cursor-pointer hover:underline focus-within:underline"
+              >
+                {uploadingPhoto ? "Enviando…" : user?.photo_updated_at ? "Trocar foto" : "Adicionar foto"}
+                <input
+                  id={fotoId}
+                  type="file"
+                  accept="image/*"
+                  className="sr-only"
+                  disabled={uploadingPhoto}
+                  onChange={handlePhotoChange}
+                />
+              </label>
+
+              {user?.photo_updated_at && (
+                <button
+                  type="button"
+                  onClick={handlePhotoRemove}
+                  className="text-xs font-medium text-content-2 hover:text-content transition-colors"
+                >
+                  Remover
+                </button>
+              )}
+            </div>
           </div>
         </div>
+
+        {photoError && (
+          <p role="alert" className="text-xs text-danger mb-4">
+            {photoError}
+          </p>
+        )}
 
         <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
           <div>

--- a/frontend/src/pages/Settings.test.jsx
+++ b/frontend/src/pages/Settings.test.jsx
@@ -10,6 +10,8 @@ vi.mock("@/api/account", () => ({
   accountApi: {
     deleteAccount: vi.fn(),
     exportData: vi.fn(),
+    uploadPhoto: vi.fn(),
+    deletePhoto: vi.fn(),
   },
 }));
 
@@ -94,5 +96,77 @@ describe("Settings", () => {
       screen.getByLabelText("Digite EXCLUIR para confirmar"),
     ).toBeInTheDocument();
     expect(screen.getByLabelText("Sua senha atual")).toBeInTheDocument();
+  });
+});
+
+describe("Settings, foto de perfil", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useAuthStore.getState().login("access", "refresh", {
+      name: "Alice",
+      email: "alice@test.com",
+      photo_updated_at: null,
+    });
+  });
+
+  function escolher(file) {
+    fireEvent.change(screen.getByLabelText("Adicionar foto"), {
+      target: { files: [file] },
+    });
+  }
+
+  it("uploads the chosen file and records the new version on the user", async () => {
+    accountApi.uploadPhoto.mockResolvedValue({
+      data: { photo_updated_at: "2026-09-04T12:00:00Z" },
+    });
+    renderSettings();
+
+    const file = new File(["x"], "eu.png", { type: "image/png" });
+    escolher(file);
+
+    await waitFor(() => expect(accountApi.uploadPhoto).toHaveBeenCalledWith(file));
+    // A versão é o que o AppLayout observa para baixar a foto processada.
+    await waitFor(() =>
+      expect(useAuthStore.getState().user.photo_updated_at).toBe("2026-09-04T12:00:00Z"),
+    );
+  });
+
+  it("refuses a file over the cap without spending an upload", async () => {
+    renderSettings();
+
+    const gigante = new File([new Uint8Array(2 * 1024 * 1024 + 1)], "g.png", {
+      type: "image/png",
+    });
+    escolher(gigante);
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("no máximo 2 MB");
+    expect(accountApi.uploadPhoto).not.toHaveBeenCalled();
+  });
+
+  it("shows the failure instead of pretending the upload worked", async () => {
+    accountApi.uploadPhoto.mockRejectedValue({
+      response: { data: { detail: "Formato de imagem não aceito" } },
+    });
+    renderSettings();
+
+    escolher(new File(["x"], "eu.txt", { type: "image/png" }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "Formato de imagem não aceito",
+    );
+    expect(useAuthStore.getState().user.photo_updated_at).toBeNull();
+  });
+
+  it("removes the photo and clears the version", async () => {
+    useAuthStore.getState().updateUser({ photo_updated_at: "2026-09-04T12:00:00Z" });
+    accountApi.deletePhoto.mockResolvedValue({});
+    renderSettings();
+
+    fireEvent.click(screen.getByRole("button", { name: "Remover" }));
+
+    await waitFor(() => expect(accountApi.deletePhoto).toHaveBeenCalled());
+    await waitFor(() =>
+      expect(useAuthStore.getState().user.photo_updated_at).toBeNull(),
+    );
   });
 });

--- a/frontend/src/store/authStore.js
+++ b/frontend/src/store/authStore.js
@@ -8,13 +8,25 @@ export const useAuthStore = create(
       refreshToken: null,
       user: null,
       isAuthenticated: false,
+      // Foto de perfil como data URI (#35). Fica no store, e não numa <img>
+      // apontando para a rota, porque a rota exige token. `photoFor` guarda o
+      // `photo_updated_at` que originou este data URI: é o que evita baixar de
+      // novo a cada montagem e o que faz a foto trocar depois de um upload.
+      photo: null,
+      photoFor: null,
 
       login: (token, refreshToken, user) =>
-        set({ token, refreshToken, user, isAuthenticated: true }),
+        // A foto do dono anterior não pode sobreviver a um login: sem zerar
+        // aqui, quem entrasse em seguida veria o rosto de quem saiu.
+        set({ token, refreshToken, user, isAuthenticated: true, photo: null, photoFor: null }),
+      setPhoto: (photo, photoFor) => set({ photo, photoFor }),
       // Atualiza só o par de tokens (usado na rotação do refresh), mantém o user.
       setTokens: (token, refreshToken) => set({ token, refreshToken }),
       logout: () =>
-        set({ token: null, refreshToken: null, user: null, isAuthenticated: false }),
+        set({
+          token: null, refreshToken: null, user: null, isAuthenticated: false,
+          photo: null, photoFor: null,
+        }),
       updateUser: (userData) =>
         set((state) => ({
           // Atualiza apenas os campos fornecidos, mantendo os outros intactos


### PR DESCRIPTION
Closes #35. Part of #15's execution backlog.

Follows the decision already recorded in the ticket: accept up to 2 MB, resize to 128x128 WebP **server-side**, store only the result on the user row. Storing the original is what breaks the Neon free tier — not the fact that it lives in Postgres.

## The column is deferred, and that has a price

Without `deferred`, **every authenticated request** would drag the blob out of Postgres, because `get_current_user` does a `select(User)` on each one.

The price is that reading `user.photo` becomes an implicit lazy load, which raises `MissingGreenlet` in an async session. The two places that genuinely need the bytes — serving and exporting — select the column explicitly. There is a test asserting the attribute stays unloaded, because nothing else in the code makes that choice visible.

## Raw body, not multipart

The cap has to hold **before the server materialises the file**, and FastAPI's multipart only hands the file over after spooling it to disk. Same shape as the Stripe webhook, for the same reason.

It also drops the `python-multipart` dependency and lets the frontend send the `File` directly, without building `FormData`. The declared `Content-Type` is ignored on purpose: the format is decided by the content.

## What validation refuses, in order

1. **Bytes over the cap, before any decoding.** Decoding first and complaining afterwards is exactly what a hostile file wants.
2. **Formats outside a small allowlist.** Pillow opens dozens of formats, some with exotic decoders and external dependencies (EPS shells out to Ghostscript). Nothing here needs them.
3. **Images over 40 megapixels.** Stricter than Pillow's own ~178 MP on purpose: 64 MP in RGB is roughly 190 MB of bitmap, and this container is small.

Pillow's own bomb error is a type that is neither `OSError` nor `ValueError`, so it gets its own branch. Without it, a decompression bomb was a **500** rather than a clean refusal.

## Metadata does not survive

A phone photo carries EXIF with GPS. That is personal data the user does not know they are sending and that nothing here needs, so the WebP is written without it.

Orientation is applied **before** the crop, so a portrait does not come out sideways. The crop is centred rather than squashed, because squashing deforms the only content that matters in an avatar.

## The serving route stays closed

`<img src>` sends no `Authorization` header, so the tempting move was to open the route. Instead the frontend downloads once with the token and keeps a data URI in the store — which also avoids adding `blob:` to the CSP's `img-src`, and this repo treats loosening the CSP as expensive.

`photo_updated_at` travels on `UserResponse`; the bytes never do. It answers two questions without a download: whether there is a photo at all, and whether the one in hand went stale.

**The ETag carries microseconds, not seconds.** With second precision, two uploads within the same second produced the same tag and the browser kept serving the stale photo. A test caught it.

## LGPD

The photo is included in the export. Portability that leaves data out is not portability. Deletion needs nothing new — it is a column on the row that already gets deleted.

## Mutation testing, including two that survived

Five mutations. The first pass had **two survivors**, both now covered:

- **the pixel cap** — the bomb test was passing through *Pillow's* limit, not ours, so the guard could have been deleted with nothing going red
- **the format allowlist** — the "lying content type" test used a broken header, which fails identification anyway

And one test **asserted its own name falsely**: `a_rectangle_is_cropped_not_squashed` only checked the output size, which a squashed image also satisfies. It now checks content.

## Verification

260 backend tests (was 241), 134 frontend (was 126). Migration adds two nullable columns, no backfill: existing accounts simply have no photo and fall back to initials.

## Not in scope

Cropping or repositioning in the browser, and any use of the avatar outside the sidebar and the profile card.
