### PR TITLE
feat(billing): Checkout and Customer Portal session endpoints

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,6 +38,13 @@ ACME_EMAIL=seu-email@exemplo.com
 # Stripe (ADR 0001). Vazio = billing desligado; o webhook responde 503.
 STRIPE_SECRET_KEY=
 STRIPE_WEBHOOK_SECRET=whsec_test_local_only_not_a_real_secret
+# O preço recorrente criado no painel (issue #26). Vazio = /billing/checkout-session
+# responde 503 em vez de criar sessão contra um preço que não existe.
+STRIPE_PRICE_ID=
+# Para onde o Stripe devolve a pessoa depois do Checkout e do Portal. Em produção,
+# a URL do frontend na Vercel (https, sem barra final) — NÃO é derivada do
+# CORS_ORIGINS, que é uma lista.
+APP_BASE_URL=http://localhost:5173
 
 # Paywall da v2 (ADR 0002). Desligado = app se comporta como antes.
 PAYWALL_ENABLED=false

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -27,6 +27,16 @@ class Settings(BaseSettings):
     # até o #26 provisionar a conta.
     stripe_secret_key: str = ""
     stripe_webhook_secret: str = ""
+    # O preço recorrente criado no painel (#26). Vazio = billing não
+    # provisionado, e o endpoint de checkout recusa com 503 em vez de tentar
+    # criar sessão contra um preço que não existe.
+    stripe_price_id: str = ""
+
+    # Base pública do frontend, para onde o Stripe devolve a pessoa depois do
+    # Checkout e do Portal. Default do dev local: em produção vem do ambiente.
+    # Não dá para derivar do CORS — aquilo é uma LISTA, e escolher um item dela
+    # como destino de redirect seria adivinhação.
+    app_base_url: str = "http://localhost:5173"
 
     # Flag de rollout do paywall (ADR 0002). Default DESLIGADO: o merge não muda
     # nada em produção, e o paywall acende por variável de ambiente quando o

--- a/backend/app/routers/billing.py
+++ b/backend/app/routers/billing.py
@@ -1,15 +1,26 @@
-"""Endpoint de webhook do Stripe (issue #45, ADR 0001)."""
+"""Rotas de billing: webhook (#45) e Checkout/Portal (#46), do ADR 0001."""
 
 import json
 import logging
 
 import stripe
 from fastapi import APIRouter, Depends, HTTPException, Request, status
+from pydantic import BaseModel, Field
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import get_settings
-from app.dependencies import get_db
-from app.services.billing_service import handle_event
+from app.dependencies import get_current_user, get_db
+from app.limiter import limiter, user_key
+from app.models.sql_models import User
+from app.services.billing_service import (
+    CheckoutNotOurs,
+    CheckoutNotPaid,
+    GatewayError,
+    confirm_checkout,
+    create_checkout_session,
+    create_portal_session,
+    handle_event,
+)
 
 router = APIRouter(prefix="/billing", tags=["Billing"])
 logger = logging.getLogger("norby.billing")
@@ -62,3 +73,118 @@ async def stripe_webhook(request: Request, db: AsyncSession = Depends(get_db)):
     # pontos de acoplamento que o ADR nomeia, em vez de uma reescrita.
     await handle_event(json.loads(corpo), db)
     return {"received": True}
+
+
+# --- Checkout e Customer Portal (issue #46) ----------------------------------
+# Rotas AUTENTICADAS, ao contrário do webhook acima. Por serem autenticadas, o
+# teto por usuário se aplica e o problema do IP atrás do proxy não aparece.
+
+# Para onde o Stripe devolve a pessoa. Aponta para `/settings`, que EXISTE hoje;
+# a `/perfil` é do #25 e ainda não foi construída — mandar a pessoa que acabou
+# de pagar para uma rota inexistente seria trocar a compra por um 404.
+ROTA_DE_VOLTA = "/settings"
+
+
+class ConfirmCheckout(BaseModel):
+    # 200 chars cobrem o `cs_...` com folga e evitam receber um texto qualquer.
+    session_id: str = Field(min_length=1, max_length=200)
+
+
+def _url(sufixo: str) -> str:
+    return f"{settings.app_base_url.rstrip('/')}{ROTA_DE_VOLTA}{sufixo}"
+
+
+@router.post("/checkout-session")
+@limiter.limit("10/minute", key_func=user_key)
+async def checkout_session(
+    request: Request,
+    current_user: User = Depends(get_current_user),
+):
+    """Cria a sessão de Checkout hospedado e devolve a URL do Stripe."""
+    if not settings.stripe_secret_key or not settings.stripe_price_id:
+        # Billing ainda não provisionado (#26). Recusar alto é melhor do que
+        # criar sessão contra um preço que não existe e jogar o erro cru do
+        # Stripe na tela de quem quis pagar.
+        raise HTTPException(status_code=503, detail="Assinatura ainda não disponível")
+
+    try:
+        url = await create_checkout_session(
+            client_reference_id=str(current_user.id),
+            price_id=settings.stripe_price_id,
+            customer_id=current_user.stripe_customer_id,
+            # O placeholder é substituído pelo próprio Stripe no redirect, e é
+            # o que permite fechar a corrida da primeira compra na volta.
+            success_url=_url("?checkout=success&session_id={CHECKOUT_SESSION_ID}"),
+            cancel_url=_url("?checkout=cancel"),
+        )
+    except GatewayError as erro:
+        logger.error("stripe: falha ao criar sessão de checkout: %s", erro)
+        raise HTTPException(
+            status_code=502,
+            detail="Não foi possível abrir o pagamento agora. Tente novamente em instantes.",
+        )
+    return {"url": url}
+
+
+@router.post("/portal-session")
+@limiter.limit("10/minute", key_func=user_key)
+async def portal_session(
+    request: Request,
+    current_user: User = Depends(get_current_user),
+):
+    """Cria a sessão do Customer Portal: cancelar, trocar cartão, ver faturas."""
+    if not current_user.stripe_customer_id:
+        # Estado NORMAL de quem nunca comprou, então 409 com mensagem e não 500.
+        raise HTTPException(
+            status_code=409, detail="Você ainda não tem uma assinatura para gerenciar"
+        )
+    if not settings.stripe_secret_key:
+        raise HTTPException(status_code=503, detail="Assinatura ainda não disponível")
+
+    try:
+        url = await create_portal_session(
+            customer_id=current_user.stripe_customer_id, return_url=_url("")
+        )
+    except GatewayError as erro:
+        logger.error("stripe: falha ao criar sessão do portal: %s", erro)
+        raise HTTPException(
+            status_code=502,
+            detail="Não foi possível abrir o gerenciamento agora. Tente novamente em instantes.",
+        )
+    return {"url": url}
+
+
+@router.post("/confirm-checkout")
+@limiter.limit("20/minute", key_func=user_key)
+async def confirm_checkout_route(
+    request: Request,
+    payload: ConfirmCheckout,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Chamado na volta do Checkout, com o id da sessão que veio na URL.
+
+    Existe porque o redirect chega ANTES do webhook. Não substitui o webhook —
+    ele segue sendo a fonte da verdade —, só antecipa em segundos o que ele
+    traria, para a pessoa não voltar de uma compra bem-sucedida e ler que não é
+    premium.
+    """
+    try:
+        await confirm_checkout(current_user, payload.session_id, db)
+    except CheckoutNotOurs:
+        # 404 e não 403: para quem apresenta a sessão de outra pessoa, ela não
+        # existe. Distinguir "não é sua" de "não existe" entregaria de graça a
+        # confirmação de que aquele id é válido.
+        logger.warning(
+            "stripe: sessão de checkout apresentada por quem não é o dono (user=%s)",
+            current_user.id,
+        )
+        raise HTTPException(status_code=404, detail="Sessão de pagamento não encontrada")
+    except CheckoutNotPaid:
+        raise HTTPException(status_code=409, detail="O pagamento ainda não foi concluído")
+    except GatewayError as erro:
+        logger.error("stripe: falha ao confirmar checkout: %s", erro)
+        raise HTTPException(
+            status_code=502, detail="Não foi possível confirmar o pagamento agora."
+        )
+    return {"confirmed": True}

--- a/backend/app/services/billing_service.py
+++ b/backend/app/services/billing_service.py
@@ -327,3 +327,129 @@ async def reconcile_subscription(user: User, db: AsyncSession) -> bool:
     await db.commit()
     logger.info("stripe: assinatura de %s reconciliada (%s)", user.id, sub.get("status"))
     return True
+
+
+# --- Checkout e Customer Portal (issue #46) ----------------------------------
+# As duas saídas ao Stripe que o USUÁRIO alcança, ambas HOSPEDADAS. O Payment
+# Element exigiria abrir a CSP para js.stripe.com mais frames — afrouxar a CSP
+# na mesma release que começa a processar pagamento. O preço é real e não está
+# escondido: a pessoa sai do app na hora de pagar.
+
+
+class GatewayError(Exception):
+    """O gateway não respondeu ou recusou a criação da sessão.
+
+    Vira 502 no router, e não 500: a falha é de um terceiro, e a mensagem
+    precisa dizer isso para a pessoa saber que tentar de novo faz sentido.
+    """
+
+
+class CheckoutNotOurs(Exception):
+    """A sessão apresentada não pertence a quem está pedindo."""
+
+
+class CheckoutNotPaid(Exception):
+    """A sessão existe mas não foi paga."""
+
+
+async def create_checkout_session(
+    *,
+    client_reference_id: str,
+    price_id: str,
+    customer_id: str | None,
+    success_url: str,
+    cancel_url: str,
+) -> str:
+    """Cria a sessão de Checkout e devolve a URL para onde redirecionar.
+
+    `client_reference_id` é o id do usuário, e é a ÚNICA vez em que o Stripe
+    ainda não sabe quem é a pessoa — o `_dono` do webhook depende dele para
+    casar a primeira compra. Dali em diante casa por `stripe_customer_id`.
+    """
+    parametros = {
+        "mode": "subscription",
+        "line_items": [{"price": price_id, "quantity": 1}],
+        "client_reference_id": client_reference_id,
+        "success_url": success_url,
+        "cancel_url": cancel_url,
+        "locale": "pt-BR",
+    }
+    # Reaproveita o customer de quem já comprou antes. Deixar o Stripe criar um
+    # segundo deixaria metade dos eventos futuros sem dono, porque a busca é
+    # por `stripe_customer_id`.
+    if customer_id:
+        parametros["customer"] = customer_id
+
+    try:
+        sessao = await stripe.checkout.Session.create_async(
+            **parametros, api_key=_chave()
+        )
+    except Exception as erro:  # noqa: BLE001 — rede, credencial ou 4xx do Stripe
+        raise GatewayError(str(erro)) from erro
+    return sessao.url
+
+
+async def create_portal_session(*, customer_id: str, return_url: str) -> str:
+    """Cria a sessão do Customer Portal e devolve a URL.
+
+    Cancelamento, troca de cartão e histórico de faturas numa superfície só. Um
+    endpoint próprio de cancelar entregaria um terço da feature.
+    """
+    try:
+        sessao = await stripe.billing_portal.Session.create_async(
+            customer=customer_id, return_url=return_url, api_key=_chave()
+        )
+    except Exception as erro:  # noqa: BLE001
+        raise GatewayError(str(erro)) from erro
+    return sessao.url
+
+
+async def fetch_checkout_session(session_id: str) -> dict:
+    """Lê a sessão de Checkout. Saída de rede, e é ela que os testes stubam."""
+    try:
+        sessao = await stripe.checkout.Session.retrieve_async(
+            session_id, api_key=_chave()
+        )
+    except Exception as erro:  # noqa: BLE001
+        raise GatewayError(str(erro)) from erro
+    return dict(sessao)
+
+
+async def confirm_checkout(user: User, session_id: str, db: AsyncSession) -> None:
+    """Fecha a corrida da PRIMEIRA compra, na volta do Checkout.
+
+    Lacuna registrada no ADR 0001: o redirect chega antes do webhook, e a
+    reconciliação preguiçosa não cobre este instante porque exige
+    `stripe_subscription_id` — que é justamente o que ainda não veio. A sessão
+    de Checkout traz os dois ids, então amarrá-los aqui deixa a reconciliação
+    conseguir trabalhar em seguida.
+
+    Nada disto substitui o webhook: ele continua sendo a fonte da verdade, e
+    este caminho só antecipa o que ele traria segundos depois.
+    """
+    sessao = await fetch_checkout_session(session_id)
+
+    # O id da sessão chega pela URL, ou seja, pelo CLIENTE. Sem esta conferência
+    # qualquer pessoa apresentaria a sessão de outra e levaria o premium dela
+    # junto do customer, o que ainda deixaria os eventos da vítima sem dono.
+    if sessao.get("client_reference_id") != str(user.id):
+        raise CheckoutNotOurs()
+
+    if sessao.get("status") != "complete" or sessao.get("payment_status") != "paid":
+        raise CheckoutNotPaid()
+
+    # O MESMO `_aplicar` do webhook, com o tipo de checkout: ele já sabe que
+    # checkout só AMARRA ids e não move o portão.
+    evento = {
+        "id": f"checkout-return:{session_id}",
+        "type": EVENTO_CHECKOUT,
+        "data": {"object": sessao},
+    }
+    _aplicar(user, evento, _projecao(evento))
+    await db.commit()
+
+    # A compra invalida a janela de consulta: sem isto, quem estava vencido e
+    # voltou a assinar dentro de 15 minutos de uma reconciliação anterior
+    # ficaria sem premium até a janela expirar.
+    _ULTIMA_CONSULTA.pop(user.id, None)
+    await reconcile_subscription(user, db)

--- a/backend/tests/test_billing_checkout.py
+++ b/backend/tests/test_billing_checkout.py
@@ -1,0 +1,356 @@
+"""Checkout e Customer Portal (issue #46, ADR 0001).
+
+As duas saídas ao Stripe que o USUÁRIO alcança. Checkout HOSPEDADO, não Payment
+Element: o Element exigiria abrir a CSP para `js.stripe.com` mais frames, ou
+seja, afrouxar a CSP na mesma release que começa a processar pagamento.
+
+As chamadas de rede são stubadas na fronteira do service, como o
+`fetch_subscription` do #48.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import select
+
+import app.routers.billing as billing_router
+import app.services.billing_service as billing
+from app.config import get_settings
+from app.models.sql_models import User
+
+
+@pytest.fixture(autouse=True)
+def billing_configurado():
+    settings = get_settings()
+    antes = (settings.stripe_secret_key, settings.stripe_price_id, settings.app_base_url)
+    settings.stripe_secret_key = "sk_test_x"
+    settings.stripe_price_id = "price_123"
+    settings.app_base_url = "https://norby.app"
+    yield settings
+    (settings.stripe_secret_key, settings.stripe_price_id, settings.app_base_url) = antes
+
+
+@pytest.fixture(autouse=True)
+def sem_memoria_de_reconciliacao():
+    billing._ULTIMA_CONSULTA.clear()
+    yield
+    billing._ULTIMA_CONSULTA.clear()
+
+
+async def _user(ac, db_session, **campos) -> User:
+    me = (await ac.get("/auth/me")).json()
+    user = (await db_session.execute(select(User).where(User.id == me["id"]))).scalar_one()
+    for campo, valor in campos.items():
+        setattr(user, campo, valor)
+    await db_session.commit()
+    return user
+
+
+# --- Checkout ----------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_checkout_carries_the_user_id_so_the_webhook_can_match(
+    make_auth_client, db_session, monkeypatch
+):
+    # `client_reference_id` é a ÚNICA vez em que o Stripe ainda não sabe quem é
+    # a pessoa. Sem ele o primeiro evento não casa com ninguém e a compra fica
+    # órfã — o `_dono` do webhook depende disto.
+    alice = await make_auth_client("Alice")
+    user = await _user(alice, db_session)
+    recebido = {}
+
+    async def _fake(**kwargs):
+        recebido.update(kwargs)
+        return "https://checkout.stripe.com/c/pay/cs_test_1"
+
+    monkeypatch.setattr(billing_router, "create_checkout_session", _fake)
+
+    res = await alice.post("/billing/checkout-session")
+    assert res.status_code == 200, res.text
+    assert res.json()["url"].startswith("https://checkout.stripe.com/")
+
+    assert recebido["client_reference_id"] == str(user.id)
+    assert recebido["price_id"] == "price_123"
+    assert recebido["customer_id"] is None  # ainda não tem
+    # A volta traz o id da sessão, que é o que fecha a corrida da 1ª compra.
+    assert "{CHECKOUT_SESSION_ID}" in recebido["success_url"]
+    assert recebido["success_url"].startswith("https://norby.app")
+    assert recebido["cancel_url"].startswith("https://norby.app")
+
+
+@pytest.mark.asyncio
+async def test_a_returning_subscriber_reuses_their_stripe_customer(
+    make_auth_client, db_session, monkeypatch
+):
+    # Quem cancelou e volta NÃO pode virar um segundo customer: o webhook casa
+    # por `stripe_customer_id` depois da primeira compra, e um duplicado deixa
+    # metade dos eventos sem dono.
+    alice = await make_auth_client("Alice")
+    await _user(alice, db_session, stripe_customer_id="cus_ja_existe")
+    recebido = {}
+
+    async def _fake(**kwargs):
+        recebido.update(kwargs)
+        return "https://checkout.stripe.com/c/pay/cs_test_2"
+
+    monkeypatch.setattr(billing_router, "create_checkout_session", _fake)
+
+    await alice.post("/billing/checkout-session")
+    assert recebido["customer_id"] == "cus_ja_existe"
+
+
+@pytest.mark.asyncio
+async def test_checkout_refuses_loudly_when_billing_is_not_provisioned(
+    make_auth_client, billing_configurado
+):
+    # Sem o #26 feito não há preço. Recusar alto é melhor que criar sessão
+    # contra um preço inexistente e devolver erro do Stripe cru na tela.
+    billing_configurado.stripe_price_id = ""
+    alice = await make_auth_client("Alice")
+
+    res = await alice.post("/billing/checkout-session")
+    assert res.status_code == 503
+
+
+@pytest.mark.asyncio
+async def test_a_gateway_failure_is_502_not_500(make_auth_client, monkeypatch):
+    alice = await make_auth_client("Alice")
+
+    async def _falha(**_kwargs):
+        raise billing_router.GatewayError("stripe fora do ar")
+
+    monkeypatch.setattr(billing_router, "create_checkout_session", _falha)
+
+    res = await alice.post("/billing/checkout-session")
+    assert res.status_code == 502
+    assert res.json()["detail"]
+
+
+# --- Customer Portal ---------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_the_portal_needs_a_customer_and_says_so(make_auth_client):
+    # Quem nunca comprou não tem customer no Stripe. Isto é 4xx com mensagem,
+    # não 500: é estado normal de usuário free, não falha do servidor.
+    alice = await make_auth_client("Alice")
+
+    res = await alice.post("/billing/portal-session")
+    assert res.status_code == 409
+    assert res.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_the_portal_returns_a_url_for_a_customer(
+    make_auth_client, db_session, monkeypatch
+):
+    alice = await make_auth_client("Alice")
+    await _user(alice, db_session, stripe_customer_id="cus_1")
+    recebido = {}
+
+    async def _fake(**kwargs):
+        recebido.update(kwargs)
+        return "https://billing.stripe.com/p/session/test_1"
+
+    monkeypatch.setattr(billing_router, "create_portal_session", _fake)
+
+    res = await alice.post("/billing/portal-session")
+    assert res.status_code == 200
+    assert res.json()["url"].startswith("https://billing.stripe.com/")
+    assert recebido["customer_id"] == "cus_1"
+    assert recebido["return_url"].startswith("https://norby.app")
+
+
+# --- A volta do Checkout: a corrida da primeira compra -----------------------
+# Lacuna registrada no ADR 0001 e atribuída a este ticket. O redirect chega
+# ANTES do webhook, e a reconciliação preguiçosa (#48) não cobre este instante
+# porque exige `stripe_subscription_id` — que é justamente o que ainda não veio.
+
+
+def _sessao(user_id, *, status="complete", pago="paid") -> dict:
+    return {
+        "id": "cs_test_1",
+        "client_reference_id": str(user_id),
+        "customer": "cus_novo",
+        "subscription": "sub_novo",
+        "status": status,
+        "payment_status": pago,
+    }
+
+
+@pytest.mark.asyncio
+async def test_coming_back_from_checkout_grants_access_without_waiting_for_the_webhook(
+    make_auth_client, db_session, monkeypatch
+):
+    alice = await make_auth_client("Alice")
+    user = await _user(alice, db_session)
+    fim = int((datetime.now(timezone.utc) + timedelta(days=30)).timestamp())
+
+    async def _sessao_fake(_id):
+        return _sessao(user.id)
+
+    async def _assinatura_fake(_id):
+        return {
+            "id": "sub_novo",
+            "customer": "cus_novo",
+            "status": "active",
+            "cancel_at_period_end": False,
+            "items": {"data": [{"id": "si_1", "current_period_end": fim}]},
+        }
+
+    monkeypatch.setattr(billing, "fetch_checkout_session", _sessao_fake)
+    monkeypatch.setattr(billing, "fetch_subscription", _assinatura_fake)
+
+    res = await alice.post("/billing/confirm-checkout", json={"session_id": "cs_test_1"})
+    assert res.status_code == 200, res.text
+
+    await db_session.refresh(user)
+    assert user.stripe_customer_id == "cus_novo"
+    assert user.stripe_subscription_id == "sub_novo"
+    assert user.premium_until > datetime.now(timezone.utc)
+
+
+@pytest.mark.asyncio
+async def test_a_session_belonging_to_someone_else_is_refused(
+    make_auth_client, db_session, monkeypatch
+):
+    # O id da sessão chega pela URL, ou seja, pelo cliente. Sem conferir o
+    # `client_reference_id`, quem passasse a sessão de OUTRA pessoa ganharia o
+    # premium dela e ainda sequestraria o customer, deixando os eventos da
+    # vítima sem dono.
+    alice = await make_auth_client("Alice")
+    bob = await make_auth_client("Bob")
+    dono_bob = await _user(bob, db_session)
+    vitima = await _user(alice, db_session)
+
+    async def _sessao_fake(_id):
+        return _sessao(dono_bob.id)
+
+    monkeypatch.setattr(billing, "fetch_checkout_session", _sessao_fake)
+
+    res = await alice.post("/billing/confirm-checkout", json={"session_id": "cs_test_1"})
+    assert res.status_code == 404
+
+    await db_session.refresh(vitima)
+    assert vitima.stripe_customer_id is None
+    assert vitima.premium_until is None
+
+
+@pytest.mark.asyncio
+async def test_an_unpaid_session_grants_nothing(make_auth_client, db_session, monkeypatch):
+    alice = await make_auth_client("Alice")
+    user = await _user(alice, db_session)
+
+    async def _sessao_fake(_id):
+        return _sessao(user.id, status="open", pago="unpaid")
+
+    monkeypatch.setattr(billing, "fetch_checkout_session", _sessao_fake)
+
+    res = await alice.post("/billing/confirm-checkout", json={"session_id": "cs_test_1"})
+    assert res.status_code == 409
+
+    await db_session.refresh(user)
+    assert user.premium_until is None
+    assert user.stripe_subscription_id is None
+
+
+@pytest.mark.asyncio
+async def test_a_recent_reconciliation_does_not_block_a_fresh_purchase(
+    make_auth_client, db_session, monkeypatch
+):
+    # Quem estava vencido e voltou a assinar já tinha sido consultado há pouco.
+    # Se a janela de 15 min do #48 valesse aqui, a pessoa pagaria e continuaria
+    # sem premium até a janela expirar. A COMPRA invalida a janela.
+    alice = await make_auth_client("Alice")
+    user = await _user(
+        alice,
+        db_session,
+        premium_until=datetime.now(timezone.utc) - timedelta(days=10),
+        subscription_status="past_due",
+    )
+    billing._ULTIMA_CONSULTA[user.id] = datetime.now(timezone.utc)
+    fim = int((datetime.now(timezone.utc) + timedelta(days=30)).timestamp())
+
+    async def _sessao_fake(_id):
+        return _sessao(user.id)
+
+    async def _assinatura_fake(_id):
+        return {
+            "id": "sub_novo",
+            "customer": "cus_novo",
+            "status": "active",
+            "cancel_at_period_end": False,
+            "items": {"data": [{"id": "si_1", "current_period_end": fim}]},
+        }
+
+    monkeypatch.setattr(billing, "fetch_checkout_session", _sessao_fake)
+    monkeypatch.setattr(billing, "fetch_subscription", _assinatura_fake)
+
+    assert (
+        await alice.post("/billing/confirm-checkout", json={"session_id": "cs_test_1"})
+    ).status_code == 200
+
+    await db_session.refresh(user)
+    assert user.premium_until > datetime.now(timezone.utc)
+
+
+# --- O payload que chega ao Stripe -------------------------------------------
+# Os testes acima stubam a função do service, então provam o que o ROUTER passa
+# e não o que o Stripe recebe. Duas mutações sobreviveram exatamente aí
+# (`client_reference_id` fora do payload, e o customer existente ignorado), o
+# que deixaria a primeira compra órfã e criaria customer duplicado sem nada
+# ficar vermelho. Este teste stuba o SDK, um nível abaixo.
+
+
+@pytest.mark.asyncio
+async def test_the_payload_that_reaches_stripe_is_complete(monkeypatch):
+    recebido = {}
+
+    async def _create(**kwargs):
+        recebido.update(kwargs)
+        return type("S", (), {"url": "https://checkout.stripe.com/c/pay/cs_1"})()
+
+    monkeypatch.setattr(billing.stripe.checkout.Session, "create_async", _create)
+
+    url = await billing.create_checkout_session(
+        client_reference_id="abc-123",
+        price_id="price_123",
+        customer_id="cus_1",
+        success_url="https://norby.app/settings?s={CHECKOUT_SESSION_ID}",
+        cancel_url="https://norby.app/settings",
+    )
+
+    assert url == "https://checkout.stripe.com/c/pay/cs_1"
+    # Sem isto o primeiro evento não casa com ninguém e a compra fica órfã.
+    assert recebido["client_reference_id"] == "abc-123"
+    # Sem isto o Stripe cria um SEGUNDO customer para quem já tinha um, e os
+    # eventos seguintes deixam de casar por `stripe_customer_id`.
+    assert recebido["customer"] == "cus_1"
+    assert recebido["mode"] == "subscription"
+    assert recebido["line_items"] == [{"price": "price_123", "quantity": 1}]
+    assert recebido["locale"] == "pt-BR"
+    assert recebido["api_key"]  # a chave nunca era configurada antes do #48
+
+
+@pytest.mark.asyncio
+async def test_a_first_time_buyer_sends_no_customer_at_all(monkeypatch):
+    # Mandar `customer=None` faria o Stripe recusar; a chave tem de ficar FORA
+    # do payload, não presente e vazia.
+    recebido = {}
+
+    async def _create(**kwargs):
+        recebido.update(kwargs)
+        return type("S", (), {"url": "https://checkout.stripe.com/c/pay/cs_2"})()
+
+    monkeypatch.setattr(billing.stripe.checkout.Session, "create_async", _create)
+
+    await billing.create_checkout_session(
+        client_reference_id="abc-123",
+        price_id="price_123",
+        customer_id=None,
+        success_url="https://norby.app/settings",
+        cancel_url="https://norby.app/settings",
+    )
+
+    assert "customer" not in recebido


### PR DESCRIPTION
Wave 4 of #15. Closes #46. From [ADR 0001](https://github.com/DigoDuck/Norby/blob/main/docs/adr/0001-modelo-de-assinatura.md).

The two outbound Stripe calls a user reaches, plus the one that closes the gap the ADR recorded against this ticket.

## Hosted, not embedded

Payment Element would require opening the CSP to `js.stripe.com` plus frames — loosening the CSP in the same release that starts processing payment. #15 already treats the CSP as untouchable to the point of refusing an external bank-logo API over it.

The cost is real and not hidden: the person leaves the app to pay.

## `POST /billing/checkout-session`

Carries `client_reference_id`, which is the **only** moment Stripe does not yet know who the person is — the webhook's owner lookup depends on it, and without it the first purchase is orphaned.

It **reuses an existing `stripe_customer_id`** rather than letting Stripe mint a second customer. After the first purchase every event is matched by that id, so a duplicate would leave half of them ownerless.

With no price configured it answers **503**, not a raw Stripe error on the screen of someone who wanted to pay.

## `POST /billing/portal-session`

Cancellation, card updates and invoice history in one hosted surface. A user with no customer gets **409 with a message**: that is the normal state of a free account, not a server fault.

The Portal does not remove the server-side client — #23 needs an admin to cancel someone else's subscription, and an admin cannot use that person's portal session.

## `POST /billing/confirm-checkout` — the gap the ADR assigned here

The redirect from Checkout arrives **before** the webhook, and the lazy reconciliation from #48 cannot help, because it requires a `stripe_subscription_id` — which is exactly what has not arrived yet. So without this, someone pays and comes back to an app telling them they are not premium.

The Checkout session carries both ids, so binding them here lets reconciliation run immediately after. **It does not replace the webhook**, which stays the source of truth; it only anticipates by seconds what the webhook would bring.

Two things it refuses:

- **A session that is not yours.** The id reaches this endpoint from the URL, meaning from the client. Without checking `client_reference_id`, presenting someone else's session would grant their premium *and* hijack their customer, leaving the victim's events ownerless. It answers **404 rather than 403**, because distinguishing "not yours" from "does not exist" would confirm for free that the id is valid.
- **A session that is not paid.**

A purchase also clears the reconciliation window from #48, otherwise a lapsed subscriber who resubscribes within 15 minutes of an earlier check would stay without access until the window expired.

## Mutation testing found a blind spot

Five mutations, all killed — but **two survived the first pass**, both in the same place: the tests stub the service function, so they prove what the *router* passes, not what *Stripe* receives. The payload built inside the service was unverified, meaning `client_reference_id` could have been dropped from it, and the existing customer ignored, with nothing going red.

A test one level down, at the SDK boundary, now covers both.

## An environment note worth recording

Mid-session the Docker bind mount served **stale file contents** to both the host and the container for a few seconds after a write, so a test run immediately after an edit executed the old code. That produced one round of mutation results that looked coherent and were meaningless. The mutation driver now confirms the container sees the mutated file before running anything.

## Verification

253 backend tests, up from 241. No Stripe key in the repository; `.env.example` gains `STRIPE_PRICE_ID` and `APP_BASE_URL` as empty-safe placeholders.

## Still needed to exercise this against real Stripe

- **#26**: confirm the account can create a recurring **BRL 20.00** price, then put the id in `STRIPE_PRICE_ID`. That is still the one unverified assumption under both ADRs.
- The **API version pinned on the webhook endpoint**, because of the `current_period_end` move found in #94.
- The **Customer Portal** has to be activated in the dashboard, or `/billing/portal-session` will return 502.

## Not in scope

Where the "become premium" call to action lives is **#25**, per #15. This PR is backend only, which also keeps it clear of #96 (still open) on `Settings.jsx`. The return handler that calls `confirm-checkout` belongs with that surface.
