### PR TITLE
feat(billing): plan state and the two Stripe doors on the settings screen

### DIFF
--- a/frontend/src/api/billing.js
+++ b/frontend/src/api/billing.js
@@ -1,0 +1,13 @@
+import api from "./axios";
+
+export const billingApi = {
+  // Devolve a URL do Checkout hospedado; quem redireciona é a tela.
+  checkoutSession: () => api.post("/billing/checkout-session"),
+  // Customer Portal: cancelar, trocar cartão, ver faturas.
+  portalSession: () => api.post("/billing/portal-session"),
+  // Chamado na VOLTA do Checkout, com o id que o Stripe põe na URL. Existe
+  // porque o redirect chega antes do webhook — sem isto a pessoa volta de uma
+  // compra bem-sucedida e lê que não é premium.
+  confirmCheckout: (sessionId) =>
+    api.post("/billing/confirm-checkout", { session_id: sessionId }),
+};

--- a/frontend/src/components/shared/PlanCard.jsx
+++ b/frontend/src/components/shared/PlanCard.jsx
@@ -1,0 +1,156 @@
+import { useEffect, useState } from "react";
+import { useSearchParams } from "react-router-dom";
+import { CreditCard } from "lucide-react";
+
+import { billingApi } from "@/api/billing";
+import { authApi } from "@/api/auth";
+import { useAuthStore } from "@/store/authStore";
+import { apiErrorMessage, formatDateBR } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+
+/**
+ * Estado do plano e as duas portas de saída para o Stripe (issue #46).
+ *
+ * A CTA de assinar aparece SÓ quando o paywall está de fato restringindo esta
+ * pessoa, e isso não é detalhe: com o flag desligado os dois booleanos do
+ * `plan` reportam liberado (ADR 0002), então nada é oferecido. É o
+ * comportamento certo — enquanto o paywall está apagado o premium não entrega
+ * nada a mais, e vender isso seria cobrar por ar. Quando o flag acender, a CTA
+ * aparece sozinha, exatamente para quem está sendo limitado.
+ *
+ * Repare que isto NÃO lê o flag: os booleanos já dizem "o paywall está fazendo
+ * algo com você", que é a pergunta real. Expor `paywall_enabled` ao frontend
+ * quebraria a regra do ADR de ele ser lido só nos dois helpers de enforcement.
+ */
+export default function PlanCard() {
+  const user = useAuthStore((s) => s.user);
+  const updateUser = useAuthStore((s) => s.updateUser);
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [carregando, setCarregando] = useState("");
+  const [erro, setErro] = useState("");
+
+  // A VOLTA do Checkout. O Stripe devolve a pessoa para cá com o id da sessão
+  // na URL, e o webhook pode ainda não ter chegado — sem isto ela volta de uma
+  // compra bem-sucedida e lê que não é premium.
+  //
+  // O id sai da URL depois, o que também evita reprocessar num F5.
+  useEffect(() => {
+    const sessionId = searchParams.get("session_id");
+    if (!sessionId) return;
+
+    let vivo = true;
+    billingApi
+      .confirmCheckout(sessionId)
+      .then(() => authApi.me())
+      .then(({ data }) => {
+        if (vivo) updateUser(data);
+      })
+      // Silencioso: o webhook chega em segundos e conserta sozinho. Assustar
+      // quem acabou de pagar com um erro que se resolve sozinho é pior do que
+      // deixar a tela atualizar um instante depois.
+      .catch(() => {})
+      .finally(() => {
+        if (!vivo) return;
+        const limpo = new URLSearchParams(searchParams);
+        limpo.delete("session_id");
+        limpo.delete("checkout");
+        setSearchParams(limpo, { replace: true });
+      });
+
+    return () => {
+      vivo = false;
+    };
+  }, [searchParams, setSearchParams, updateUser]);
+
+  const plan = user?.plan;
+  const restringido =
+    plan?.ai_allowed === false || plan?.wallet_cap_applies === true;
+  const temAssinatura = Boolean(plan?.subscription_status);
+  const premiumAtivo = Boolean(
+    plan?.premium_until && new Date(plan.premium_until) > new Date(),
+  );
+
+  async function abrir(qual) {
+    setErro("");
+    setCarregando(qual);
+    try {
+      const { data } =
+        qual === "checkout"
+          ? await billingApi.checkoutSession()
+          : await billingApi.portalSession();
+      // Checkout e Portal são HOSPEDADOS: a pessoa sai do app de propósito,
+      // para a CSP não precisar abrir para js.stripe.com (ADR 0001).
+      window.location.assign(data.url);
+    } catch (err) {
+      setErro(apiErrorMessage(err, "Não foi possível abrir agora. Tente de novo."));
+      setCarregando("");
+    }
+  }
+
+  function descricao() {
+    if (plan?.subscription_status === "past_due") {
+      return "Pagamento recusado. Atualize o cartão para não perder o acesso.";
+    }
+    if (premiumAtivo) {
+      const data = formatDateBR(plan.premium_until);
+      // "Renova" e "termina" não são a mesma frase, e a diferença mora só no
+      // `cancel_at_period_end`: sem ele a tela diria "renova" para quem já
+      // cancelou.
+      return plan.cancel_at_period_end
+        ? `Sua assinatura termina em ${data}.`
+        : `Sua assinatura renova em ${data}.`;
+    }
+    if (plan?.ai_trial_ends_at && new Date(plan.ai_trial_ends_at) > new Date()) {
+      return `Você está no teste da IA até ${formatDateBR(plan.ai_trial_ends_at)}.`;
+    }
+    return "Você está no plano gratuito.";
+  }
+
+  // Sem nada a dizer nem a oferecer, o cartão não aparece: um bloco "plano
+  // gratuito" sem ação vira ruído na tela de quem não pode fazer nada com ele.
+  if (!plan || (!restringido && !temAssinatura)) return null;
+
+  return (
+    <div className="glass p-6">
+      <div className="flex items-center gap-3 mb-5">
+        <div className="w-8 h-8 rounded-lg flex items-center justify-center bg-accent/[0.12] text-accent">
+          <CreditCard size={16} />
+        </div>
+        <h2 className="font-semibold text-content">Plano</h2>
+      </div>
+
+      <p className="text-sm text-content-2 leading-relaxed">{descricao()}</p>
+
+      {erro && (
+        <p role="alert" className="text-xs text-danger mt-3">
+          {erro}
+        </p>
+      )}
+
+      <div className="flex flex-wrap gap-3 mt-5">
+        {/* Sem `&& !premiumAtivo`: seria redundante, e a mutação provou. Quem
+            tem premium ativo já tem `wallet_cap_applies` falso e `ai_allowed`
+            verdadeiro, ou seja, `restringido` já é falso. */}
+        {restringido && (
+          <Button
+            onClick={() => abrir("checkout")}
+            disabled={carregando !== ""}
+            className="bg-accent-fill text-accent-contrast hover:bg-accent-fill/90 font-medium"
+          >
+            {carregando === "checkout" ? "Abrindo…" : "Assinar"}
+          </Button>
+        )}
+
+        {temAssinatura && (
+          <Button
+            variant="outline"
+            onClick={() => abrir("portal")}
+            disabled={carregando !== ""}
+          >
+            {carregando === "portal" ? "Abrindo…" : "Gerenciar assinatura"}
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/shared/PlanCard.test.jsx
+++ b/frontend/src/components/shared/PlanCard.test.jsx
@@ -1,0 +1,163 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+
+import { billingApi } from "@/api/billing";
+import { authApi } from "@/api/auth";
+import { useAuthStore } from "@/store/authStore";
+import PlanCard from "./PlanCard";
+
+vi.mock("@/api/billing", () => ({
+  billingApi: {
+    checkoutSession: vi.fn(),
+    portalSession: vi.fn(),
+    confirmCheckout: vi.fn(),
+  },
+}));
+
+vi.mock("@/api/auth", () => ({
+  authApi: { me: vi.fn() },
+}));
+
+const LIBERADO = {
+  ai_allowed: true,
+  wallet_cap_applies: false,
+  premium_until: null,
+  ai_trial_ends_at: null,
+  subscription_status: null,
+  cancel_at_period_end: false,
+};
+
+function renderCard(plan, { url = "/settings" } = {}) {
+  useAuthStore.getState().login("access", "refresh", {
+    name: "Alice",
+    email: "alice@test.com",
+    plan,
+  });
+  render(
+    <MemoryRouter initialEntries={[url]}>
+      <PlanCard />
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => vi.clearAllMocks());
+afterEach(() => useAuthStore.getState().logout());
+
+describe("PlanCard", () => {
+  it("offers nothing while the paywall is off", () => {
+    // Estado de produção hoje: os dois booleanos reportam liberado, então o
+    // premium não entrega nada a mais. Oferecer assinatura aqui seria cobrar
+    // por ar — e é por isso que a CTA NÃO se guia por "esta pessoa é free?",
+    // que seria a regra óbvia e errada.
+    renderCard(LIBERADO);
+    expect(screen.queryByRole("button", { name: "Assinar" })).not.toBeInTheDocument();
+    expect(screen.queryByText("Plano")).not.toBeInTheDocument();
+  });
+
+  it("offers a subscription once the paywall actually restricts the person", () => {
+    renderCard({ ...LIBERADO, ai_allowed: false, wallet_cap_applies: true });
+    expect(screen.getByRole("button", { name: "Assinar" })).toBeInTheDocument();
+  });
+
+  it("offers it to someone capped on wallets even while the AI trial is running", () => {
+    // Faixa real: o trial concede só IA, o teto de carteiras segue valendo.
+    renderCard({ ...LIBERADO, ai_allowed: true, wallet_cap_applies: true });
+    expect(screen.getByRole("button", { name: "Assinar" })).toBeInTheDocument();
+  });
+
+  it("sends the person to the hosted Checkout", async () => {
+    const assign = vi.fn();
+    vi.spyOn(window, "location", "get").mockReturnValue({ assign });
+    billingApi.checkoutSession.mockResolvedValue({
+      data: { url: "https://checkout.stripe.com/c/pay/cs_1" },
+    });
+    renderCard({ ...LIBERADO, ai_allowed: false, wallet_cap_applies: true });
+
+    fireEvent.click(screen.getByRole("button", { name: "Assinar" }));
+
+    await waitFor(() =>
+      expect(assign).toHaveBeenCalledWith("https://checkout.stripe.com/c/pay/cs_1"),
+    );
+  });
+
+  it("says it failed instead of pretending the redirect is coming", async () => {
+    billingApi.checkoutSession.mockRejectedValue({
+      response: { data: { detail: "Assinatura ainda não disponível" } },
+    });
+    renderCard({ ...LIBERADO, ai_allowed: false, wallet_cap_applies: true });
+
+    fireEvent.click(screen.getByRole("button", { name: "Assinar" }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "Assinatura ainda não disponível",
+    );
+  });
+
+  it("distinguishes renewing from ending, which only cancel_at_period_end knows", () => {
+    const fim = new Date(Date.now() + 20 * 86400000).toISOString();
+    renderCard({
+      ...LIBERADO,
+      premium_until: fim,
+      subscription_status: "active",
+      cancel_at_period_end: true,
+    });
+    expect(screen.getByText(/termina em/i)).toBeInTheDocument();
+    expect(screen.queryByText(/renova em/i)).not.toBeInTheDocument();
+  });
+
+  it("surfaces a declined payment, which lives only in the status", () => {
+    renderCard({
+      ...LIBERADO,
+      premium_until: new Date(Date.now() + 86400000).toISOString(),
+      subscription_status: "past_due",
+    });
+    expect(screen.getByText(/pagamento recusado/i)).toBeInTheDocument();
+  });
+
+  it("does not offer a second subscription to someone who already pays", () => {
+    renderCard({
+      ...LIBERADO,
+      premium_until: new Date(Date.now() + 86400000).toISOString(),
+      subscription_status: "active",
+      wallet_cap_applies: false,
+    });
+    expect(screen.queryByRole("button", { name: "Assinar" })).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Gerenciar assinatura" }),
+    ).toBeInTheDocument();
+  });
+
+  it("confirms the checkout on the way back, without waiting for the webhook", async () => {
+    // A razão de o `session_id` existir na URL: o redirect chega antes do
+    // webhook, e sem isto a pessoa volta de uma compra boa e lê que é free.
+    billingApi.confirmCheckout.mockResolvedValue({});
+    authApi.me.mockResolvedValue({
+      data: {
+        name: "Alice",
+        plan: {
+          ...LIBERADO,
+          premium_until: new Date(Date.now() + 30 * 86400000).toISOString(),
+          subscription_status: "active",
+        },
+      },
+    });
+
+    renderCard(
+      { ...LIBERADO, ai_allowed: false, wallet_cap_applies: true },
+      { url: "/settings?checkout=success&session_id=cs_test_1" },
+    );
+
+    await waitFor(() =>
+      expect(billingApi.confirmCheckout).toHaveBeenCalledWith("cs_test_1"),
+    );
+    await waitFor(() =>
+      expect(useAuthStore.getState().user.plan.subscription_status).toBe("active"),
+    );
+  });
+
+  it("does not call confirm when there is no session in the URL", () => {
+    renderCard({ ...LIBERADO, ai_allowed: false, wallet_cap_applies: true });
+    expect(billingApi.confirmCheckout).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -16,6 +16,7 @@ import { accountApi } from "@/api/account";
 import { apiErrorMessage, shadcnInputCls } from "@/lib/utils";
 import ThemeToggle from "@/components/shared/ThemeToggle";
 import Avatar from "@/components/shared/Avatar";
+import PlanCard from "@/components/shared/PlanCard";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 
@@ -273,6 +274,10 @@ export default function Settings() {
           <Save size={15} /> {saved ? "Salvo!" : "Salvar alterações"}
         </Button>
       </div>
+
+      {/* Plano e assinatura (#46). Some sozinho quando não há nada a dizer nem
+          a oferecer, que é o estado com o paywall desligado. */}
+      <PlanCard />
 
       {/* Segurança */}
       <div className="glass p-6">


### PR DESCRIPTION
Follows #46, which shipped the endpoints with no caller. This is the surface that reaches them.

## The call to action is not driven by "is this person free?"

That would be the obvious rule, and it would be wrong.

It appears only when the paywall is **actually restricting this person**, which the two `plan` booleans from #89 already answer. With the flag off both report permissive, so **nothing is offered** — and that is the point: while the paywall is dark, premium delivers nothing extra, and selling it would be charging for air.

When the flag is switched on, the call to action appears on its own, for exactly the people being limited. Someone in the AI trial still sees it, because the trial grants only AI and the wallet cap still applies to them.

This also keeps the frontend from reading `paywall_enabled`, which [ADR 0002](https://github.com/DigoDuck/Norby/blob/main/docs/adr/0002-onde-o-paywall-e-aplicado.md) restricts to the two enforcement helpers. The booleans already say "the paywall is doing something to you", which is the real question.

## The return from Checkout

The card confirms the session and refreshes the user. The redirect arrives **before** the webhook, so without this someone pays and reads that they are not premium — which is the entire reason `/billing/confirm-checkout` exists.

It fails **silently** on purpose: the webhook lands seconds later and fixes it, and alarming someone who just paid about a problem that resolves itself is worse than letting the screen catch up a moment later. The session id is then stripped from the URL, which also stops a refresh from reprocessing it.

## Wording that carries real state

- **"Renews" and "ends" are different sentences**, and the difference lives only in `cancel_at_period_end`. Without it the screen would tell someone who already cancelled that their subscription renews.
- **A declined payment exists only in `subscription_status`**, so it gets its own line rather than being folded into "your subscription renews on".

Both have tests.

The card renders **nothing** when there is neither something to say nor something to offer, instead of a dead "free plan" block that the person cannot act on.

## Mutation testing

Four mutations:

- call to action driven by "is free" instead of the booleans → the flag-off test fails
- `cancel_at_period_end` ignored → the renew/end test fails
- one mutation was **invalid**: it crashed the component rather than changing behaviour, so its 10 failures prove nothing and I am not counting it
- **one survived, and was right to.** The `!premiumAtivo` guard on the button was dead code: active premium already implies `wallet_cap_applies` false and `ai_allowed` true, so `restringido` is already false. Deleted rather than covered with a test.

## Verification

144 frontend tests, up from 134. Lint clean. No backend change.

## What this still is not

The designed `/perfil` page is **#25**. This is the functional surface on the existing settings screen so the Stripe flow is reachable end to end; where the upgrade offer eventually lives is that ticket's call.
