### PR TITLE
fix(billing): convert Stripe objects with to_dict, not dict()

### DIFF
--- a/backend/app/services/billing_service.py
+++ b/backend/app/services/billing_service.py
@@ -257,7 +257,13 @@ async def fetch_subscription(subscription_id: str) -> dict:
     objeto do SDK, e é isso que mantém a troca de gateway localizada.
     """
     sub = await stripe.Subscription.retrieve_async(subscription_id, api_key=_chave())
-    return dict(sub)
+    # `.to_dict()`, NÃO `dict(obj)`: no SDK 15 o StripeObject deixou de ser um
+    # mapping e `dict(obj)` levanta TypeError. Como os testes stubavam esta
+    # função com um dict, o erro só apareceria contra o Stripe de verdade — e
+    # apareceria como reconciliação "falhando" em silêncio, porque o TypeError
+    # cai no `except Exception` de quem chama. `to_dict()` é recursivo o
+    # bastante: os aninhados voltam como dict puro (verificado contra a conta).
+    return sub.to_dict()
 
 
 def precisa_reconciliar(user: User, now: datetime | None = None) -> bool:
@@ -410,9 +416,12 @@ async def fetch_checkout_session(session_id: str) -> dict:
         sessao = await stripe.checkout.Session.retrieve_async(
             session_id, api_key=_chave()
         )
+        # DENTRO do try, e com `.to_dict()`: `dict(obj)` levanta TypeError no
+        # SDK 15, e cá fora ele escapava do GatewayError e virava 500 na volta
+        # de toda primeira compra.
+        return sessao.to_dict()
     except Exception as erro:  # noqa: BLE001
         raise GatewayError(str(erro)) from erro
-    return dict(sessao)
 
 
 async def confirm_checkout(user: User, session_id: str, db: AsyncSession) -> None:

--- a/backend/tests/test_billing_reconcile.py
+++ b/backend/tests/test_billing_reconcile.py
@@ -208,7 +208,12 @@ async def test_both_gateway_calls_carry_the_secret_key(monkeypatch):
 
     async def _retrieve(subscription_id, **kwargs):
         recebidas["retrieve"] = kwargs.get("api_key")
-        return {"id": subscription_id}
+        # StripeObject de verdade, não dict: o SDK 15 devolve um objeto que
+        # NÃO é mapping, e devolver dict aqui escondia o `dict(obj)` quebrado
+        # que só aparecia contra o Stripe real (ver test_billing_sdk_boundary).
+        return billing.stripe.Subscription.construct_from(
+            {"id": subscription_id}, "sk_test_dummy"
+        )
 
     async def _cancel(subscription_id, **kwargs):
         recebidas["cancel"] = kwargs.get("api_key")

--- a/backend/tests/test_billing_sdk_boundary.py
+++ b/backend/tests/test_billing_sdk_boundary.py
@@ -1,0 +1,98 @@
+"""A fronteira com o SDK, com objetos de VERDADE do Stripe.
+
+Todo o resto da suíte stuba as saídas de rede com `dict`, o que é certo para
+testar comportamento — e foi exatamente por isso que um defeito real passou:
+no SDK 15 o `StripeObject` DEIXOU DE SER um mapping, então `dict(obj)` levanta
+`TypeError`. Stubando com dict, nada ficava vermelho.
+
+O efeito em produção era grave e silencioso: a reconciliação preguiçosa (#48)
+engolia o TypeError no seu `except Exception` e registrava "falhou" para
+sempre, e o `confirm-checkout` (#46) devolvia 500 na volta de toda primeira
+compra, porque a conversão estava FORA do try que traduz para GatewayError.
+
+Estes testes constroem StripeObject de verdade, sem rede.
+"""
+
+import pytest
+import stripe
+
+import app.services.billing_service as billing
+
+
+def _objeto(cls, valores: dict):
+    """StripeObject real, montado sem rede — é o que o SDK devolveria."""
+    return cls.construct_from(valores, "sk_test_dummy")
+
+
+@pytest.mark.asyncio
+async def test_fetch_subscription_returns_a_plain_dict_from_a_stripe_object(monkeypatch):
+    assinatura = _objeto(
+        stripe.Subscription,
+        {
+            "id": "sub_1",
+            "customer": "cus_1",
+            "status": "active",
+            "cancel_at_period_end": False,
+            "items": {"data": [{"id": "si_1", "current_period_end": 1788000000}]},
+        },
+    )
+
+    async def _retrieve(_id, **_kwargs):
+        return assinatura
+
+    monkeypatch.setattr(stripe.Subscription, "retrieve_async", _retrieve)
+
+    sub = await billing.fetch_subscription("sub_1")
+
+    assert isinstance(sub, dict)
+    assert sub["status"] == "active"
+    # O aninhado precisa aceitar `.get()`: é por ele que o `_periodo_fim`
+    # encontra o fim do período desde que o campo saiu do topo da assinatura.
+    assert billing._periodo_fim(sub) is not None
+
+
+@pytest.mark.asyncio
+async def test_fetch_checkout_session_returns_a_plain_dict(monkeypatch):
+    sessao = _objeto(
+        stripe.checkout.Session,
+        {
+            "id": "cs_1",
+            "client_reference_id": "abc",
+            "customer": "cus_1",
+            "subscription": "sub_1",
+            "status": "complete",
+            "payment_status": "paid",
+        },
+    )
+
+    async def _retrieve(_id, **_kwargs):
+        return sessao
+
+    monkeypatch.setattr(stripe.checkout.Session, "retrieve_async", _retrieve)
+
+    s = await billing.fetch_checkout_session("cs_1")
+
+    assert isinstance(s, dict)
+    assert s["client_reference_id"] == "abc"
+    assert s["payment_status"] == "paid"
+
+
+@pytest.mark.asyncio
+async def test_a_conversion_failure_still_arrives_as_a_gateway_error(monkeypatch):
+    """A conversão mora DENTRO do try de propósito.
+
+    Fora dele, qualquer erro ali escapava do `GatewayError` e o router
+    devolvia 500 em vez da mensagem que ele sabe dar.
+    """
+
+    class _Quebrado:
+        def to_dict(self):
+            raise TypeError("nao e um mapping")
+
+    async def _retrieve(_id, **_kwargs):
+        return _Quebrado()
+
+    monkeypatch.setattr(stripe.checkout.Session, "retrieve_async", _retrieve)
+
+    with pytest.raises(billing.GatewayError):
+        await billing.fetch_checkout_session("cs_1")


### PR DESCRIPTION
Found by pointing the code at the **real Stripe account**, which #26 finally made possible. Nothing in the suite was red, and both outbound reads were broken.

## What was wrong

In SDK 15 a `StripeObject` is no longer a mapping — `dict(obj)` raises `TypeError`:

```
TypeError: Price is not iterable or a mapping; call .to_dict() for a plain dict
```

Both fetch helpers used `dict()`, and every test stubbed them with plain dicts. That is exactly the blind spot the mutation round on #46 already pointed at: the tests proved what the *router* passes, never what the *SDK* returns.

## Two silent failures, both serious

**`fetch_subscription`** — the `TypeError` landed inside `reconcile_subscription`'s `except Exception`, so lazy reconciliation would log "failed" forever and never once work. The feature would have looked implemented and done nothing, which is the worst of both.

**`fetch_checkout_session`** — the conversion sat **outside** the `try` that translates to `GatewayError`, so it escaped as a **500 on the return from every first purchase**. The conversion is now inside that try, which is where it belonged regardless of this bug; there is a test for that alone.

## The fix

`.to_dict()`, which is deep enough for what the code reads: nested values come back as plain dicts, so `_periodo_fim` still reaches `items.data[].current_period_end`. Verified against the account. `to_dict_recursive` no longer exists in this version.

## Tests that would have caught it

The new ones build **real StripeObjects** with `construct_from` and need no network. The existing api_key test stubbed with a dict — the very habit that hid this — so its stub is a real object now too.

Proven by mutation: restoring `dict()` in either helper fails exactly the matching test, and nothing else.

## Also verified against the account while here

- **#26 is settled empirically**: the price is `brl`, `20.00`, `month × 1`, active, on a BR account. A recurring BRL price works.
- **Customer Portal** is configured, active and default, with cancel, card update and invoice history all enabled — so `/billing/portal-session` will work.
- **A real Checkout session was created** end to end and returned a URL, which is #46's "Done when".
- **There is no webhook endpoint registered on the account.** That is reported separately; it does not block this PR.

## Verification

275 backend tests, up from 272.
