### PR TITLE
fix(auth): refresh the user on every app load

### DIFF
--- a/frontend/src/components/layout/AppLayout.jsx
+++ b/frontend/src/components/layout/AppLayout.jsx
@@ -2,6 +2,7 @@ import { useEffect } from "react";
 import { Outlet } from "react-router-dom";
 import { recurringApi } from "@/api/recurring";
 import { accountApi } from "@/api/account";
+import { authApi } from "@/api/auth";
 import { useAuthStore } from "@/store/authStore";
 import Sidebar from "./Sidebar";
 import MobileNav from "./MobileNav";
@@ -20,6 +21,24 @@ export default function AppLayout() {
   // na sessão. Um ponto de chamada, as duas entradas cobertas.
   useEffect(() => {
     recurringApi.run().catch(() => {});
+  }, []);
+
+  // Recarrega o usuário a cada entrada na área autenticada.
+  //
+  // O `user` (com o `plan` dentro) é gravado no localStorage no login e, sem
+  // isto, NUNCA mais era atualizado. O ADR 0002 aceitou o plano ficar velho
+  // numa direção — a tela oferecer o que o backend recusa, que custa um 403
+  // com mensagem clara. Mas a direção INVERSA não é aceitável e foi o que
+  // aconteceu: quem já estava logado quando o paywall acendeu passava a levar
+  // 403 e a tela não mostrava como resolver, porque o plano guardado dizia
+  // "liberado" para sempre. Uma chamada por carga do app conserta isso.
+  useEffect(() => {
+    authApi
+      .me()
+      .then(({ data }) => useAuthStore.getState().updateUser(data))
+      // Silencioso: token expirado já é tratado pelo interceptor do axios, e
+      // falha de rede não pode derrubar a área autenticada inteira.
+      .catch(() => {});
   }, []);
 
   // Baixa a foto de perfil UMA vez por versão (issue #35).

--- a/frontend/src/components/layout/AppLayout.test.jsx
+++ b/frontend/src/components/layout/AppLayout.test.jsx
@@ -1,16 +1,24 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 
 import { recurringApi } from "@/api/recurring";
+import { authApi } from "@/api/auth";
+import { useAuthStore } from "@/store/authStore";
 import AppLayout from "./AppLayout";
 
 vi.mock("@/api/recurring", () => ({ recurringApi: { run: vi.fn() } }));
+vi.mock("@/api/auth", () => ({ authApi: { me: vi.fn() } }));
+vi.mock("@/api/account", () => ({ accountApi: { photo: vi.fn() } }));
 vi.mock("./Sidebar", () => ({ default: () => <aside /> }));
 vi.mock("./MobileNav", () => ({ default: () => <nav /> }));
 
 describe("AppLayout", () => {
-  beforeEach(() => vi.clearAllMocks());
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authApi.me.mockResolvedValue({ data: {} });
+  });
+  afterEach(() => useAuthStore.getState().logout());
 
   it("materializa recorrências ao entrar na área autenticada", async () => {
     // Regressão: com a chamada só no boot do App (deps vazias), um login feito
@@ -36,6 +44,43 @@ describe("AppLayout", () => {
     );
 
     await waitFor(() => expect(recurringApi.run).toHaveBeenCalled());
+    expect(container.querySelector("main")).toBeInTheDocument();
+  });
+
+  it("recarrega o usuário, senão o plano guardado no login nunca envelhece", async () => {
+    // O caso concreto: o paywall acende e quem já estava logado passa a levar
+    // 403 do backend enquanto a tela, lendo um `plan` velho do localStorage,
+    // continua sem oferecer o upgrade. Uma chamada por carga do app resolve.
+    recurringApi.run.mockResolvedValue({});
+    useAuthStore.getState().login("access", "refresh", {
+      name: "Alice",
+      plan: { ai_allowed: true, wallet_cap_applies: false },
+    });
+    authApi.me.mockResolvedValue({
+      data: { name: "Alice", plan: { ai_allowed: false, wallet_cap_applies: true } },
+    });
+
+    render(
+      <MemoryRouter>
+        <AppLayout />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() =>
+      expect(useAuthStore.getState().user.plan.wallet_cap_applies).toBe(true),
+    );
+  });
+
+  it("não derruba a tela quando o /auth/me falha", async () => {
+    recurringApi.run.mockResolvedValue({});
+    authApi.me.mockRejectedValue(new Error("rede"));
+    const { container } = render(
+      <MemoryRouter>
+        <AppLayout />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => expect(authApi.me).toHaveBeenCalled());
     expect(container.querySelector("main")).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Found while testing the Stripe flow end to end: after enabling the paywall flag, the subscribe button did not appear, and logging out and back in was the only way to see it.

## The bug

The user object, `plan` included, is written to localStorage at login and **never read again**. Nothing in the app called `/auth/me` after that.

[ADR 0002](https://github.com/DigoDuck/Norby/blob/main/docs/adr/0002-onde-o-paywall-e-aplicado.md) accepted the plan going stale in **one** direction:

> UI pode mostrar afordância que o backend recusa enquanto o `plan` do frontend está velho. Custo: um 403 com mensagem clara.

The opposite direction is not acceptable, and it is what actually happens. On the day the flag is switched on, **everyone already logged in starts getting 403s while their screen never shows how to fix it**, because the stored plan says permissive forever. The upgrade path would be invisible to exactly the people being restricted.

The ADR left this to be judged "with the screen in hand" (#25). With the screen in hand: it bites.

## The fix

One `/auth/me` per app load, in the same place as the recurring materialization and the photo — that is the point that mounts both on boot with a persisted token and on a login inside the SPA.

It fails silently on purpose: an expired token is already handled by the axios interceptor, and a network error must not take down the authenticated area.

## Verification

Proven by mutation: removing the call fails the two new tests and nothing else.

146 frontend tests, up from 144. Lint clean, no backend change.

## Note on the design hook

The impeccable hook flags a `broken-image` on this file. It is a false positive: the match is the string `<img src>` inside a comment explaining why the profile photo is *not* an image tag pointing at the closed route. There is no image markup in the file, so the comment stays as it is.
