### PR TITLE
chore(deps): clear the Dependabot backlog, minus bcrypt 5

### DIFF
--- a/backend/requirements-dev.lock
+++ b/backend/requirements-dev.lock
@@ -152,16 +152,18 @@ pydantic-core==2.46.4
 pydantic-settings==2.15.0
     # via -r requirements.txt
 pygments==2.20.0
-    # via rich
+    # via
+    #   pytest
+    #   rich
 pymongo==4.9.2
     # via motor
 pyparsing==3.3.2
     # via pip-requirements-parser
-pytest==8.3.3
+pytest==9.1.1
     # via
     #   -r requirements-dev.txt
     #   pytest-asyncio
-pytest-asyncio==0.24.0
+pytest-asyncio==1.4.0
     # via -r requirements-dev.txt
 python-dotenv==1.2.3
     # via
@@ -193,7 +195,7 @@ sniffio==1.3.1
     # via google-genai
 sortedcontainers==2.4.0
     # via cyclonedx-python-lib
-sqlalchemy==2.0.36
+sqlalchemy==2.0.52
     # via
     #   -r requirements.txt
     #   alembic
@@ -217,6 +219,7 @@ typing-extensions==4.16.0
     #   limits
     #   pydantic
     #   pydantic-core
+    #   pytest-asyncio
     #   sqlalchemy
     #   starlette
     #   stripe

--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -1,6 +1,6 @@
 # Só para desenvolvimento e CI — NÃO entra na imagem de produção.
 -r requirements.txt
-pytest==8.3.3
-pytest-asyncio==0.24.0
+pytest==9.1.1
+pytest-asyncio==1.4.0
 httpx==0.28.1  # cliente de teste (AsyncClient); não é dep de produção
 pip-audit==2.10.1

--- a/backend/requirements.lock
+++ b/backend/requirements.lock
@@ -134,7 +134,7 @@ slowapi==0.1.10
     # via -r requirements.txt
 sniffio==1.3.1
     # via google-genai
-sqlalchemy==2.0.36
+sqlalchemy==2.0.52
     # via
     #   -r requirements.txt
     #   alembic

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,6 +1,6 @@
 fastapi==0.141.1
 uvicorn[standard]==0.30.6
-sqlalchemy[asyncio]==2.0.36
+sqlalchemy[asyncio]==2.0.52
 asyncpg==0.30.0
 alembic==1.19.1
 motor==3.7.1

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -11,6 +11,7 @@ from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker, Asyn
 from app.main import app
 from app.database import Base
 from app.dependencies import get_db
+from app.config import get_settings
 from app.limiter import limiter
 
 load_dotenv(os.path.join(os.path.dirname(__file__), "..", "..", ".env"), encoding="utf-8")
@@ -30,6 +31,26 @@ def disable_rate_limit():
     limiter.enabled = False
     yield
     limiter.enabled = True
+
+
+@pytest.fixture(autouse=True)
+def paywall_no_padrao_de_producao():
+    """Toda a suíte começa com o paywall DESLIGADO, o default de produção.
+
+    Sem isto os testes herdavam o `PAYWALL_ENABLED` do `.env` de quem estivesse
+    rodando, e ligar o flag para testar assinatura à mão deixava 5 testes
+    vermelhos que pareciam regressão e não eram — inclusive os quatro chamados
+    `test_with_the_flag_off_*`, que afirmam exatamente o comportamento que o
+    ambiente estava contradizendo.
+
+    Os arquivos que precisam do paywall ligado têm a própria fixture e a
+    aplicam depois desta, porque autouse roda primeiro no mesmo escopo.
+    """
+    settings = get_settings()
+    antes = settings.paywall_enabled
+    settings.paywall_enabled = False
+    yield
+    settings.paywall_enabled = antes
 
 
 @pytest_asyncio.fixture(autouse=True)

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -34,7 +34,7 @@
         "@vitejs/plugin-react": "^6.0.1",
         "autoprefixer": "^10.4.27",
         "eslint": "^9.39.4",
-        "eslint-plugin-react-hooks": "^7.0.1",
+        "eslint-plugin-react-hooks": "^7.1.1",
         "eslint-plugin-react-refresh": "^0.5.2",
         "globals": "^17.4.0",
         "jsdom": "^25.0.1",
@@ -3217,9 +3217,9 @@
       }
     },
     "node_modules/eslint-plugin-react-hooks": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.0.1.tgz",
-      "integrity": "sha512-O0d0m04evaNzEPoSW+59Mezf8Qt0InfgGIBJnpC0h3NH/WjUAR7BIKUfysC6todmtiZ/A0oUVS8Gce0WhBrHsA==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.1.1.tgz",
+      "integrity": "sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3233,7 +3233,7 @@
         "node": ">=18"
       },
       "peerDependencies": {
-        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0"
       }
     },
     "node_modules/eslint-plugin-react-refresh": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@base-ui/react": "^1.3.0",
-        "@fontsource-variable/geist": "^5.2.8",
+        "@fontsource-variable/geist": "^5.3.0",
         "@hookform/resolvers": "^5.9.1",
         "axios": "^1.19.0",
         "class-variance-authority": "^0.7.1",
@@ -26,7 +26,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.4",
-        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/jest-dom": "^7.0.1",
         "@testing-library/react": "^16.3.2",
         "@types/node": "^26.2.0",
         "@types/react": "^19.2.18",
@@ -36,7 +36,7 @@
         "eslint": "^9.39.4",
         "eslint-plugin-react-hooks": "^7.1.1",
         "eslint-plugin-react-refresh": "^0.5.2",
-        "globals": "^17.4.0",
+        "globals": "^17.11.0",
         "jsdom": "^25.0.1",
         "postcss": "^8.5.8",
         "tailwindcss": "^3.4.19",
@@ -1224,9 +1224,9 @@
       "license": "MIT"
     },
     "node_modules/@fontsource-variable/geist": {
-      "version": "5.2.8",
-      "resolved": "https://registry.npmjs.org/@fontsource-variable/geist/-/geist-5.2.8.tgz",
-      "integrity": "sha512-cJ6m9e+8MQ5dCYJsLylfZrgBh6KkG4bOLckB35Tr9J/EqdkEM6QllH5PxqP1dhTvFup+HtMRPuz9xOjxXJggxw==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/geist/-/geist-5.3.0.tgz",
+      "integrity": "sha512-j0m+vLQuG5XAYoHtGCVu0spvlGreR3EzpECUVzkFmI1mTVnAO38l/NEPDCFgZ177JxzYJCLSmTQibIiYPilGrA==",
       "license": "OFL-1.1",
       "funding": {
         "url": "https://github.com/sponsors/ayuhito"
@@ -1849,9 +1849,9 @@
       }
     },
     "node_modules/@testing-library/jest-dom": {
-      "version": "6.9.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
-      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-7.0.1.tgz",
+      "integrity": "sha512-oMDTC3oA+6CXSO2JZnvOI7CA6oVub6kij5ggk9ohwye5slmkwxYDXcPOVxgMw/RQlticjtO0C1RZkR97HgrWMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1863,9 +1863,18 @@
         "redent": "^3.0.0"
       },
       "engines": {
-        "node": ">=14",
+        "node": ">=22",
         "npm": ">=6",
         "yarn": ">=1"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=10 <11",
+        "vitest": ">= 0.32"
+      },
+      "peerDependenciesMeta": {
+        "vitest": {
+          "optional": true
+        }
       }
     },
     "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
@@ -3686,9 +3695,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "17.4.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-17.4.0.tgz",
-      "integrity": "sha512-hjrNztw/VajQwOLsMNT1cbJiH2muO3OROCHnbehc8eY5JyD2gqz4AcMHPqgaOR59DjgUjYAYLeH699g/eWi2jw==",
+      "version": "17.11.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.11.0.tgz",
+      "integrity": "sha512-Z2I8hM+PbJDXQDq3Icgpzv+mPdwr68iZUU9d5WW4FuXfDUQfkZaZuvjMv42/5crNyw154+9+VWXbYrUgDXbxNw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -37,7 +37,7 @@
     "@vitejs/plugin-react": "^6.0.1",
     "autoprefixer": "^10.4.27",
     "eslint": "^9.39.4",
-    "eslint-plugin-react-hooks": "^7.0.1",
+    "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-react-refresh": "^0.5.2",
     "globals": "^17.4.0",
     "jsdom": "^25.0.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@base-ui/react": "^1.3.0",
-    "@fontsource-variable/geist": "^5.2.8",
+    "@fontsource-variable/geist": "^5.3.0",
     "@hookform/resolvers": "^5.9.1",
     "axios": "^1.19.0",
     "class-variance-authority": "^0.7.1",
@@ -29,7 +29,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",
-    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/jest-dom": "^7.0.1",
     "@testing-library/react": "^16.3.2",
     "@types/node": "^26.2.0",
     "@types/react": "^19.2.18",
@@ -39,7 +39,7 @@
     "eslint": "^9.39.4",
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-react-refresh": "^0.5.2",
-    "globals": "^17.4.0",
+    "globals": "^17.11.0",
     "jsdom": "^25.0.1",
     "postcss": "^8.5.8",
     "tailwindcss": "^3.4.19",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -29,15 +29,17 @@ function RootRoute() {
 
 export default function App() {
   const token = useAuthStore((s) => s.token);
-  const [booting, setBooting] = useState(true);
+  // Sem token não há o que validar, então já nasce liberado. Antes isto era
+  // `useState(true)` mais um `setBooting(false)` dentro do efeito, o que
+  // gastava uma renderização extra em TODA visita anônima só para desfazer um
+  // estado que nunca precisou existir. A regra
+  // `react-hooks/set-state-in-effect` apontou isto, e estava certa.
+  const [booting, setBooting] = useState(() => Boolean(token));
 
   // No boot: se há token persistido, valida no backend antes de liberar as rotas.
   // Token expirado/inválido -> logout, evitando o "flash" de tela protegida.
   useEffect(() => {
-    if (!token) {
-      setBooting(false);
-      return;
-    }
+    if (!token) return;
     authApi
       .me()
       .then((res) => useAuthStore.getState().updateUser(res.data))

--- a/frontend/src/pages/Transactions.jsx
+++ b/frontend/src/pages/Transactions.jsx
@@ -105,6 +105,10 @@ export default function Transactions() {
     walletsApi.list().then((r) => {
       setWallets(r.data);
     });
+    // Falso positivo: `load` só chama setState DEPOIS do await. Buscar no
+    // mount é o padrão do React sem biblioteca de data fetching, e este
+    // projeto não tem uma.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     load();
   }, []);
 
@@ -122,6 +126,11 @@ export default function Transactions() {
   useEffect(() => {
     const preset = location.state?.newType;
     if (preset !== "INCOME" && preset !== "EXPENSE") return;
+    // Aqui a regra está tecnicamente certa: são setStates síncronos e custam
+    // uma renderização a mais. Fica assim porque a fonte do dado é EXTERNA (o
+    // state da rota), que é justamente o que efeito existe para sincronizar, e
+    // roda uma vez só, no mount, antes de o dialog abrir.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setEditing(null);
     setServerError(null);
     reset({ ...emptyForm(), type: preset, category: categoriesFor(preset)[0] });
@@ -259,6 +268,11 @@ export default function Transactions() {
               </DialogTitle>
             </DialogHeader>
 
+            {/* eslint-disable-next-line react-hooks/refs -- falso positivo
+                contra o react-hook-form: `handleSubmit(onSubmit)` devolve um
+                handler, e os refs internos só são lidos quando ele é chamado
+                no submit, nunca durante a renderização. É o uso documentado
+                da biblioteca. */}
             <form onSubmit={handleSubmit(onSubmit)} className="space-y-3 mt-2">
               {/* Tipo */}
               <Field label="Tipo" error={errors.type?.message}>

--- a/frontend/src/pages/Wallets.jsx
+++ b/frontend/src/pages/Wallets.jsx
@@ -39,6 +39,10 @@ export default function Wallets() {
   }
 
   useEffect(() => {
+    // Falso positivo: `load` só chama setState DEPOIS do await, então nada
+    // é síncrono aqui. Buscar dados no mount é o padrão do React quando não
+    // há biblioteca de data fetching, e este projeto não tem uma.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     load();
   }, []);
 


### PR DESCRIPTION
Clears the Dependabot backlog. Two commits, and one dependency deliberately left out with a reason.

## Backend pins, applied properly

Dependabot opens these against `requirements.txt` only, while the Dockerfile installs from the lock — so its PRs are structurally inert here, and the lock guard from #62 fails them by design. Done properly instead: pins bumped, **both** locks regenerated, suite run against the result.

- `sqlalchemy` 2.0.36 → 2.0.52
- `pytest` 8.3.3 → 9.1.1 and `pytest-asyncio` 0.24.0 → 1.4.0, which have to move together; the existing `pytest.ini` already sets `asyncio_mode` and the default fixture loop scope, which is what the 1.x line requires

The guard also caught me mid-work: I regenerated only one of the two locks and it refused, naming the exact mismatch. That is the hole I closed by mutation back when the guard was written, doing its job.

## bcrypt 5 is not here, and it is not a judgement call

It does **not** merely warn — it breaks the app at import:

```
AttributeError: module 'bcrypt' has no attribute '__about__'
ValueError: password cannot be longer than 72 bytes
```

`passlib` 1.7.4 probes the bcrypt backend with a password over 72 bytes to detect an old wraparound bug. bcrypt 5 raises instead of truncating, so `_DUMMY_HASH` at module level fails and **the process never boots**. Merging #67 would take production down completely, not degrade it.

The real cause is that passlib has been unmaintained since 2020 and stands between us and bcrypt. It also imports `crypt`, removed in Python 3.13, so the same wall is in the way of the next Python upgrade. Written up as its own issue.

## The tests no longer depend on the developer's .env

Turning `PAYWALL_ENABLED` on locally to test the subscription flow left five tests red that looked like regressions and were not — including the four named `test_with_the_flag_off_*`, which assert exactly what the environment was contradicting.

An autouse fixture now pins the flag to the production default. Files that need it on still set it afterwards, since autouse runs first in the same scope. Verified by running the paywall files green **with the flag still on** in `.env`.

## Frontend: eslint-plugin-react-hooks 7.1.1

Dependabot's #84 fails CI, and not because of the dependency: the new version ships rules that flag five places in our code. I checked each rather than trusting or dismissing the tool.

**One was real.** `App.jsx` started `booting` at `true` and immediately set it to `false` in an effect whenever there was no token — an extra render on every anonymous visit, to undo a state that never needed to exist. The initial value now derives from the token.

**Two are false positives**, and provably so: `Wallets` and `Transactions` call `load()` on mount, and `load()` only touches state *after* its `await`. Nothing is synchronous there.

**One is a false positive against react-hook-form**: `handleSubmit(onSubmit)` returns a handler and reads its internal refs at submit time, never during render.

**One is technically right and stays anyway**: the route-preset effect in `Transactions` does set state synchronously, but its source is external (router state), which is what effects are for, and it runs once on mount.

Each exception is justified at the site instead of loosening the rule, so it still guards new code.

A detail worth knowing: `eslint-disable-next-line` applies to the line immediately after it, so the explanation has to come *before* the directive. Written the other way it silently does nothing, which is how I first wrote it.

## Verification

275 backend tests. 146 frontend tests, lint clean, build green.

## Left open on purpose

- **#67** (bcrypt 5) — blocked until passlib is replaced; see the issue.
- **#82** (`@eslint/js` 10) — a peer conflict, not a code problem: it requires eslint 10 while the project is on eslint 9. Dependabot proposed an incomplete set again. Bumping eslint to 10 is a major with flat-config changes and deserves its own ticket rather than riding along here.
