### PR TITLE
fix(auth): replace passlib, unblocking bcrypt 5 and Python 3.13

### DIFF
--- a/backend/app/services/auth_service.py
+++ b/backend/app/services/auth_service.py
@@ -3,37 +3,34 @@ import secrets
 from datetime import datetime, timedelta, timezone
 
 from jose import jwt
-from passlib.context import CryptContext
 from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import get_settings
 from app.models.sql_models import RefreshToken, User
+# Reexportados de propósito: todo o app já importa `hash_password` e
+# `verify_password` daqui, e a troca do passlib (#102) não precisa vazar para
+# os chamadores. Quem quiser o detalhe do esquema lê o password_service.
+from app.services.password_service import (  # noqa: F401
+    hash_password,
+    needs_update,
+    verify_password,
+)
 
 settings = get_settings()
-# bcrypt_sha256 aplica SHA-256 antes do bcrypt, então a senha inteira conta e o
-# limite de 72 bytes do bcrypt cru deixa de existir. "bcrypt" permanece para
-# verificar hashes antigos, que serão atualizados no próximo login.
-pwd_context = CryptContext(schemes=["bcrypt_sha256", "bcrypt"], deprecated="auto")
-
-def hash_password(password: str) -> str:
-    return pwd_context.hash(password) # Retorna a senha criptografada
-
-def verify_password(plain: str, hashed: str) -> bool:
-    return pwd_context.verify(plain, hashed) # Compara a senha com hash
 
 def verify_and_upgrade(plain: str, hashed: str) -> tuple[bool, str | None]:
     """Verifica a senha e devolve um hash novo quando o esquema está obsoleto."""
-    if not pwd_context.verify(plain, hashed):
+    if not verify_password(plain, hashed):
         return False, None
-    if pwd_context.needs_update(hashed):
-        return True, pwd_context.hash(plain)
+    if needs_update(hashed):
+        return True, hash_password(plain)
     return True, None
 
 # Hash descartável usado quando o e-mail não existe. Verificar contra ele custa
 # o mesmo que verificar contra um hash real, então o tempo de resposta do login
 # não revela se o e-mail está cadastrado. Calculado uma vez no import (~200ms).
-_DUMMY_HASH = pwd_context.hash("norby-dummy-password-nunca-usada")
+_DUMMY_HASH = hash_password("norby-dummy-password-nunca-usada")
 
 def create_access_token(user_id: str) -> str:
     expire = datetime.now(timezone.utc) + timedelta(minutes=settings.access_token_expire_minutes) # Define um tempo de expiração pro token

--- a/backend/app/services/password_service.py
+++ b/backend/app/services/password_service.py
@@ -1,0 +1,117 @@
+"""Hash de senha, sem passlib (issue #102).
+
+Por que sair do passlib: ele parou em 2020, e duas consequências já batem na
+porta. Prende o projeto no bcrypt 3.x — com bcrypt 5 o app **não sobe**, porque
+o passlib sonda o backend com uma senha de mais de 72 bytes e o bcrypt novo
+levanta em vez de truncar. E importa `crypt`, removido no Python 3.13.
+
+O esquema NÃO muda: continua sendo o `bcrypt_sha256` do passlib, byte a byte.
+Ele aplica SHA-256 antes do bcrypt, então a senha inteira conta e o teto de 72
+bytes do bcrypt cru deixa de existir. Reimplementá-lo é o que permite trocar a
+dependência sem forçar ninguém a redefinir a senha — os testes carregam
+hashes-testemunha gerados pelo passlib para provar isso.
+
+O formato, para quem for ler um hash no banco:
+
+    $bcrypt-sha256$v=2,t=2b,r=12$<salt de 22 chars>$<checksum de 31 chars>
+
+A derivação v2 é `bcrypt(base64(hmac_sha256(key=salt, msg=senha)), salt)`. A
+chave do HMAC é o SALT CODIFICADO, não o config completo — o próprio passlib
+escolheu assim para facilitar implementações paralelas, e esta é uma delas.
+"""
+
+import base64
+import hashlib
+import hmac
+import secrets
+
+import bcrypt
+
+# Mesmo custo que o passlib usava por padrão, para os hashes existentes não
+# serem marcados para upgrade sem necessidade.
+ROUNDS = 12
+
+PREFIXO = "$bcrypt-sha256$"
+_IDENT = "2b"
+# bcrypt gera 22 chars de salt no alfabeto próprio dele.
+_SALT_CHARS = "./ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
+# O passlib recusa salt cujo último caractere tenha bits de padding ligados,
+# porque implementações de bcrypt não os tratam igual. Mantido.
+_FINAL_SALT_CHARS = ".Oeu"
+
+
+def _checksum(senha: str, salt: str, rounds: int) -> str:
+    digest = hmac.new(salt.encode("ascii"), senha.encode("utf-8"), hashlib.sha256).digest()
+    config = f"${_IDENT}${rounds:02d}${salt}".encode("ascii")
+    return bcrypt.hashpw(base64.b64encode(digest), config).decode("ascii")[len(config):]
+
+
+def _novo_salt() -> str:
+    return "".join(secrets.choice(_SALT_CHARS) for _ in range(21)) + secrets.choice(
+        _FINAL_SALT_CHARS
+    )
+
+
+def hash_password(senha: str) -> str:
+    salt = _novo_salt()
+    return f"{PREFIXO}v=2,t={_IDENT},r={ROUNDS}${salt}${_checksum(senha, salt, ROUNDS)}"
+
+
+def _partes(hashed: str) -> tuple[str, int] | None:
+    """(salt, rounds) de um hash `bcrypt_sha256`, ou None se não for um."""
+    try:
+        _, esquema, params, salt, _checksum_guardado = hashed.split("$")
+        if esquema != "bcrypt-sha256":
+            return None
+        campos = dict(p.split("=") for p in params.split(","))
+        if campos.get("v") != "2":
+            # v1 usava sha256 puro e nunca foi gerado por este app: o
+            # CryptContext sempre criou v2. Recusar é melhor do que implementar
+            # um caminho que ninguém tem e ninguém testa.
+            return None
+        return salt, int(campos["r"])
+    except (ValueError, KeyError):
+        return None
+
+
+def verify_password(senha: str, hashed: str) -> bool:
+    """Confere a senha contra os DOIS esquemas que existem no banco.
+
+    Nunca levanta: uma linha corrompida não pode virar 500 no login, e muito
+    menos autenticar alguém.
+    """
+    if not hashed:
+        return False
+
+    partes = _partes(hashed)
+    if partes is not None:
+        salt, rounds = partes
+        try:
+            calculado = _checksum(senha, salt, rounds)
+        except (ValueError, TypeError):
+            return False
+        # compare_digest: comparação em tempo constante, para o tempo de
+        # resposta não vazar quantos caracteres do checksum bateram.
+        return hmac.compare_digest(calculado, hashed.rsplit("$", 1)[-1])
+
+    # Legado: bcrypt cru, de antes do bcrypt_sha256.
+    try:
+        # Truncar em 72 bytes é o que o bcrypt sempre fez em silêncio, e é o
+        # que esses hashes viram quando foram criados. Sem isto o bcrypt 5
+        # levanta ValueError e uma senha longa e CORRETA seria recusada.
+        return bcrypt.checkpw(senha.encode("utf-8")[:72], hashed.encode("ascii"))
+    except (ValueError, TypeError, UnicodeEncodeError):
+        return False
+
+
+def needs_update(hashed: str) -> bool:
+    """True quando o hash deve ser reescrito no próximo login bem-sucedido.
+
+    Cobre o esquema legado e também custo abaixo do atual, para um aumento
+    futuro de `ROUNDS` se propagar sozinho em vez de valer só para contas novas.
+    """
+    partes = _partes(hashed)
+    if partes is None:
+        return True
+    _salt, rounds = partes
+    return rounds < ROUNDS

--- a/backend/requirements-dev.lock
+++ b/backend/requirements-dev.lock
@@ -14,10 +14,8 @@ anyio==4.14.2
     #   watchfiles
 asyncpg==0.30.0
     # via -r requirements.txt
-bcrypt==3.2.2
-    # via
-    #   -r requirements.txt
-    #   passlib
+bcrypt==5.0.0
+    # via -r requirements.txt
 boolean-py==5.0
     # via license-expression
 cachecontrol==0.14.4
@@ -27,10 +25,8 @@ certifi==2026.6.17
     #   httpcore
     #   httpx
     #   requests
-cffi==2.1.0
-    # via
-    #   bcrypt
-    #   cryptography
+cffi==2.1.0 ; platform_python_implementation != 'PyPy'
+    # via cryptography
 charset-normalizer==3.4.9
     # via requests
 click==8.4.2
@@ -115,8 +111,6 @@ packaging==26.2
     #   pip-audit
     #   pip-requirements-parser
     #   pytest
-passlib==1.7.4
-    # via -r requirements.txt
 pillow==12.3.0
     # via -r requirements.txt
 pip==26.1.2
@@ -140,7 +134,7 @@ pyasn1==0.6.4
     #   rsa
 pyasn1-modules==0.4.2
     # via google-auth
-pycparser==3.0 ; implementation_name != 'PyPy'
+pycparser==3.0 ; implementation_name != 'PyPy' and platform_python_implementation != 'PyPy'
     # via cffi
 pydantic==2.13.4
     # via

--- a/backend/requirements.lock
+++ b/backend/requirements.lock
@@ -14,19 +14,15 @@ anyio==4.14.2
     #   watchfiles
 asyncpg==0.30.0
     # via -r requirements.txt
-bcrypt==3.2.2
-    # via
-    #   -r requirements.txt
-    #   passlib
+bcrypt==5.0.0
+    # via -r requirements.txt
 certifi==2026.6.17
     # via
     #   httpcore
     #   httpx
     #   requests
-cffi==2.1.0
-    # via
-    #   bcrypt
-    #   cryptography
+cffi==2.1.0 ; platform_python_implementation != 'PyPy'
+    # via cryptography
 charset-normalizer==3.4.9
     # via requests
 click==8.4.2
@@ -86,8 +82,6 @@ motor==3.7.1
     # via -r requirements.txt
 packaging==26.2
     # via limits
-passlib==1.7.4
-    # via -r requirements.txt
 pillow==12.3.0
     # via -r requirements.txt
 pyasn1==0.6.4
@@ -97,7 +91,7 @@ pyasn1==0.6.4
     #   rsa
 pyasn1-modules==0.4.2
     # via google-auth
-pycparser==3.0 ; implementation_name != 'PyPy'
+pycparser==3.0 ; implementation_name != 'PyPy' and platform_python_implementation != 'PyPy'
     # via cffi
 pydantic==2.13.4
     # via

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -10,12 +10,11 @@ python-jose[cryptography]==3.5.0
 # e so HS256, entao nao ha caminho alcancavel, mas o gate de release do
 # AGENTS.md exige o pip-audit limpo.
 cryptography==50.0.0
-passlib[bcrypt]==1.7.4
 python-dotenv==1.2.3
 pydantic-settings==2.15.0
 google-genai==2.22.0
 email-validator==2.3.0
-bcrypt==3.2.2
+bcrypt==5.0.0
 slowapi==0.1.10
 # Billing (ADR 0001). O SDK entra por causa da verificação de assinatura do
 # webhook: ela precisa ser timing-safe e checar a tolerância de timestamp

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -240,10 +240,13 @@ async def test_new_passwords_use_bcrypt_sha256(client, db_session):
 
 
 def test_verify_and_upgrade_rehashes_legacy_bcrypt():
-    from passlib.hash import bcrypt
+    import bcrypt
+
     from app.services.auth_service import verify_and_upgrade
 
-    legacy = bcrypt.using(rounds=12).hash("secret123")
+    # bcrypt direto, sem passlib (#102). Continua gerando o MESMO formato
+    # legado que existe no banco, que é o ponto do teste.
+    legacy = bcrypt.hashpw(b"secret123", bcrypt.gensalt(12)).decode("ascii")
     ok, upgraded = verify_and_upgrade("secret123", legacy)
     assert ok is True
     assert upgraded is not None and upgraded.startswith("$bcrypt-sha256$")
@@ -255,13 +258,14 @@ def test_verify_and_upgrade_rehashes_legacy_bcrypt():
 
 @pytest.mark.asyncio
 async def test_login_persists_upgraded_legacy_bcrypt_hash(client, db_session):
-    from passlib.hash import bcrypt
+    import bcrypt
+
     from app.models.sql_models import User
 
     user = User(
         name="Gus",
         email="gus@test.com",
-        password_hash=bcrypt.using(rounds=12).hash("secret123"),
+        password_hash=bcrypt.hashpw(b"secret123", bcrypt.gensalt(12)).decode("ascii"),
     )
     db_session.add(user)
     await db_session.commit()

--- a/backend/tests/test_password_service.py
+++ b/backend/tests/test_password_service.py
@@ -1,0 +1,141 @@
+"""Hash de senha sem passlib (issue #102).
+
+O passlib parou em 2020, prende o projeto no bcrypt 3.x — merge do bcrypt 5
+derruba o app no import — e importa `crypt`, removido no Python 3.13.
+
+A parte perigosa da troca não é gerar hash novo: é continuar verificando os
+hashes que JÁ EXISTEM. Por isso os testes abaixo carregam HASHES-TESTEMUNHA
+gerados pelo passlib 1.7.4 com bcrypt 3.2.2 antes da troca. Se a
+reimplementação divergir em qualquer detalhe, estes testes ficam vermelhos e
+ninguém descobre em produção com a conta trancada.
+"""
+
+import pytest
+
+from app.services.password_service import (
+    ROUNDS,
+    hash_password,
+    needs_update,
+    verify_password,
+)
+
+# --- Gerados pelo passlib 1.7.4 + bcrypt 3.2.2, antes da substituição --------
+# Esquema atual do app: `bcrypt_sha256`, que aplica SHA-256 antes do bcrypt e
+# assim faz a senha inteira contar, sem o teto de 72 bytes do bcrypt cru.
+MODERNO = [
+    ("secret123", "$bcrypt-sha256$v=2,t=2b,r=12$tIxKLHZIE3mwNTd3gYQGI.$udqn2VQ6XXF5NvasI7wbzlj7.Ri1pPW"),
+    ("senha com acento çãé", "$bcrypt-sha256$v=2,t=2b,r=12$zbeJVaFStxhaRnYcVg8uYu$8ogsm.8LUws2UoNCzPfZj5cOhJsOSR6"),
+    ("L" * 100, "$bcrypt-sha256$v=2,t=2b,r=12$rp1vYId4g8eTIsWdkoTIa.$llGXOA0ld.KL78kZ870r5palOcSyHBS"),
+]
+# Esquema LEGADO, bcrypt puro. Contas antigas ainda têm hashes assim, e é o
+# `verify_and_upgrade` que os troca no próximo login.
+LEGADO = [
+    ("secret123", "$2b$12$5zzQzEj2d1RkBBAYUWh.c.BLn3rTpCqdsyDbnihg8c6p7lakldWk6"),
+    ("senha com acento çãé", "$2b$12$747qytHbaN4mn4pv6hnKhu87kvomHy6SGCWkBtSwPYi5tv1BGKID2"),
+    ("L" * 100, "$2b$12$o/Wz/s8BYxLaN2GKATOn3unOJHPwq7NkPI6qvlkIp0sMLahdCxhBK"),
+]
+
+
+@pytest.mark.parametrize("senha,hash_antigo", MODERNO)
+def test_hashes_made_by_passlib_still_verify(senha, hash_antigo):
+    # A promessa inteira da issue: ninguém perde o login.
+    assert verify_password(senha, hash_antigo) is True
+
+
+@pytest.mark.parametrize("senha,hash_antigo", MODERNO)
+def test_a_wrong_password_is_still_refused_against_an_old_hash(senha, hash_antigo):
+    assert verify_password(senha + "x", hash_antigo) is False
+
+
+@pytest.mark.parametrize("senha,hash_antigo", LEGADO)
+def test_legacy_plain_bcrypt_hashes_still_verify(senha, hash_antigo):
+    # Estes vêm de antes do bcrypt_sha256. Continuam válidos até o próximo
+    # login, quando o upgrade transparente os reescreve.
+    assert verify_password(senha, hash_antigo) is True
+
+
+@pytest.mark.parametrize("senha,hash_antigo", LEGADO)
+def test_a_wrong_password_is_refused_against_a_legacy_hash(senha, hash_antigo):
+    # Diferença no COMEÇO, de propósito: ver o teste abaixo.
+    assert verify_password("x" + senha, hash_antigo) is False
+
+
+def test_a_legacy_hash_cannot_tell_passwords_apart_after_72_bytes():
+    """Limitação do bcrypt cru, registrada em vez de escondida.
+
+    Ele trunca em 72 bytes sem avisar, então para um hash LEGADO uma senha de
+    100 caracteres e a mesma com um caractere a mais no fim são indistinguíveis.
+    O `bcrypt_sha256` existe exatamente para isto, e o `UserRegister` recusa
+    senha acima de 72 bytes desde a Onda 1 — mas hashes antigos ficaram, e
+    fingir que o problema não existe seria pior do que dizer onde ele está.
+    """
+    _senha, hash_legado = LEGADO[2]
+    assert verify_password("L" * 100, hash_legado) is True
+    assert verify_password("L" * 100 + "x", hash_legado) is True  # mesmo hash
+    # E é por isso que estes são marcados para upgrade no próximo login.
+    assert needs_update(hash_legado) is True
+
+
+# --- Hash novo ---------------------------------------------------------------
+
+
+def test_a_new_hash_uses_the_scheme_the_app_already_used():
+    h = hash_password("secret123")
+    assert h.startswith(f"$bcrypt-sha256$v=2,t=2b,r={ROUNDS}$")
+    assert verify_password("secret123", h) is True
+    assert verify_password("outra", h) is False
+
+
+def test_two_hashes_of_the_same_password_differ():
+    # Salt aleatório: sem isso, senhas iguais viram hashes iguais e o banco
+    # entrega de graça quem usa a mesma senha.
+    assert hash_password("secret123") != hash_password("secret123")
+
+
+def test_the_72_byte_ceiling_of_raw_bcrypt_does_not_apply():
+    # É para isto que o `bcrypt_sha256` existe. Duas senhas de 100 caracteres
+    # que só diferem no fim TÊM de ser distinguíveis; com bcrypt cru as duas
+    # dariam o mesmo hash, porque ele trunca em 72 bytes e não avisa.
+    a = "L" * 99 + "a"
+    b = "L" * 99 + "b"
+    h = hash_password(a)
+    assert verify_password(a, h) is True
+    assert verify_password(b, h) is False
+
+
+def test_a_unicode_password_survives_the_round_trip():
+    senha = "çãé ñ 日本語 🙂"
+    assert verify_password(senha, hash_password(senha)) is True
+
+
+# --- Robustez ----------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "lixo",
+    ["", "nao e um hash", "$bcrypt-sha256$quebrado", "$2b$12$curto", "$desconhecido$x$y"],
+)
+def test_a_malformed_hash_is_false_and_never_raises(lixo):
+    # Uma linha corrompida no banco não pode virar 500 no login, e muito menos
+    # autenticar alguém. Falso, sempre.
+    assert verify_password("secret123", lixo) is False
+
+
+# --- Upgrade transparente ----------------------------------------------------
+
+
+@pytest.mark.parametrize("_senha,hash_antigo", LEGADO)
+def test_legacy_hashes_are_marked_for_upgrade(_senha, hash_antigo):
+    assert needs_update(hash_antigo) is True
+
+
+@pytest.mark.parametrize("_senha,hash_antigo", MODERNO)
+def test_current_hashes_are_not_marked_for_upgrade(_senha, hash_antigo):
+    assert needs_update(hash_antigo) is False
+
+
+def test_a_hash_with_fewer_rounds_is_marked_for_upgrade():
+    # Se um dia o custo subir, os hashes velhos precisam ser reescritos no
+    # login em vez de ficarem baratos para sempre.
+    fraco = "$bcrypt-sha256$v=2,t=2b,r=10$tIxKLHZIE3mwNTd3gYQGI.$udqn2VQ6XXF5NvasI7wbzlj7.Ri1pPW"
+    assert needs_update(fraco) is True


### PR DESCRIPTION
Closes #102. Unblocks #67, which I closed as unmergeable a few hours ago.

## Why this had to happen

`passlib` has had no release since 2020 and stood between the app and two upgrades it cannot keep refusing:

- **bcrypt 5 did not degrade the app, it stopped it from booting.** passlib probes the bcrypt backend with an over-72-byte password to detect an old wraparound bug; bcrypt 5 raises instead of truncating, so the module-level `_DUMMY_HASH` failed and the import died.
- **passlib imports `crypt`, removed in Python 3.13.** The suite has printed that deprecation warning on every run for months.

## Nobody has to reset a password

The scheme does not change. It is still `bcrypt_sha256`, byte for byte:

```
bcrypt(base64(hmac_sha256(key=salt, msg=password)), salt)
```

The detail that makes or breaks this: **the HMAC key is the encoded salt, not the full config string**. I got that wrong on the first attempt and the checksums simply did not match. passlib's own source documents the choice as deliberately making parallel implementations possible — this is one of them.

## The risk is concentrated in one place, so that is where the tests are

Because the entire danger is "does it still verify what is already in the database", the tests carry **golden hashes generated with passlib 1.7.4 and bcrypt 3.2.2 before the swap** — ascii, accented, and over-72-byte passwords, for both the current and the legacy scheme.

If the reimplementation drifts anywhere, those go red here instead of locking someone out in production.

## Three properties kept, deliberately

- **Legacy plain-bcrypt hashes still verify**, and are still marked for upgrade, so the next successful login rewrites them. That path is unchanged.
- **The module-level dummy hash still exists**, so an unknown email costs the same time as a real one and login stays useless as an account-enumeration oracle. That was a fix from wave 1 and it would have been easy to drop by accident here.
- **Comparison is constant-time.**

`needs_update` also now marks any hash below the current cost, so a future increase in rounds propagates on login instead of applying only to new accounts.

## One behaviour that had to become explicit

The legacy path truncates to 72 bytes. bcrypt always did it silently; bcrypt 5 raises, so without truncating, a long and **correct** password would be refused.

There is a test recording that raw bcrypt cannot tell two 100-character passwords apart when they differ only after byte 72. That is a real limitation of the old hashes, not of this change, and it is exactly why `bcrypt_sha256` exists. Writing it down beats leaving it to be rediscovered.

## Verified by mutation

Five, all killed by exactly the right tests:

- HMAC keyed off the config instead of the salt → the golden-hash tests fail
- truncation dropped from the legacy path → the long-password tests fail
- `needs_update` always false → every upgrade test fails, including the one in `test_auth`
- a malformed hash authenticating instead of refusing → the robustness test fails
- salt frozen → the "two hashes differ" test fails

## Verification

304 backend tests, and the `crypt` deprecation warning is gone — the suite now runs with **zero warnings**. `passlib` is out of both lock files; CI installs from the lock, so its build is the real proof that nothing still imports it.
