### PR TITLE
fix(db): close the alembic drift and guard it in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,22 @@ jobs:
       - name: Install dependencies
         run: pip install -r requirements-dev.lock
 
+      # The test database is built by `Base.metadata.create_all`, so the suite
+      # only ever sees the models and is blind by construction to a migration
+      # that has drifted from them. `alembic check` is the only thing that
+      # compares the two, and without it here three consecutive migrations had
+      # to hand-strip phantom operations out of their autogenerate output.
+      # Building from an empty database also proves the chain itself still runs
+      # end to end, which `alembic check` alone would not.
+      - name: Migrations match the models
+        env:
+          DATABASE_URL: postgresql+asyncpg://norby_user:norby_pass@localhost:5432/norby_migrations
+          PGPASSWORD: norby_pass
+        run: |
+          psql -h localhost -U norby_user -d postgres -c 'CREATE DATABASE norby_migrations'
+          alembic upgrade head
+          alembic check
+
       - name: Run tests
         run: pytest
 

--- a/backend/alembic/versions/d02a76d9af21_drop_the_redundant_token_hash_index.py
+++ b/backend/alembic/versions/d02a76d9af21_drop_the_redundant_token_hash_index.py
@@ -1,0 +1,54 @@
+"""drop the redundant token_hash index
+
+Revision ID: d02a76d9af21
+Revises: a1f4c9d2e7b3
+Create Date: 2026-09-05 13:31:03.798757
+
+Fecha o drift que as migrations 1c1a72a15b9e, 764bc1132df0 e 154dd832e2d8
+recusaram, cada uma corretamente, por estar fora do escopo delas. Aqui ele É o
+escopo, e ficar sem essa migration custa caro: todo autogenerate futuro volta a
+emitir estas operações e alguém precisa apagá-las à mão de novo.
+
+O que o banco tinha em `refresh_tokens.token_hash`:
+
+    ix_refresh_tokens_token_hash        btree (token_hash)
+    refresh_tokens_token_hash_key       UNIQUE CONSTRAINT, btree (token_hash)
+
+DOIS B-trees na mesma coluna. A migration c4d5e6f7a8b9 criou os dois porque o
+modelo declara `unique=True, index=True`, e o autogenerate da época emitiu a
+constraint e o índice separadamente em vez do índice único que essa combinação
+significa no SQLAlchemy. O índice não-único nunca serviu para nada: qualquer
+consulta que ele atenderia já é atendida pelo índice da constraint.
+
+`refresh_tokens` recebe INSERT em todo login E em toda rotação de refresh, então
+o índice sobrando é escrita desperdiçada no caminho mais quente da autenticação.
+
+SEM PERDA DE DADOS. As três operações rodam na mesma transação, e DDL em
+Postgres pega ACCESS EXCLUSIVE na tabela até o commit — nenhuma outra sessão
+consegue inserir enquanto a unicidade está momentaneamente sem quem a imponha.
+Nenhum código referencia o nome `refresh_tokens_token_hash_key` (conferido), e
+o downgrade recria o estado anterior exatamente, os dois índices inclusive.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'd02a76d9af21'
+down_revision: Union[str, None] = 'a1f4c9d2e7b3'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.drop_constraint(op.f('refresh_tokens_token_hash_key'), 'refresh_tokens', type_='unique')
+    op.drop_index(op.f('ix_refresh_tokens_token_hash'), table_name='refresh_tokens')
+    op.create_index(op.f('ix_refresh_tokens_token_hash'), 'refresh_tokens', ['token_hash'], unique=True)
+
+
+def downgrade() -> None:
+    op.drop_index(op.f('ix_refresh_tokens_token_hash'), table_name='refresh_tokens')
+    op.create_index(op.f('ix_refresh_tokens_token_hash'), 'refresh_tokens', ['token_hash'], unique=False)
+    op.create_unique_constraint(op.f('refresh_tokens_token_hash_key'), 'refresh_tokens', ['token_hash'], postgresql_nulls_not_distinct=False)

--- a/backend/app/models/sql_models.py
+++ b/backend/app/models/sql_models.py
@@ -213,7 +213,13 @@ class RecurringTransaction(Base):
     day_of_month: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
     weekday: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
     next_run_date: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
-    active: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
+    # `server_default` além do `default`: o banco tem DEFAULT true desde a
+    # criação da tabela, e sem declarar isso aqui o autogenerate propõe derrubá-lo
+    # em toda migration nova. Derrubar quebraria qualquer INSERT que omita a
+    # coluna, então quem estava certo era o banco.
+    active: Mapped[bool] = mapped_column(
+        Boolean, default=True, server_default=text("true"), nullable=False
+    )
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utcnow)
 
     user: Mapped["User"] = relationship("User", back_populates="recurring_transactions")


### PR DESCRIPTION
`alembic check` has been failing for months. Three consecutive migrations — `1c1a72a15b9e`, `764bc1132df0` and `154dd832e2d8` — each opened with a note explaining which phantom operations they had deleted from their autogenerate output by hand, and each was right to refuse them: the drift was outside their scope. Nobody ever wrote the migration whose scope it *is*. This is that one.

## Two items, and they need opposite fixes

**`recurring_transactions.active`** — the database has `DEFAULT true`, the model does not declare it, so autogenerate wanted to drop it. Dropping it would break any INSERT that omits the column, which is why every migration refused. The database was the one that was right, so the model changes, not the schema. **Zero DDL.** `Wallet.archived` on line 86 already does exactly this, so this is the file's own existing pattern.

**`refresh_tokens.token_hash`** — here the database really is wrong. `psql` before:

```
"ix_refresh_tokens_token_hash"   btree (token_hash)
"refresh_tokens_token_hash_key"  UNIQUE CONSTRAINT, btree (token_hash)
```

Two B-trees on one column. The model says `unique=True, index=True`, which SQLAlchemy means as *one unique index*; migration `c4d5e6f7a8b9` emitted the constraint and a separate non-unique index instead. The non-unique one has never been able to serve a query the constraint's own index does not already serve.

`refresh_tokens` takes an INSERT on every login **and** every token rotation, so that index is wasted write work on the hottest path in auth. After: one unique index, nothing else changes.

## The migration does not lose data

All three operations run in one transaction, and DDL in Postgres holds ACCESS EXCLUSIVE on the table until commit, so no other session can insert during the moment uniqueness has no enforcer. Nothing in `app/` or `tests/` references the constraint name `refresh_tokens_token_hash_key` (checked). Note that `start.sh` runs `alembic upgrade head` on boot, so **merging this runs the migration on production**; that is the normal path here, but it is worth saying out loud rather than discovering.

Verified by hand against the dev database: upgrade, inspect, downgrade, inspect, upgrade again. The downgrade restores both indexes exactly as they were.

## The part that stops it coming back

The suite could never have caught this. `conftest.py` builds the test database with `Base.metadata.create_all`, so it only ever sees the models — a migration that has drifted from them is invisible **by construction**. `alembic check` is the only thing in the project that compares the two, and CI did not run it.

So CI now does, against an empty database:

```yaml
psql ... -c 'CREATE DATABASE norby_migrations'
alembic upgrade head
alembic check
```

Building from zero also proves the twelve-migration chain still runs end to end, which `alembic check` on an already-migrated database would not.

This mirrors the `check_locks.py` step that is already in this job, and for the same reason: a divergence that tests cannot see needs its own guard.

**The guard was checked for teeth, not assumed.** With the model reverted, the step fails with `FAILED: New upgrade operations detected: modify_default ... recurring_transactions.active`. With the model as committed, `No new upgrade operations detected`. A check that has never been observed failing is not yet a check.
