### PR TITLE
feat(legal): terms, refund policy and privacy for a paid product

### DIFF
--- a/frontend/src/components/shared/PlanCard.jsx
+++ b/frontend/src/components/shared/PlanCard.jsx
@@ -1,11 +1,12 @@
 import { useEffect, useState } from "react";
-import { useSearchParams } from "react-router-dom";
+import { Link, useSearchParams } from "react-router-dom";
 import { CreditCard } from "lucide-react";
 
 import { billingApi } from "@/api/billing";
 import { authApi } from "@/api/auth";
 import { useAuthStore } from "@/store/authStore";
 import { apiErrorMessage, formatDateBR } from "@/lib/utils";
+import { PRECO_MENSAL } from "@/lib/plano";
 import { Button } from "@/components/ui/button";
 
 /**
@@ -151,6 +152,22 @@ export default function PlanCard() {
           </Button>
         )}
       </div>
+
+      {/* Preço, periodicidade e direito de arrependimento ao lado do botão, e
+          não só na página de termos. O art. 6º, III do CDC pede informação
+          adequada e clara ANTES de contratar, e "antes" é aqui: é neste botão
+          que a decisão é tomada. O Checkout do Stripe repete o valor depois,
+          mas quem clica já precisa saber o que está clicando. */}
+      {restringido && (
+        <p className="text-xs text-content-3 leading-relaxed mt-4">
+          {PRECO_MENSAL} por mês, com renovação automática. Cancele quando
+          quiser, sem multa. Veja os{" "}
+          <Link to="/termos" className="text-accent hover:underline">
+            Termos de Uso
+          </Link>
+          , incluindo o direito de desistir em 7 dias com devolução integral.
+        </p>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/shared/PlanCard.test.jsx
+++ b/frontend/src/components/shared/PlanCard.test.jsx
@@ -5,6 +5,7 @@ import { MemoryRouter } from "react-router-dom";
 import { billingApi } from "@/api/billing";
 import { authApi } from "@/api/auth";
 import { useAuthStore } from "@/store/authStore";
+import { PRECO_MENSAL } from "@/lib/plano";
 import PlanCard from "./PlanCard";
 
 vi.mock("@/api/billing", () => ({
@@ -159,5 +160,35 @@ describe("PlanCard", () => {
   it("does not call confirm when there is no session in the URL", () => {
     renderCard({ ...LIBERADO, ai_allowed: false, wallet_cap_applies: true });
     expect(billingApi.confirmCheckout).not.toHaveBeenCalled();
+  });
+
+  it("states price, renewal and the withdrawal right beside the subscribe button", () => {
+    // Art. 6º, III do CDC: informação clara ANTES de contratar. O Checkout do
+    // Stripe repete o valor na tela seguinte, mas quem clica aqui já tem de
+    // saber o que está clicando.
+    renderCard({ ...LIBERADO, ai_allowed: false, wallet_cap_applies: true });
+
+    expect(screen.getByRole("link", { name: "Termos de Uso" })).toHaveAttribute(
+      "href",
+      "/termos",
+    );
+    const cartao = screen.getByText("Plano").closest("div.glass");
+    expect(cartao.textContent).toContain(PRECO_MENSAL);
+    expect(cartao.textContent).toContain("renovação automática");
+    expect(cartao.textContent).toContain("7 dias");
+  });
+
+  it("does not pitch the price to someone who already subscribed", () => {
+    // Quem já assinou vê o cartão pelo botão de gerenciar, e repetir a oferta
+    // ali é ruído: a informação prévia serve a quem ainda vai decidir.
+    renderCard({
+      ...LIBERADO,
+      subscription_status: "active",
+      premium_until: "2099-01-01T00:00:00Z",
+    });
+
+    expect(screen.getByRole("button", { name: "Gerenciar assinatura" })).toBeInTheDocument();
+    const cartao = screen.getByText("Plano").closest("div.glass");
+    expect(cartao.textContent).not.toContain(PRECO_MENSAL);
   });
 });

--- a/frontend/src/lib/plano.js
+++ b/frontend/src/lib/plano.js
@@ -1,0 +1,13 @@
+/**
+ * O preço aparece em dois lugares que o consumidor lê antes de decidir: o
+ * cartão de plano, ao lado do botão de assinar, e os Termos de Uso.
+ *
+ * Ficam na mesma constante porque divergirem não é bug de manutenção, é
+ * problema de consumo: o art. 31 do CDC exige informação de preço correta e
+ * precisa, e duas telas do mesmo produto anunciando valores diferentes é
+ * exatamente o que ele proíbe.
+ *
+ * A fonte da verdade continua sendo o Price do Stripe. Isto é a cópia que a
+ * interface exibe, e ao mudar o valor lá o reajuste passa por aqui também.
+ */
+export const PRECO_MENSAL = "R$ 20,00";

--- a/frontend/src/pages/LegalPages.test.jsx
+++ b/frontend/src/pages/LegalPages.test.jsx
@@ -3,6 +3,7 @@ import { createElement } from "react";
 import { MemoryRouter } from "react-router-dom";
 import { describe, expect, it } from "vitest";
 
+import { PRECO_MENSAL } from "@/lib/plano";
 import Privacidade from "./Privacidade";
 import Termos from "./Termos";
 
@@ -44,5 +45,57 @@ describe.each([
         "leading-relaxed",
       );
     }
+  });
+});
+
+// Conteúdo que existe por obrigação legal, não por estilo. Um refactor de
+// layout que reescreva estas páginas continua passando no teste de estrutura
+// acima mesmo tendo apagado o direito de arrependimento — daí estes.
+describe("Termos de Uso: o que a cobrança obriga a informar", () => {
+  it("informa preço, renovação automática e cancelamento sem intermediário", () => {
+    const { container } = renderPage(Termos);
+    const texto = container.textContent;
+
+    expect(texto).toContain(PRECO_MENSAL);
+    expect(texto).toContain("renovada automaticamente");
+    expect(texto).toContain("Gerenciar assinatura");
+    expect(texto).toContain("Não há fidelidade nem multa por cancelar");
+  });
+
+  it("informa o direito de arrependimento de 7 dias com devolução integral", () => {
+    // Art. 49 do CDC. É o item mais fácil de perder numa reescrita e o mais
+    // caro de não ter: o direito existe mesmo sem estar escrito, mas não
+    // informá-lo é a infração.
+    const { container } = renderPage(Termos);
+    const texto = container.textContent;
+
+    expect(texto).toContain("art. 49");
+    expect(texto).toContain("7 dias corridos");
+    expect(texto).toContain("tudo o que pagou");
+  });
+
+  it("diz o que acontece com os dados de quem cancela", () => {
+    const { container } = renderPage(Termos);
+    const texto = container.textContent;
+
+    expect(texto).toContain("Cancelar não apaga nada");
+    expect(texto).toContain("72 horas");
+  });
+});
+
+describe("Política de Privacidade: o que o pagamento acrescentou", () => {
+  it("declara que dado de cartão nunca chega ao Norby", () => {
+    const { container } = renderPage(Privacidade);
+    const texto = container.textContent;
+
+    expect(texto).toContain("nunca chegam aos servidores do Norby");
+    expect(texto).toContain("Stripe");
+  });
+
+  it("declara a transferência internacional", () => {
+    // Stripe e Gemini ficam fora do Brasil. Omitir isso seria a política
+    // descrever um tratamento que não é o que acontece.
+    const { container } = renderPage(Privacidade);
+    expect(container.textContent).toContain("art. 33");
   });
 });

--- a/frontend/src/pages/Privacidade.jsx
+++ b/frontend/src/pages/Privacidade.jsx
@@ -1,7 +1,6 @@
 import { Link } from "react-router-dom";
 import { ArrowLeft } from "lucide-react";
 
-// Rascunho de portfólio — não substitui revisão jurídica.
 export default function Privacidade() {
   return (
     <div className="app-mesh min-h-screen bg-bg-base px-4 py-8 text-content sm:py-12">
@@ -18,7 +17,7 @@ export default function Privacidade() {
             Política de Privacidade
           </h1>
           <p className="mt-2 text-sm text-content-3">
-            Última atualização: 29/06/2026
+            Última atualização: 05/09/2026
           </p>
 
           <section>
@@ -41,6 +40,7 @@ export default function Privacidade() {
               <li><strong>Cadastro:</strong> nome, e-mail e senha (armazenada apenas como hash bcrypt — nunca em texto puro).</li>
               <li><strong>Financeiros:</strong> carteiras, transações, transações recorrentes e metas que você registra.</li>
               <li><strong>Interações com a IA:</strong> mensagens enviadas ao assistente e os insights gerados a partir dos seus dados financeiros.</li>
+              <li><strong>Assinatura:</strong> apenas identificadores e datas, detalhados na seção 5. <strong>Nenhum dado de cartão.</strong></li>
               <li><strong>Técnicos:</strong> dados mínimos de sessão (tokens de autenticação) necessários para manter você conectado.</li>
             </ul>
           </section>
@@ -51,7 +51,7 @@ export default function Privacidade() {
             </h2>
             <p className="leading-relaxed text-content-2">Tratamos seus dados com as seguintes bases legais (art. 7º da LGPD):</p>
             <ul className="mt-3 list-disc space-y-1 pl-5 leading-relaxed text-content-2">
-              <li><strong>Execução de contrato (art. 7º, V):</strong> cadastro, autenticação e funcionamento do organizador financeiro — sem esses dados o serviço não existe.</li>
+              <li><strong>Execução de contrato (art. 7º, V):</strong> cadastro, autenticação e funcionamento do organizador financeiro — sem esses dados o serviço não existe. Também é a base do plano pago: sem os identificadores da seção 5 não há como saber que a assinatura está válida.</li>
               <li><strong>Consentimento (art. 7º, I):</strong> envio dos seus dados financeiros ao provedor de IA (Google Gemini) para gerar insights e responder no chat. Você pode deixar de usar os recursos de IA a qualquer momento.</li>
               <li><strong>Cumprimento de obrigação legal/regulatória (art. 7º, II):</strong> quando aplicável, para atender determinações legais.</li>
             </ul>
@@ -59,19 +59,49 @@ export default function Privacidade() {
 
           <section>
             <h2 className="mb-3 mt-8 text-lg font-semibold text-content">
-              4. Compartilhamento
+              4. Compartilhamento e transferência internacional
             </h2>
             <p className="leading-relaxed text-content-2">
               Não vendemos seus dados. Eles são compartilhados apenas com
-              provedores necessários ao funcionamento do serviço, como a
-              infraestrutura de hospedagem e o provedor de IA (Google Gemini),
-              estritamente para as finalidades acima.
+              provedores necessários ao funcionamento do serviço, na condição de
+              operadores e estritamente para as finalidades acima: a infraestrutura
+              de hospedagem, o provedor de IA (Google Gemini) e, se você assinar, a{" "}
+              <strong>Stripe</strong> para processar o pagamento. Esses provedores
+              ficam fora do Brasil, então há transferência internacional de dados,
+              feita nos termos do art. 33 da LGPD e limitada ao necessário para
+              prestar o serviço.
             </p>
           </section>
 
           <section>
             <h2 className="mb-3 mt-8 text-lg font-semibold text-content">
-              5. Seus direitos
+              5. Pagamento e assinatura
+            </h2>
+            <p className="leading-relaxed text-content-2">
+              O pagamento acontece inteiramente dentro da Stripe. Os dados do seu
+              cartão são digitados no ambiente dela e{" "}
+              <strong>nunca chegam aos servidores do Norby</strong>: não os
+              recebemos, não os armazenamos e não temos como vê-los. O que fica
+              guardado aqui é o mínimo para saber que sua assinatura está válida:
+            </p>
+            <ul className="mt-3 list-disc space-y-1 pl-5 leading-relaxed text-content-2">
+              <li>o identificador do seu cadastro na Stripe e o da assinatura;</li>
+              <li>a data até quando o acesso Premium vale;</li>
+              <li>a data do último aviso recebido da Stripe, usada para não aplicar avisos fora de ordem.</li>
+            </ul>
+            <p className="mt-3 leading-relaxed text-content-2">
+              Dos avisos que a Stripe envia guardamos <strong>somente esses
+              campos</strong>, nunca a mensagem original. É uma escolha de projeto,
+              não um detalhe técnico: a mensagem original carrega dados como o
+              e-mail usado na compra, e guardá-la deixaria informação sua fora do
+              alcance do botão de excluir a conta. O histórico completo dos
+              pagamentos fica com a Stripe, sujeito à política de privacidade dela.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="mb-3 mt-8 text-lg font-semibold text-content">
+              6. Seus direitos
             </h2>
             <p className="leading-relaxed text-content-2">A LGPD garante a você, entre outros direitos:</p>
             <ul className="mt-3 list-disc space-y-1 pl-5 leading-relaxed text-content-2">
@@ -83,18 +113,21 @@ export default function Privacidade() {
 
           <section>
             <h2 className="mb-3 mt-8 text-lg font-semibold text-content">
-              6. Retenção
+              7. Retenção
             </h2>
             <p className="leading-relaxed text-content-2">
               Seus dados são mantidos enquanto sua conta existir. Ao excluir a
               conta, eles são apagados de forma definitiva e não podem ser
-              recuperados.
+              recuperados. Excluir a conta apaga o que está do nosso lado, incluindo
+              os identificadores da seção 5; o registro dos pagamentos já feitos
+              permanece com a Stripe pelo prazo que a legislação fiscal e financeira
+              exige dela, o que está fora do nosso controle.
             </p>
           </section>
 
           <section>
             <h2 className="mb-3 mt-8 text-lg font-semibold text-content">
-              7. Contato
+              8. Contato
             </h2>
             <p className="leading-relaxed text-content-2">
               Para exercer seus direitos ou tirar dúvidas sobre privacidade, fale
@@ -102,14 +135,13 @@ export default function Privacidade() {
               <a className="text-accent hover:underline" href="mailto:privacidade@norby.app">
                 privacidade@norby.app
               </a>
+              . Sobre cobrança, cancelamento e reembolso, veja os{" "}
+              <Link to="/termos" className="text-accent hover:underline">
+                Termos de Uso
+              </Link>
               .
             </p>
           </section>
-
-          <p className="mt-8 border-t border-line/10 pt-4 text-xs leading-relaxed text-content-3">
-            Este documento é um rascunho de um projeto de portfólio e não constitui
-            aconselhamento jurídico.
-          </p>
         </article>
       </main>
     </div>

--- a/frontend/src/pages/Termos.jsx
+++ b/frontend/src/pages/Termos.jsx
@@ -1,7 +1,26 @@
 import { Link } from "react-router-dom";
 import { ArrowLeft } from "lucide-react";
 
-// Rascunho de portfólio — não substitui revisão jurídica.
+import { PRECO_MENSAL } from "@/lib/plano";
+
+/**
+ * Identidade do fornecedor.
+ *
+ * O Decreto nº 7.962/2013, art. 2º, I e II, exige que o site de comércio
+ * eletrônico traga o NOME e o CPF/CNPJ de quem vende, mais um endereço
+ * eletrônico de contato. Não é recomendação, é condição para cobrar.
+ *
+ * PREENCHER ANTES DE LIGAR O PAYWALL EM PRODUÇÃO. Fica isolado aqui de
+ * propósito: é uma edição de duas linhas, e assim o CPF entra no repositório
+ * por decisão consciente de quem edita, não porque veio junto num commit
+ * grande. Enquanto `nome` estiver vazio a seção mostra só o e-mail.
+ */
+const FORNECEDOR = {
+  nome: "",
+  documento: "",
+  email: "contato@norby.app",
+};
+
 export default function Termos() {
   return (
     <div className="app-mesh min-h-screen bg-bg-base px-4 py-8 text-content sm:py-12">
@@ -18,7 +37,7 @@ export default function Termos() {
             Termos de Uso
           </h1>
           <p className="mt-2 text-sm text-content-3">
-            Última atualização: 29/06/2026
+            Última atualização: 05/09/2026
           </p>
 
           <section>
@@ -31,13 +50,39 @@ export default function Termos() {
               <Link to="/privacidade" className="text-accent hover:underline">
                 Política de Privacidade
               </Link>
-              .
+              . Se você assinar o plano pago, valem também as condições das seções
+              6 a 10, que tratam de preço, cobrança, cancelamento e reembolso.
             </p>
           </section>
 
           <section>
             <h2 className="mb-3 mt-8 text-lg font-semibold text-content">
-              2. O serviço
+              2. Quem oferece o serviço
+            </h2>
+            <ul className="list-disc space-y-1 pl-5 leading-relaxed text-content-2">
+              {FORNECEDOR.nome && (
+                <li>
+                  <strong>Fornecedor:</strong> {FORNECEDOR.nome}
+                </li>
+              )}
+              {FORNECEDOR.documento && (
+                <li>
+                  <strong>CPF/CNPJ:</strong> {FORNECEDOR.documento}
+                </li>
+              )}
+              <li>
+                <strong>Contato:</strong>{" "}
+                <a className="text-accent hover:underline" href={`mailto:${FORNECEDOR.email}`}>
+                  {FORNECEDOR.email}
+                </a>{" "}
+                — este é o canal oficial para dúvidas, cancelamento e reembolso.
+              </li>
+            </ul>
+          </section>
+
+          <section>
+            <h2 className="mb-3 mt-8 text-lg font-semibold text-content">
+              3. O serviço
             </h2>
             <p className="leading-relaxed text-content-2">
               O Norby é uma ferramenta de organização financeira pessoal com apoio
@@ -49,7 +94,7 @@ export default function Termos() {
 
           <section>
             <h2 className="mb-3 mt-8 text-lg font-semibold text-content">
-              3. Conteúdo gerado por IA
+              4. Conteúdo gerado por IA
             </h2>
             <p className="leading-relaxed text-content-2">
               Os insights e respostas do assistente são gerados automaticamente e
@@ -61,7 +106,7 @@ export default function Termos() {
 
           <section>
             <h2 className="mb-3 mt-8 text-lg font-semibold text-content">
-              4. Sua conta
+              5. Sua conta
             </h2>
             <ul className="list-disc space-y-1 pl-5 leading-relaxed text-content-2">
               <li>Você é responsável por manter a confidencialidade da sua senha.</li>
@@ -72,29 +117,149 @@ export default function Termos() {
 
           <section>
             <h2 className="mb-3 mt-8 text-lg font-semibold text-content">
-              5. Limitação de responsabilidade
+              6. Planos e o que cada um inclui
+            </h2>
+            <ul className="list-disc space-y-1 pl-5 leading-relaxed text-content-2">
+              <li>
+                <strong>Gratuito:</strong> até 2 carteiras e sem acesso à
+                inteligência artificial.
+              </li>
+              <li>
+                <strong>Teste de IA:</strong> toda conta nova recebe{" "}
+                <strong>7 dias de inteligência artificial</strong>, sem cartão e sem
+                cobrança. Durante o teste o limite de 2 carteiras continua valendo,
+                e ao fim dele nada é cobrado: a conta simplesmente volta a ser
+                gratuita.
+              </li>
+              <li>
+                <strong>Premium:</strong> carteiras ilimitadas e acesso à
+                inteligência artificial enquanto a assinatura estiver válida.
+              </li>
+            </ul>
+          </section>
+
+          <section>
+            <h2 className="mb-3 mt-8 text-lg font-semibold text-content">
+              7. Preço, cobrança e renovação
+            </h2>
+            <ul className="list-disc space-y-1 pl-5 leading-relaxed text-content-2">
+              <li>
+                O plano Premium custa <strong>{PRECO_MENSAL} por mês</strong>, em reais.
+              </li>
+              <li>
+                A cobrança é <strong>mensal e renovada automaticamente</strong> na
+                mesma data de cada mês, até que você cancele. Não há fidelidade nem
+                multa por cancelar.
+              </li>
+              <li>
+                O pagamento é processado pela <strong>Stripe</strong>. Os dados do
+                seu cartão são digitados no ambiente dela e{" "}
+                <strong>não passam nem são armazenados pelo Norby</strong>.
+              </li>
+              <li>
+                A data da próxima renovação fica visível em{" "}
+                <em>Configurações → Plano</em>.
+              </li>
+            </ul>
+          </section>
+
+          <section>
+            <h2 className="mb-3 mt-8 text-lg font-semibold text-content">
+              8. Cancelamento
             </h2>
             <p className="leading-relaxed text-content-2">
-              O serviço é fornecido "como está". Na máxima extensão permitida pela
-              lei, o Norby não se responsabiliza por perdas decorrentes do uso da
-              ferramenta ou de indisponibilidades temporárias.
+              Você cancela sozinho, a qualquer momento, em{" "}
+              <em>Configurações → Plano → Gerenciar assinatura</em>, sem precisar
+              falar com ninguém e sem justificar. É o mesmo número de cliques que
+              contratar, como manda o art. 5º do Decreto nº 7.962/2013. O
+              cancelamento interrompe as cobranças seguintes e{" "}
+              <strong>o acesso Premium continua até o fim do período que você já
+              pagou</strong>. Se preferir, peça o cancelamento pelo e-mail da seção 2.
             </p>
           </section>
 
           <section>
             <h2 className="mb-3 mt-8 text-lg font-semibold text-content">
-              6. Alterações
+              9. Direito de arrependimento e reembolso
+            </h2>
+            <ul className="list-disc space-y-1 pl-5 leading-relaxed text-content-2">
+              <li>
+                <strong>7 dias para desistir, com devolução integral.</strong> Por
+                ser uma contratação feita pela internet, o art. 49 do Código de
+                Defesa do Consumidor garante que você desista em até 7 dias corridos
+                a contar da contratação e receba de volta{" "}
+                <strong>tudo o que pagou</strong>, sem precisar dar motivo.
+              </li>
+              <li>
+                <strong>Como pedir:</strong> escreva para o e-mail da seção 2. O
+                estorno é feito pela Stripe, no mesmo meio de pagamento usado na
+                compra, e o prazo até o valor aparecer na fatura depende do seu
+                banco ou da bandeira do cartão.
+              </li>
+              <li>
+                <strong>Depois dos 7 dias</strong>, o cancelamento vale para as
+                renovações futuras e não gera devolução do mês em curso, porque o
+                acesso continua até o fim dele. Se uma renovação for cobrada depois
+                de você ter pedido o cancelamento,{" "}
+                <strong>essa cobrança é devolvida integralmente</strong>.
+              </li>
+            </ul>
+          </section>
+
+          <section>
+            <h2 className="mb-3 mt-8 text-lg font-semibold text-content">
+              10. O que acontece com seus dados ao cancelar
             </h2>
             <p className="leading-relaxed text-content-2">
-              Estes termos podem ser atualizados. Mudanças relevantes serão
-              comunicadas dentro do aplicativo.
+              <strong>Cancelar não apaga nada.</strong> Sua conta volta a ser
+              gratuita e todo o histórico continua lá. A inteligência artificial
+              deixa de responder no vencimento; as carteiras que excedem o limite do
+              plano gratuito seguem abertas por mais{" "}
+              <strong>72 horas</strong> e, depois disso, ficam somente leitura, sem
+              perder um lançamento sequer e continuando a contar nos seus totais.
+              Voltando a assinar, tudo se reabre. Para apagar de verdade, use{" "}
+              <em>Configurações → Excluir minha conta</em>, o que é irreversível.
             </p>
           </section>
 
-          <p className="mt-8 border-t border-line/10 pt-4 text-xs leading-relaxed text-content-3">
-            Este documento é um rascunho de um projeto de portfólio e não constitui
-            aconselhamento jurídico.
-          </p>
+          <section>
+            <h2 className="mb-3 mt-8 text-lg font-semibold text-content">
+              11. Limitação de responsabilidade
+            </h2>
+            <p className="leading-relaxed text-content-2">
+              O serviço é fornecido "como está". Na máxima extensão permitida pela
+              lei, o Norby não se responsabiliza por perdas decorrentes do uso da
+              ferramenta ou de indisponibilidades temporárias. Nada aqui afasta os
+              direitos que o Código de Defesa do Consumidor garante a você.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="mb-3 mt-8 text-lg font-semibold text-content">
+              12. Alterações nos termos e no preço
+            </h2>
+            <p className="leading-relaxed text-content-2">
+              Estes termos podem ser atualizados, e mudanças relevantes serão
+              comunicadas dentro do aplicativo. Um{" "}
+              <strong>aumento de preço nunca se aplica sem aviso</strong>: ele é
+              informado com pelo menos 30 dias de antecedência e passa a valer
+              apenas nas renovações seguintes, para que você possa cancelar antes
+              se não concordar.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="mb-3 mt-8 text-lg font-semibold text-content">
+              13. Contato
+            </h2>
+            <p className="leading-relaxed text-content-2">
+              Dúvidas, cancelamento e reembolso pelo e-mail{" "}
+              <a className="text-accent hover:underline" href={`mailto:${FORNECEDOR.email}`}>
+                {FORNECEDOR.email}
+              </a>
+              .
+            </p>
+          </section>
         </article>
       </main>
     </div>


### PR DESCRIPTION
Closes #27.

## One thing had to go before anything else could be added

Both pages ended with *"Este documento é um rascunho de um projeto de portfólio e não constitui aconselhamento jurídico."*

That line is now gone, and its removal is the point. **Charging money makes the CDC apply whether the page says so or not.** A disclaimer cannot opt out of consumer law; all it does is tell a consumer, or Procon, that the supplier knew there was an obligation and treated it as optional. Keeping it while adding a refund policy underneath would have been the worst of both.

## What the terms now say, and why each part is there

| Section | Exists because |
|---|---|
| Quem oferece o serviço | Decreto 7.962/2013, art. 2º, I and II: name, CPF/CNPJ, electronic address |
| Planos | The free tier, the 7-day AI trial and Premium, stated as the code actually behaves |
| Preço, cobrança e renovação | Automatic renewal has to be stated before it happens, not discovered on the invoice |
| Cancelamento | Decreto 7.962/2013, art. 5º: cancelling must be as easy as subscribing |
| Direito de arrependimento | **CDC art. 49**: 7 days, full refund, no reason needed |
| Dados ao cancelar | The 72-hour grace and the read-only wallets are surprising if undocumented |
| Alterações no preço | 30 days notice, applying only to later renewals |

The plan descriptions were written against `plan_service.py` rather than from memory, so the page matches the code: the trial grants AI only and the 2-wallet cap still applies during it, AI stops at expiry while extra wallets stay open for 72 hours and then go read-only without losing a single entry.

## The refund decision the ticket asked for

> *decide how a refund is actually executed (Stripe dashboard, or in-app)*

**Stripe dashboard, requested by email.** Building an in-app refund flow means an endpoint, an authorization rule, an audit trail and a UI for an event that may happen a handful of times a year, and Stripe's dashboard already does all four. If refunds ever become routine, that is the moment to automate, and the terms do not have to change for it.

The policy itself is three cases, so nobody has to interpret:

1. **Within 7 days of subscribing**: everything paid comes back, no reason required.
2. **After 7 days**: cancelling stops the next charge and access runs to the end of the paid month. No pro-rata refund, because the service continues.
3. **A renewal charged after a cancellation request**: refunded in full. This is the case that actually generates complaints, so it is written down rather than left to goodwill.

## The consent decision, and why it is "no new column"

> *Decide whether accepting the paid terms is a separate consent from `privacy_accepted_at`, and whether existing users must re-accept.*

**No separate consent field, and nobody re-accepts.**

A version-pinned consent column sounds rigorous and costs a `terms_version`, a re-acceptance modal, a blocking state in the app and a migration, every time the text changes. It also solves the wrong problem: **someone who never subscribes is never bound by paid-plan terms**, so forcing the whole user base through a modal would interrupt everyone to record consent that matters to almost none of them.

There is a better place to record it, and Stripe already owns it: `consent_collection.terms_of_service: "required"` on the Checkout Session makes Stripe show the checkbox and store the acceptance on the session, timestamped, attached to the payment itself. That is stronger evidence than a boolean in our database, and it is one line of code.

**I did not ship it here on purpose.** That parameter requires a Terms of Service URL configured in the Stripe Dashboard under Settings → Business → Public details, and without it **Checkout Sessions fail to create at all**. Shipping it today would arm a failure that only fires when the paywall is switched on, months from now, far from this PR. Filed as a follow-up with the prerequisite written down.

## Before this can charge anyone

`Termos.jsx` opens with:

```js
const FORNECEDOR = { nome: "", documento: "", email: "contato@norby.app" };
```

While `nome` is empty the section renders only the contact email, so nothing looks broken, but **the page is not compliant with Decreto 7.962/2013 until it is filled**. It is isolated in one constant deliberately: putting a CPF in a public repository should be a conscious edit, not something that rides along inside a large commit. That decision is yours, and it is the last gate before `PAYWALL_ENABLED=true` in production.

Related, from #39: the seller identity for the first phase is the **CPF**, not a company. MEI is not available to a software business, so there is no cheaper vehicle to wait for.

## Verification

- 153 frontend tests (7 new), lint clean on eslint 10, production build passing.
- **The new tests were checked for teeth.** Three mutations, all killed:
  - changing "7 dias corridos" to "30 dias" → the withdrawal-right test fails
  - deleting the promise that card data never reaches Norby → the privacy test fails
  - showing the sales fine print to someone who already subscribed → the PlanCard test fails

The last one guards something easy to get wrong: the price and renewal notice appears beside the **subscribe** button, and must not appear for someone whose card is already charged, where it reads as a second sales pitch instead of prior information.
