### PR TITLE
docs(ops): refund runbook, plus three items from the review

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -165,6 +165,17 @@ Start em produção: `backend/start.sh` roda `alembic upgrade head` + uvicorn na
 `$PORT` do provedor (o `CMD` do `backend/Dockerfile`; o `docker-compose.yml` de
 dev sobrescreve com `--reload`).
 
+**Reembolso são DUAS ações, sempre (2026-09-05):** estornar a cobrança no
+painel do Stripe **não cancela a assinatura**. Os quatro eventos que o webhook
+assina não incluem nada de estorno, então só devolver o dinheiro deixa
+`premium_until` intacto, o acesso pago em pé até o fim do período **e a
+renovação cobrando de novo no mês seguinte** — a pessoa que exerceu o direito de
+arrependimento leva uma segunda cobrança, o oposto exato do que os Termos de Uso
+prometem. O procedimento é: **(1)** cancelar a assinatura no painel, o que
+dispara `customer.subscription.deleted` e fecha o portão pelo `ended_at`, e
+**(2)** estornar a cobrança. Nessa ordem, porque o cancelamento é o que a
+aplicação enxerga. Achado na revisão do #29, sem ocorrência real até aqui.
+
 **Sessão:** access token de 15 min (`ACCESS_TOKEN_EXPIRE_MINUTES`), refresh de 7
 dias com rotação e detecção de reuso. O logout revoga só o refresh — um access
 token roubado vale até 15 min. Revogação imediata exigiria denylist de `jti`
@@ -178,15 +189,22 @@ por 7 dias. Como o logout passou a ter o mesmo poder do refresh, ganhou o mesmo
 teto (20/min); sem ele, um refresh antigo viraria um botão de derrubar sessão
 replicável para sempre.
 
-**Hash de senha — migração em andamento (2026-08-15):** `bcrypt_sha256` para
-hashes novos, `bcrypt` mantido no `CryptContext` só para verificar os antigos,
-que são regravados no próximo login de cada usuário (`verify_and_upgrade`).
-Motivo: o bcrypt cru trunca em 72 **bytes** em silêncio, então qualquer sufixo
-depois disso autenticava igual. O cadastro agora recusa senha acima de 72 bytes.
+**Hash de senha (2026-08-15, reescrito sem passlib em 2026-09-05):**
+`bcrypt_sha256` para hashes novos, `bcrypt` cru ainda verificado para os
+antigos, que são regravados no próximo login (`verify_and_upgrade`). Motivo da
+migração: o bcrypt cru trunca em 72 **bytes** em silêncio, então qualquer sufixo
+depois disso autenticava igual. O cadastro recusa senha acima de 72 bytes.
+
+O `passlib` **não existe mais aqui** (#102): ele parou em 2020, quebrava no
+import com bcrypt 5 e importava o `crypt`, removido no Python 3.13. Os dois
+esquemas são implementados em `app/services/password_service.py`, e os testes
+carregam hashes-testemunha gerados pelo passlib antes da troca — são eles que
+provam que ninguém precisa redefinir senha.
+
 ⚠️ **Esta mudança não é revertível sozinha.** Depois que um usuário loga, o hash
-dele vira `$bcrypt-sha256$`, formato que o código anterior (`schemes=["bcrypt"]`)
-não sabe verificar — reverter o commit tranca esses usuários para fora com a
-senha correta. Em rollback, manter `bcrypt_sha256` na lista de schemes.
+dele vira `$bcrypt-sha256$`, formato que o código anterior a 2026-08-15 não sabe
+verificar — reverter tranca esses usuários para fora com a senha correta. Em
+qualquer rollback, `bcrypt_sha256` tem de continuar sendo verificado.
 
 **Tokens no navegador — decisão consciente (2026-07-21):** access e refresh
 ficam no `localStorage` (Zustand persist). A correção canônica seria refresh em

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -104,7 +104,10 @@ app.add_middleware(
 # preflights OPTIONS que o CORSMiddleware responde sem chamar request_context.
 @app.middleware("http")
 async def response_headers(request: Request, call_next):
-    rid = request.headers.get("X-Request-ID") or uuid.uuid4().hex
+    # Fatiado em 64: o valor vem do CLIENTE e vai para o log de toda
+    # requisição. O parser de HTTP já barra quebra de linha, então o que sobra
+    # é tamanho — sem teto, um header gordo infla o log a cada chamada.
+    rid = (request.headers.get("X-Request-ID") or "")[:64] or uuid.uuid4().hex
     request.state.request_id = rid
     response = await call_next(request)
 

--- a/backend/app/routers/billing.py
+++ b/backend/app/routers/billing.py
@@ -155,7 +155,11 @@ async def portal_session(
 
 
 @router.post("/confirm-checkout")
-@limiter.limit("20/minute", key_func=user_key)
+# 5/min e não 20: a checagem de dono não pode vir antes da consulta ao Stripe,
+# porque é a sessão que diz de quem ela é. Então todo `session_id` inventado
+# vira uma chamada de saída ao gateway do qual a cobrança inteira depende, e o
+# teto é o único controle. Uma compra chama isto UMA vez.
+@limiter.limit("5/minute", key_func=user_key)
 async def confirm_checkout_route(
     request: Request,
     payload: ConfirmCheckout,

--- a/backend/app/services/billing_service.py
+++ b/backend/app/services/billing_service.py
@@ -295,6 +295,9 @@ async def reconcile_subscription(user: User, db: AsyncSession) -> bool:
     if not precisa_reconciliar(user):
         return False
 
+    # ponytail: janela por PROCESSO. Com dois workers ou duas instâncias o
+    # teto vira 2x, e em silêncio — a conta chega pelo Stripe, não por erro.
+    # Escalando horizontal, mover para Redis ou para uma coluna no usuário.
     agora = datetime.now(timezone.utc)
     for antigo in [k for k, v in _ULTIMA_CONSULTA.items() if agora - v >= JANELA_CONSULTA]:
         del _ULTIMA_CONSULTA[antigo]

--- a/backend/tests/test_observability.py
+++ b/backend/tests/test_observability.py
@@ -44,6 +44,19 @@ async def test_request_id_is_echoed_when_provided(client):
 
 
 @pytest.mark.asyncio
+async def test_a_long_request_id_from_the_client_is_truncated(client):
+    """O valor vem do cliente e vai para o log de TODA requisição.
+
+    Quebra de linha o parser de HTTP já barra, então o que sobra é tamanho:
+    sem teto, um header gordo infla o log a cada chamada. Truncar preserva a
+    correlação (o prefixo continua identificando a requisição) e tira o
+    incentivo.
+    """
+    res = await client.get("/health", headers={"X-Request-ID": "a" * 500})
+    assert res.headers.get("x-request-id") == "a" * 64
+
+
+@pytest.mark.asyncio
 async def test_responses_carry_security_headers(client):
     res = await client.get("/health")
     assert res.status_code == 200


### PR DESCRIPTION
Acts on the review in #29. Four changes, and the first one is the reason this PR exists.

## The refund procedure was wrong the moment #27 published the policy

`AGENTS.md` now says it, dated, next to the other production procedures:

**Refunding a charge in Stripe does not cancel the subscription.**

The webhook subscribes to four event types and none of them fire on a refund. So the sequence an operator would naturally follow, open the dashboard and refund, returns the money, leaves `premium_until` untouched, keeps paid access alive to the end of the period, **and renews and charges again next month.** Someone who exercised the 7-day right of withdrawal gets billed a second time, which is the exact opposite of what the terms promise.

Order matters, so the runbook fixes it: **cancel first**, which emits `customer.subscription.deleted` and closes the gate on `ended_at`, **then refund.** Cancelling is the half the application can see.

This is documentation rather than code by choice. Handling `charge.refunded` and cancelling programmatically is possible, but a partial refund should not always cancel, and encoding that judgment costs more than the two-step procedure is worth at zero refunds so far. If refunds ever become routine, the runbook is the specification for automating it.

## Three items from the same review

**`confirm-checkout` drops from 20/min to 5/min.** The ownership check cannot come before the Stripe call, because it is the session that says who owns it, so every invented `session_id` becomes an outbound request to the gateway the whole billing system depends on. The rate limit is the only control there, and a purchase calls this endpoint once.

**The reconciliation window is now labelled as per-process.** `_ULTIMA_CONSULTA` is correctly bounded, it evicts before it checks, so it is not a leak. But it lives in one process: two workers means twice the Stripe calls, silently, and the news arrives as a bill rather than an error. A `ponytail:` comment names the ceiling and the upgrade path instead of leaving the next person to discover it.

**`X-Request-ID` is truncated at 64 characters.** It comes from the client and lands in the log line of every request. The HTTP parser already rejects newlines, so response splitting was never possible; what remained was unbounded length inflating logs on every call. Truncating keeps correlation working, since the prefix still identifies the request.

## Also fixed: a production note that had gone stale and was giving bad rollback advice

The password-hashing paragraph in `AGENTS.md` still described `CryptContext` and told a future operator to "keep `bcrypt_sha256` in the schemes list" during a rollback. **passlib was removed in #102 and there is no schemes list any more.** Advice that names code which does not exist is worse than no advice, because it is read during an incident. Rewritten to describe `app/services/password_service.py`, with the warning that actually matters left intact: the change is not self-revertible, because a user who has logged in since has a `$bcrypt-sha256$` hash.

It is not in the scope of #29, but it is three lines above the section this PR was already editing, and leaving a known-false rollback instruction in place to keep a diff tidy is the wrong trade.

## Verification

- Full backend suite green.
- **The one behavioural change carries a test, and the test was checked for teeth.** Removing `[:64]` makes `test_a_long_request_id_from_the_client_is_truncated` fail, and nothing else.
- That mutation was confirmed to actually reach the container before the result was trusted: the count of the literal `[:64]` inside `norby_backend` went 1 → 0 → 1 across the run. This repository has been burned before by a bind mount serving stale content and invalidating a whole mutation round, so the check is deliberate. My first attempt at it was wrong, incidentally, because `grep` read `[:64]` as a character class; the numbers above come from `grep -F`.

The rate-limit change has no test, and that is honest rather than an omission: `conftest.py` disables the limiter for the whole suite, so any test asserting it would be asserting nothing.
