### PR TITLE
fix(legal): point the contact addresses at a domain we own

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -213,8 +213,11 @@ cookie `HttpOnly` + access só em memória, mas o frontend (`vercel.app`) e a AP
 seria bloqueado pelo Safari ITP e pelo Chrome, deslogando o usuário a cada
 recarga. Mitigações no lugar: CSP restritiva no `vercel.json`, access token de
 15 min e revogação de todas as sessões quando um refresh token é reusado.
-**Pré-requisito para migrar:** domínio próprio com API e frontend no mesmo site
-registrável (`norby.app` + `api.norby.app`) — aí o cookie vira `SameSite=Lax`.
+**Pré-requisito para migrar: CUMPRIDO em 2026-09-05.** `norby.com.br` foi
+adquirido, então API e frontend podem passar a viver no mesmo site registrável
+(`norby.com.br` + `api.norby.com.br`) e o cookie vira `SameSite=Lax`. A razão
+que segurava a correção canônica deixou de existir; falta apontar os domínios e
+fazer a migração.
 
 **Rate limit atrás do proxy — reescrito em 2026-08-16 (issue #22, fix round 1
 incluído):** o uvicorn só honra `X-Forwarded-For` quando o peer é

--- a/LGPD.md
+++ b/LGPD.md
@@ -4,7 +4,7 @@
 > substitui revisão jurídica**. Mantido versionado no repo porque `docs/` é
 > ignorado pelo git (ver `.gitignore`).
 
-Controlador: **Norby** · Contato do titular: `privacidade@norby.app`
+Controlador: **Norby** · Contato do titular: `privacidade@norby.com.br`
 
 ## 1. Inventário de dados e base legal
 

--- a/frontend/src/pages/LegalPages.test.jsx
+++ b/frontend/src/pages/LegalPages.test.jsx
@@ -46,6 +46,19 @@ describe.each([
       );
     }
   });
+
+  it("aponta o contato para um domínio que é nosso", () => {
+    // Isto já esteve errado: as duas páginas nasceram apontando para
+    // `norby.app`, que nunca foi nosso. Num documento legal isso não é typo.
+    // O Decreto 7.962/2013 exige endereço eletrônico do fornecedor e a LGPD
+    // exige canal do controlador, e um e-mail que ninguém recebe é PIOR que
+    // nenhum, porque parece um: a pessoa escreve, ninguém responde, e o
+    // registro mostra que ela tentou.
+    const { container } = renderPage(Page);
+
+    expect(container.textContent).toContain("@norby.com.br");
+    expect(container.textContent).not.toMatch(/norby\.app/);
+  });
 });
 
 // Conteúdo que existe por obrigação legal, não por estilo. Um refactor de

--- a/frontend/src/pages/Privacidade.jsx
+++ b/frontend/src/pages/Privacidade.jsx
@@ -132,8 +132,8 @@ export default function Privacidade() {
             <p className="leading-relaxed text-content-2">
               Para exercer seus direitos ou tirar dúvidas sobre privacidade, fale
               com o controlador pelo e-mail{" "}
-              <a className="text-accent hover:underline" href="mailto:privacidade@norby.app">
-                privacidade@norby.app
+              <a className="text-accent hover:underline" href="mailto:privacidade@norby.com.br">
+                privacidade@norby.com.br
               </a>
               . Sobre cobrança, cancelamento e reembolso, veja os{" "}
               <Link to="/termos" className="text-accent hover:underline">

--- a/frontend/src/pages/Termos.jsx
+++ b/frontend/src/pages/Termos.jsx
@@ -18,7 +18,7 @@ import { PRECO_MENSAL } from "@/lib/plano";
 const FORNECEDOR = {
   nome: "",
   documento: "",
-  email: "contato@norby.app",
+  email: "contato@norby.com.br",
 };
 
 export default function Termos() {


### PR DESCRIPTION
`norby.com.br` was acquired today, which turned a line in #106 from cosmetic into wrong.

## The terms named a channel that does not exist

The terms merged yesterday say, in the section that exists to satisfy Decreto 7.962/2013:

> **Contato:** contato@norby.app — este é o canal oficial para dúvidas, cancelamento e reembolso.

**That domain was never ours.** The privacy policy had the same problem with `privacidade@norby.app`, which is the LGPD controller contact, and so did `LGPD.md`.

In a legal document this is not a typo. The decree requires the supplier's electronic address and the LGPD requires a reachable controller, and **an address nobody receives is worse than no address at all, because it looks like one**: the person writes, nobody answers, and the record shows they tried and were ignored. For a cancellation or refund request, that is the exact evidence you would not want to exist.

Both now point at `norby.com.br`.

## Two mailboxes have to exist before this is actually true

Changing the string is half the fix. **`contato@norby.com.br` and `privacidade@norby.com.br` must receive mail**, or the page is still promising a channel that drops messages. Free forwarding to an existing inbox is enough at this stage; nothing here needs a mailbox of its own.

This is the same shape as the `FORNECEDOR` block in the terms: the page can be correct and the obligation still unmet.

## A test, because this class of bug is silent

```js
expect(container.textContent).toContain("@norby.com.br");
expect(container.textContent).not.toMatch(/norby\.app/);
```

It runs against both legal pages. Nothing else in the suite would have noticed: the pages rendered fine, the link was a valid `mailto:`, and the address was well-formed. It was wrong only against a fact that lives outside the code, which is why it needed an assertion rather than a review.

Checked for teeth: putting `norby.app` back makes it fail on the terms page.

## Also unblocked, and recorded rather than left to rot

`AGENTS.md` documented the token-storage decision like this: access and refresh live in `localStorage` because the canonical fix, refresh in an `HttpOnly` cookie, needs the frontend and the API on the same registrable site, and `vercel.app` and `railway.app` are not. It named the prerequisite explicitly.

**That prerequisite is now met.** With `norby.com.br` and `api.norby.com.br` the cookie becomes `SameSite=Lax` and the whole reason for the compromise disappears. The note now says so, so the next person reading it does not re-derive a blocker that no longer exists.

## Verification

155 frontend tests, lint clean, and the test above verified by mutation.
