### PR TITLE
chore(csp): allow the custom API domain before the switch

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -161,6 +161,14 @@ App no ar, deploy a partir da branch `main`:
 - **Frontend:** Vercel — `https://norby-finance.vercel.app`. `VITE_API_URL`
   aponta pro Railway (**embutida no build** → mudou, tem que rebuildar).
 
+⚠️ **Trocar o host da API é DUAS mudanças, e a ordem importa.** O
+`connect-src` da CSP em `frontend/vercel.json` lista os hosts permitidos na
+unha. Apontar a `VITE_API_URL` para um host que não está lá faz o navegador
+**bloquear toda chamada**, e isso não aparece como erro de build nem de deploy:
+a tela sobe e as requisições morrem. Primeiro o host entra na CSP e vai para
+produção, depois a variável muda. Durante a transição os dois hosts ficam
+listados; o antigo só sai quando ninguém mais o usa.
+
 Start em produção: `backend/start.sh` roda `alembic upgrade head` + uvicorn na
 `$PORT` do provedor (o `CMD` do `backend/Dockerfile`; o `docker-compose.yml` de
 dev sobrescreve com `--reload`).

--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -6,7 +6,7 @@
       "headers": [
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self' 'sha256-R+3Pq9GSZ0ahTzusI2wOQaex2PsnJfJjEtMCubzhkJo='; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self' https://norby-production.up.railway.app; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'"
+          "value": "default-src 'self'; script-src 'self' 'sha256-R+3Pq9GSZ0ahTzusI2wOQaex2PsnJfJjEtMCubzhkJo='; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self' https://api.norby.com.br https://norby-production.up.railway.app; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'"
         },
         { "key": "X-Content-Type-Options", "value": "nosniff" },
         { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },


### PR DESCRIPTION
Prerequisite for moving the API to `api.norby.com.br`, and it has to land **before** the environment variable changes.

## Why this is not a detail

`connect-src` in `frontend/vercel.json` lists the allowed API hosts literally:

```
connect-src 'self' https://norby-production.up.railway.app
```

Point `VITE_API_URL` at `api.norby.com.br` without touching this and the browser refuses every request to it. **The build succeeds, the deploy succeeds, the page renders, and nothing works.** There is no error in Vercel and none in Railway; the evidence is only in the browser console, which is the last place anyone looks when the deploy went green.

This repository already has a scar from the same shape: `csp.test.js` exists because the inline theme script and its hash in `script-src` diverged once, the browser blocked the script, every `--*` token went undefined and the app shipped with no colours. That test's own comment ends with "nada no build acusou".

## The change

Both hosts are listed during the transition, so the switch can be made and reverted without a deploy in between. The Railway host comes out once nothing points at it.

`AGENTS.md` now carries the ordering as a warning next to the frontend deploy notes, because the rule is not obvious and the failure is silent: **host into the CSP and shipped first, variable second.**

## Verification

`csp.test.js` still passes. It only asserts on `script-src`, so it does not cover this, which is precisely why the note in `AGENTS.md` had to be written instead: the value that would need comparing lives in a Vercel environment variable, outside the repository, and no test here can reach it.