### PR TITLE
chore(seo): add robots.txt and sitemap, and stop stubbing a real domain

### DIFF
--- a/backend/tests/test_billing_checkout.py
+++ b/backend/tests/test_billing_checkout.py
@@ -25,7 +25,11 @@ def billing_configurado():
     antes = (settings.stripe_secret_key, settings.stripe_price_id, settings.app_base_url)
     settings.stripe_secret_key = "sk_test_x"
     settings.stripe_price_id = "price_123"
-    settings.app_base_url = "https://norby.app"
+    # `example.com` e nao um dominio parecido com o nosso: a RFC 2606 reserva
+    # este nome exatamente para exemplo e teste, entao ele nao pertence nem
+    # pode vir a pertencer a ninguem. O stub anterior era `norby.app`, que
+    # nunca foi nosso e pode ser de outra pessoa.
+    settings.app_base_url = "https://example.com"
     yield settings
     (settings.stripe_secret_key, settings.stripe_price_id, settings.app_base_url) = antes
 
@@ -75,8 +79,8 @@ async def test_checkout_carries_the_user_id_so_the_webhook_can_match(
     assert recebido["customer_id"] is None  # ainda não tem
     # A volta traz o id da sessão, que é o que fecha a corrida da 1ª compra.
     assert "{CHECKOUT_SESSION_ID}" in recebido["success_url"]
-    assert recebido["success_url"].startswith("https://norby.app")
-    assert recebido["cancel_url"].startswith("https://norby.app")
+    assert recebido["success_url"].startswith("https://example.com")
+    assert recebido["cancel_url"].startswith("https://example.com")
 
 
 @pytest.mark.asyncio
@@ -159,7 +163,7 @@ async def test_the_portal_returns_a_url_for_a_customer(
     assert res.status_code == 200
     assert res.json()["url"].startswith("https://billing.stripe.com/")
     assert recebido["customer_id"] == "cus_1"
-    assert recebido["return_url"].startswith("https://norby.app")
+    assert recebido["return_url"].startswith("https://example.com")
 
 
 # --- A volta do Checkout: a corrida da primeira compra -----------------------
@@ -317,8 +321,8 @@ async def test_the_payload_that_reaches_stripe_is_complete(monkeypatch):
         client_reference_id="abc-123",
         price_id="price_123",
         customer_id="cus_1",
-        success_url="https://norby.app/settings?s={CHECKOUT_SESSION_ID}",
-        cancel_url="https://norby.app/settings",
+        success_url="https://example.com/settings?s={CHECKOUT_SESSION_ID}",
+        cancel_url="https://example.com/settings",
     )
 
     assert url == "https://checkout.stripe.com/c/pay/cs_1"
@@ -349,8 +353,8 @@ async def test_a_first_time_buyer_sends_no_customer_at_all(monkeypatch):
         client_reference_id="abc-123",
         price_id="price_123",
         customer_id=None,
-        success_url="https://norby.app/settings",
-        cancel_url="https://norby.app/settings",
+        success_url="https://example.com/settings",
+        cancel_url="https://example.com/settings",
     )
 
     assert "customer" not in recebido

--- a/frontend/public/robots.txt
+++ b/frontend/public/robots.txt
@@ -1,0 +1,12 @@
+# As rotas abaixo exigem login, então um crawler só encontra redirect nelas.
+# Bloquear economiza crawl budget e evita indexar tela de login.
+User-agent: *
+Disallow: /dashboard
+Disallow: /wallets
+Disallow: /transactions
+Disallow: /ai
+Disallow: /recurring
+Disallow: /goals
+Disallow: /settings
+
+Sitemap: https://norby.com.br/sitemap.xml

--- a/frontend/public/sitemap.xml
+++ b/frontend/public/sitemap.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://norby.com.br/</loc></url>
+  <url><loc>https://norby.com.br/termos</loc></url>
+  <url><loc>https://norby.com.br/privacidade</loc></url>
+</urlset>


### PR DESCRIPTION
The two items from the domain-migration audit that are safe before the apex is serving.

## robots.txt and sitemap.xml

The bug is real and worth stating plainly: the SPA catch-all rewrite in `vercel.json` sends `/(.*)` to `index.html`, so **`/robots.txt` returned the application HTML with a 200**, not a 404. A crawler asking for crawl rules got a page. Vercel serves static files before applying rewrites, so putting the file in `public/` is the entire fix.

Verified rather than assumed: after `npm run build`, both files are in `dist/`.

`robots.txt` blocks the seven authenticated routes. A crawler finds only a redirect to login there, so indexing them wastes crawl budget and risks putting a login screen in the results.

`sitemap.xml` lists the three public pages with absolute apex URLs. That carries the canonical signal **without** a static `<link rel="canonical">`, which in a single-`index.html` SPA would apply the same canonical to every route and declare `/termos` to be `/`. Worse than having none.

## The test stub was a domain we do not own

`test_billing_checkout.py` set `app_base_url` to `https://norby.app`. That domain was never ours and may well be someone else's. RFC 2606 reserves `example.com` for exactly this purpose, so it cannot belong to anyone and cannot start resolving somewhere unexpected.

**Eight occurrences, not seven** as the migration report counted. Worth saying because the count is how you verify the replacement was complete.

One occurrence of the string stays, deliberately: the comment in `LegalPages.test.jsx` that records why that test exists. It documents the mistake rather than repeating it.

## Not in this PR, and deliberately

The rest of the audit waits for the apex to actually serve: the Lighthouse target in `ci.yml`, the URLs in `README.md` and `AGENTS.md`, the docstring in `seed_demo.py`, and removing the Railway host from `connect-src`. Changing any of them now points CI or a reader at a hostname that does not resolve yet.

`.env.example` keeps `DOMAIN=norby.duckdns.org`. Setting it to `norby.com.br` would be wrong, not stale: that variable feeds the Caddy of the self-hosted VPS route, and pointing it at a hostname Vercel serves would have Caddy trying to issue a certificate for a name it does not control. An obviously dead value is safer than a plausible wrong one.

## Verification

12 billing tests pass, production build passes, and both files confirmed present in `dist/`.