### PR TITLE
chore(csp): drop the old API host now that nothing calls it

### DIFF
--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -6,7 +6,7 @@
       "headers": [
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self' 'sha256-R+3Pq9GSZ0ahTzusI2wOQaex2PsnJfJjEtMCubzhkJo='; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self' https://api.norby.com.br https://norby-production.up.railway.app; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'"
+          "value": "default-src 'self'; script-src 'self' 'sha256-R+3Pq9GSZ0ahTzusI2wOQaex2PsnJfJjEtMCubzhkJo='; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self' https://api.norby.com.br; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'"
         },
         { "key": "X-Content-Type-Options", "value": "nosniff" },
         { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },


### PR DESCRIPTION
Final step of the domain migration on the code side. Independent of #113, different file, merge in any order.

## Verified in production before removing, not after

The whole risk of this change is a stale build: if the bundle still called the Railway host, removing it from `connect-src` would fail every API call, and a CSP block in the console looks nothing like a deploy problem. So the check was the deployed artifact itself, not the panel setting.

```
Origin: https://norby.com.br  ->  access-control-allow-origin: https://norby.com.br
bundle at norby.com.br        ->  contains https://api.norby.com.br
                              ->  0 occurrences of norby-production.up.railway.app
```

The second line is the one that matters. A saved environment variable proves an intention; the string inside the shipped JavaScript proves the build actually picked it up.

## What this does not do

The API keeps answering on `norby-production.up.railway.app`. This only stops the browser being permitted to call that host from our pages, which nothing does any more.

`norby-finance.vercel.app` serves the same deployment, so that copy also calls `api.norby.com.br`, and its origin is still allowed in `CORS_ORIGINS`. It keeps working, unaffected, until the 308 goes up.

## Still pending, and not code

- the 308 from `norby-finance.vercel.app` to the apex
- afterwards, dropping that origin from `CORS_ORIGINS`, and I will then remove the mention of it from `AGENTS.md`