### PR TITLE
feat(wallets): let a wallet carry a bank, shown as a two-letter mark

### DIFF
--- a/backend/alembic/versions/fe1092dba7da_add_wallet_bank.py
+++ b/backend/alembic/versions/fe1092dba7da_add_wallet_bank.py
@@ -1,0 +1,34 @@
+"""add wallet bank
+
+Issue #34. PURAMENTE ADITIVA: coluna nullable, sem backfill. NULO significa
+"sem banco definido" e e o estado de toda carteira que ja existe, entao o front
+cai no comportamento antigo (inicial do nome) sem uma linha de UPDATE.
+
+Guarda o SLUG, nao o nome do banco. O catalogo (rotulo, marca de duas letras)
+vive no frontend, porque e apresentacao: manter a lista aqui exigiria deploy do
+backend so para acrescentar um banco.
+
+Revision ID: fe1092dba7da
+Revises: d02a76d9af21
+Create Date: 2026-09-05 21:58:20.762230
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'fe1092dba7da'
+down_revision: Union[str, None] = 'd02a76d9af21'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column('wallets', sa.Column('bank', sa.String(length=20), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column('wallets', 'bank')

--- a/backend/app/models/sql_models.py
+++ b/backend/app/models/sql_models.py
@@ -158,6 +158,10 @@ class Wallet(Base):
     user_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("users.id", ondelete="CASCADE"))
     name: Mapped[str] = mapped_column(String(100), nullable=False)
     balance: Mapped[Decimal] = mapped_column(Numeric(15,2), default=Decimal("0.00"))
+    # Banco escolhido (issue #34). NULO = carteira criada antes desta coluna, ou
+    # sem banco definido — e o front cai no comportamento antigo. Guarda o slug,
+    # nao o nome: o rotulo e a marca sao apresentacao e vivem no frontend.
+    bank: Mapped[Optional[str]] = mapped_column(String(20), nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utcnow)
     
     user: Mapped["User"] = relationship("User", back_populates="wallets")

--- a/backend/app/schemas/common.py
+++ b/backend/app/schemas/common.py
@@ -28,3 +28,9 @@ PersonName = Annotated[str, Field(min_length=2, max_length=100)]
 
 # Espelha String(500) da coluna description.
 LongText = Annotated[str, Field(max_length=500)]
+
+# Slug do banco escolhido para a carteira (issue #34). O catalogo de bancos vive
+# no FRONTEND, porque marca e cor sao apresentacao: manter a lista aqui exigiria
+# deploy do backend para acrescentar um banco, e o backend nao tem opiniao sobre
+# quais existem. O que ele garante e que o valor e um token curto e seguro.
+BankSlug = Annotated[str, Field(min_length=1, max_length=20, pattern=r"^[a-z0-9-]+$")]

--- a/backend/app/schemas/wallet.py
+++ b/backend/app/schemas/wallet.py
@@ -3,20 +3,26 @@ from uuid import UUID
 from datetime import datetime
 from decimal import Decimal
 
-from app.schemas.common import MoneyOrZero, ShortText
+from app.schemas.common import BankSlug, MoneyOrZero, ShortText
 
 class WalletCreate(BaseModel):
     name: ShortText
     balance: MoneyOrZero = Decimal("0.00")
+    bank: BankSlug | None = None
 
 class WalletUpdate(BaseModel):
     # Saldo NÃO é editável à mão: ele deriva das transações (fonte única de verdade).
     name: ShortText | None = None
+    # O router aplica `exclude_none`, então mandar `bank: null` NÃO limpa o
+    # banco — troca para outro sim. Limpar não é caso real: o catálogo tem
+    # "dinheiro" e "outro", que é o que alguém escolhe em vez de "nenhum".
+    bank: BankSlug | None = None
     
 class WalletResponse(BaseModel):
     id: UUID
     name: str
     balance: Decimal
+    bank: str | None = None
     created_at: datetime
 
     model_config = ConfigDict(from_attributes=True)

--- a/backend/tests/test_wallets.py
+++ b/backend/tests/test_wallets.py
@@ -85,3 +85,47 @@ async def test_rejects_negative_initial_balance(make_auth_client):
     ac = await make_auth_client("Alice")
     res = await ac.post("/wallets/", json={"name": "Cofre", "balance": "-50.00"})
     assert res.status_code == 422
+
+
+# --- Banco da carteira (issue #34) -------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_bank_round_trips(make_auth_client):
+    ac = await make_auth_client("Alice")
+    res = await ac.post("/wallets/", json={"name": "Conta", "bank": "nubank"})
+    assert res.status_code == 201, res.text
+    assert res.json()["bank"] == "nubank"
+
+    listado = (await ac.get("/wallets/")).json()
+    assert listado[0]["bank"] == "nubank"
+
+
+@pytest.mark.asyncio
+async def test_bank_is_optional_and_comes_back_null(make_auth_client):
+    # É o estado de toda carteira criada antes desta coluna: o front cai no
+    # comportamento antigo, e nenhuma migração de dado foi necessária.
+    ac = await make_auth_client("Alice")
+    w = await make_wallet(ac)
+    assert w["bank"] is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("slug", ["Nubank", "nu bank", "nubank!", "", "x" * 21])
+async def test_rejects_a_slug_the_catalog_could_not_produce(make_auth_client, slug):
+    # O catálogo vive no frontend, então o backend não sabe QUAIS bancos
+    # existem — mas garante que o valor é um token curto e seguro, e não texto
+    # livre entrando numa coluna que a interface vai renderizar.
+    ac = await make_auth_client("Alice")
+    res = await ac.post("/wallets/", json={"name": "Conta", "bank": slug})
+    assert res.status_code == 422, res.text
+
+
+@pytest.mark.asyncio
+async def test_update_can_switch_banks(make_auth_client):
+    ac = await make_auth_client("Alice")
+    w = await make_wallet(ac)
+    res = await ac.put(f"/wallets/{w['id']}", json={"bank": "itau"})
+    assert res.status_code == 200, res.text
+    assert res.json()["bank"] == "itau"
+

--- a/frontend/src/lib/bancos.js
+++ b/frontend/src/lib/bancos.js
@@ -1,0 +1,53 @@
+/**
+ * Catálogo de bancos para o chip da carteira (issue #34).
+ *
+ * MARCA DE DUAS LETRAS, NÃO O LOGO. Reproduzir a arte dos bancos esbarra em
+ * dois direitos independentes: o art. 132 da LPI não tem exceção que cubra
+ * exibir marca de terceiro num app pago (a de citação exige "sem conotação
+ * comercial"), e o desenho em si é obra protegida por direito autoral, que no
+ * Brasil nasce com a criação. Este repositório é público, então commitar um
+ * `nubank.svg` seria redistribuir a arte para quem clonar. O nome do banco em
+ * texto é uso descritivo e continua liberado — é o desenho que fica de fora.
+ *
+ * SEM COR DE MARCA. O DESIGN.md é explícito: "não há hex solto em componente,
+ * toda cor sai de um token", e o contraste é medido sobre o vidro renderizado
+ * NOS DOIS TEMAS. Roxo do Nubank ou verde do PicPay são hex fixos: passariam
+ * num tema e reprovariam no outro. A cor do chip continua vindo da paleta do
+ * app, só que chaveada pelo slug do banco em vez do nome da carteira — assim
+ * todas as carteiras do mesmo banco ficam iguais entre si, que é o ganho de
+ * reconhecimento que importa aqui.
+ *
+ * A cor AGRUPA, não identifica: são mais bancos que cores na paleta, então dois
+ * bancos diferentes podem calhar na mesma. Quem identifica é a marca.
+ *
+ * A ordem é a de exibição no seletor, com os mais usados primeiro.
+ */
+export const BANCOS = [
+  { slug: "nubank", label: "Nubank", marca: "Nu" },
+  { slug: "itau", label: "Itaú", marca: "It" },
+  { slug: "bradesco", label: "Bradesco", marca: "Br" },
+  { slug: "bb", label: "Banco do Brasil", marca: "BB" },
+  { slug: "caixa", label: "Caixa", marca: "Cx" },
+  { slug: "santander", label: "Santander", marca: "St" },
+  { slug: "inter", label: "Inter", marca: "In" },
+  { slug: "c6", label: "C6 Bank", marca: "C6" },
+  { slug: "picpay", label: "PicPay", marca: "Pp" },
+  { slug: "mercadopago", label: "Mercado Pago", marca: "MP" },
+  // "Dinheiro" fica porque diz algo que nenhum banco diz: a carteira é física.
+  // "Outro" NÃO entra: a opção vazia do seletor já é ela, e oferecer as duas
+  // seria pedir ao usuário para escolher entre dois nomes da mesma coisa.
+  { slug: "dinheiro", label: "Dinheiro", marca: "R$" },
+];
+
+const POR_SLUG = new Map(BANCOS.map((b) => [b.slug, b]));
+
+/** O banco do slug, ou `undefined` para nulo e para slug desconhecido. */
+export function banco(slug) {
+  return slug ? POR_SLUG.get(slug) : undefined;
+}
+
+/** Opções do `<Select>`, com "" para "sem banco". */
+export const OPCOES_BANCO = [
+  { value: "", label: "Sem banco" },
+  ...BANCOS.map((b) => ({ value: b.slug, label: b.label })),
+];

--- a/frontend/src/lib/bancos.test.js
+++ b/frontend/src/lib/bancos.test.js
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+
+import { BANCOS, banco, OPCOES_BANCO } from "./bancos";
+
+describe("catálogo de bancos", () => {
+  it("não repete slug", () => {
+    // Slug repetido faria o Map descartar um dos bancos em silêncio, e o
+    // seletor mostraria duas linhas que levam ao mesmo lugar.
+    const slugs = BANCOS.map((b) => b.slug);
+    expect(new Set(slugs).size).toBe(slugs.length);
+  });
+
+  it("mantém a marca curta o bastante para caber no chip", () => {
+    // O chip tem 48px e usa text-lg. Três caracteres estouram.
+    for (const b of BANCOS) {
+      expect(b.marca.length, b.slug).toBeLessThanOrEqual(2);
+      expect(b.marca.length, b.slug).toBeGreaterThanOrEqual(1);
+    }
+  });
+
+  it("aceita o slug que o backend aceitaria", () => {
+    // Espelha o pattern de `BankSlug` (schemas/common.py). Um slug com
+    // maiúscula ou espaço passaria aqui e tomaria 422 na hora de salvar.
+    for (const b of BANCOS) expect(b.slug).toMatch(/^[a-z0-9-]+$/);
+  });
+
+  it("devolve undefined para nulo e para slug desconhecido", () => {
+    // O card chama isto com `w.bank`, que é null na maioria das carteiras.
+    expect(banco(null)).toBeUndefined();
+    expect(banco("")).toBeUndefined();
+    expect(banco("banco-que-nao-existe")).toBeUndefined();
+    expect(banco("nubank")?.marca).toBe("Nu");
+  });
+
+  it("oferece 'sem banco' como primeira opção do seletor", () => {
+    // O valor vazio é o que faz o front OMITIR `bank` no envio.
+    expect(OPCOES_BANCO[0].value).toBe("");
+    expect(OPCOES_BANCO).toHaveLength(BANCOS.length + 1);
+  });
+});

--- a/frontend/src/pages/Wallets.jsx
+++ b/frontend/src/pages/Wallets.jsx
@@ -3,11 +3,13 @@ import { Plus, Pencil, Trash2, Wallet } from "lucide-react";
 import { walletsApi } from "@/api/wallets";
 import { apiErrorMessage, formatBRL, shadcnInputCls } from "@/lib/utils";
 import { CHART_SERIES, hashIndex } from "@/lib/palette";
+import { banco, OPCOES_BANCO } from "@/lib/bancos";
 import { ConfirmDialog } from "@/components/shared/ConfirmDialog";
 import Money from "@/components/shared/Money";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { MoneyInput } from "@/components/ui/money-input";
+import { Select } from "@/components/ui/select";
 import {
   Dialog,
   DialogContent,
@@ -15,8 +17,12 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 
-// Cor do chip do ícone, determinística pelo nome da carteira (só apresentação).
-const chipColor = (name) => CHART_SERIES[hashIndex(name, CHART_SERIES.length)];
+// Cor do chip, determinística e só apresentação. Chaveada pelo BANCO quando
+// existe um, para que todas as carteiras do mesmo banco fiquem iguais entre si;
+// sem banco, cai no nome, que é como sempre foi. A paleta continua sendo a do
+// app: cor de marca seria hex fixo, e o DESIGN.md mede contraste sobre o vidro
+// nos DOIS temas — um hex passa num e reprova no outro.
+const chipColor = (chave) => CHART_SERIES[hashIndex(chave, CHART_SERIES.length)];
 
 export default function Wallets() {
   const [wallets, setWallets] = useState([]);
@@ -24,9 +30,10 @@ export default function Wallets() {
   const [editing, setEditing] = useState(null);
   const [error, setError] = useState(null);
   const [saving, setSaving] = useState(false);
-  const [form, setForm] = useState({ name: "", balance: "" });
+  const [form, setForm] = useState({ name: "", balance: "", bank: "" });
   const nomeId = useId();
   const saldoId = useId();
+  const bancoId = useId();
   // Qual botão abriu o diálogo. O Dialog é controlado por estado, sem
   // DialogTrigger, então o Base UI não tem para onde devolver o foco ao fechar
   // e o usuário de teclado caía no body.
@@ -52,16 +59,22 @@ export default function Wallets() {
     try {
       if (editing) {
         // Saldo não é editável: deriva das transações. Edita só o nome.
-        await walletsApi.update(editing.id, { name: form.name });
+        // `bank: null` seria descartado pelo `exclude_none` do backend, então
+        // "sem banco" só existe na criação. Trocar de banco funciona.
+        await walletsApi.update(editing.id, {
+          name: form.name,
+          ...(form.bank ? { bank: form.bank } : {}),
+        });
       } else {
         await walletsApi.create({
           name: form.name,
           balance: form.balance === "" ? 0 : form.balance,
+          ...(form.bank ? { bank: form.bank } : {}),
         });
       }
       setOpen(false);
       setEditing(null);
-      setForm({ name: "", balance: "" });
+      setForm({ name: "", balance: "", bank: "" });
       load();
     } catch (err) {
       setError(apiErrorMessage(err, "Não foi possível salvar a carteira."));
@@ -79,14 +92,14 @@ export default function Wallets() {
     ultimoGatilho.current = e?.currentTarget ?? null;
     setEditing(null);
     setError(null);
-    setForm({ name: "", balance: "" });
+    setForm({ name: "", balance: "", bank: "" });
     setOpen(true);
   }
 
   function openEdit(wallet, e) {
     ultimoGatilho.current = e?.currentTarget ?? null;
     setEditing(wallet);
-    setForm({ name: wallet.name, balance: wallet.balance });
+    setForm({ name: wallet.name, balance: wallet.balance, bank: wallet.bank || "" });
     setError(null);
     setOpen(true);
   }
@@ -163,6 +176,18 @@ export default function Wallets() {
                 className={shadcnInputCls}
               />
             </div>
+            <div>
+              <label htmlFor={bancoId} className="block text-xs font-medium text-content-2 mb-2">
+                Banco <span className="text-content-3">(opcional)</span>
+              </label>
+              <Select
+                id={bancoId}
+                value={form.bank}
+                placeholder="Sem banco"
+                options={OPCOES_BANCO}
+                onChange={(v) => setForm({ ...form, bank: v })}
+              />
+            </div>
             {!editing && (
               <div>
                 <label htmlFor={saldoId} className="block text-xs font-medium text-content-2 mb-2">
@@ -224,7 +249,8 @@ export default function Wallets() {
         )}
 
         {wallets.map((w) => {
-          const color = chipColor(w.name);
+          const b = banco(w.bank);
+          const color = chipColor(w.bank || w.name);
           return (
             <div
               key={w.id}
@@ -239,7 +265,7 @@ export default function Wallets() {
                     color,
                   }}
                 >
-                  {w.name?.[0]?.toUpperCase() || "?"}
+                  {b ? b.marca : w.name?.[0]?.toUpperCase() || "?"}
                 </div>
               </div>
 

--- a/frontend/src/pages/Wallets.test.jsx
+++ b/frontend/src/pages/Wallets.test.jsx
@@ -53,4 +53,60 @@ describe("Wallets", () => {
     expect(await screen.findByText("Informe um nome.")).toBeInTheDocument();
     expect(walletsApi.create).not.toHaveBeenCalled();
   });
+
+  it("mostra a marca do banco no chip, e a inicial quando não há banco", async () => {
+    walletsApi.list.mockResolvedValue({
+      data: [
+        { id: "1", name: "Conta principal", balance: "10.00", bank: "nubank" },
+        { id: "2", name: "Poupança", balance: "20.00", bank: null },
+      ],
+    });
+    render(<Wallets />);
+
+    // Com banco, a marca vence o nome: "Conta principal" mostraria "C".
+    expect(await screen.findByText("Nu")).toBeInTheDocument();
+    // Sem banco, nada muda em relação ao que já existia.
+    expect(screen.getByText("P")).toBeInTheDocument();
+  });
+
+  it("agrupa a cor pelo banco, não pelo nome", async () => {
+    // Duas carteiras do mesmo banco com nomes DIFERENTES têm de ficar com o
+    // mesmo chip. É esse o ganho de escolher um banco: reconhecer de relance.
+    //
+    // Não se afirma aqui que bancos diferentes têm cores diferentes, e a
+    // primeira versão deste teste afirmava: são 11 bancos para 9 cores na
+    // paleta, então colisão é garantida por casa dos pombos. A cor agrupa,
+    // não identifica — quem identifica é a marca de duas letras.
+    walletsApi.list.mockResolvedValue({
+      data: [
+        { id: "1", name: "Conta principal", balance: "1.00", bank: "itau" },
+        { id: "2", name: "Reserva de emergência", balance: "2.00", bank: "itau" },
+      ],
+    });
+    const { container } = render(<Wallets />);
+    await screen.findAllByText("It");
+
+    const cores = [...container.querySelectorAll("[style*='color-mix']")].map(
+      (el) => el.style.color,
+    );
+    expect(cores).toHaveLength(2);
+    expect(cores[0]).toBe(cores[1]);
+  });
+
+  it("omite `bank` quando nenhum banco foi escolhido", async () => {
+    // O backend valida o slug com `min_length=1` e um pattern, então mandar
+    // `bank: ""` seria 422. Omitir é o que faz "sem banco" funcionar.
+    walletsApi.create.mockResolvedValue({ data: {} });
+    render(<Wallets />);
+    fireEvent.click(await screen.findByRole("button", { name: /nova carteira/i }));
+    await screen.findByRole("dialog");
+
+    fireEvent.change(await screen.findByLabelText("Nome da carteira"), {
+      target: { value: "Carteira" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /criar carteira/i }));
+
+    await waitFor(() => expect(walletsApi.create).toHaveBeenCalled());
+    expect(walletsApi.create.mock.calls[0][0]).not.toHaveProperty("bank");
+  });
 });


### PR DESCRIPTION
Closes #34.

## The logos are not in here, and that was the whole decision

The ticket assumed local SVGs of each bank. Researched and recorded in the issue: **two independent rights would have to be cleared, and this repository is public.**

Art. 132 of the LPI has no exception that covers a paid app displaying a third party's figurative mark. The one that sounds closest, citation, is conditioned on being *"sem conotação comercial"*, which a subscription product is not. Separately, a logo is artwork, and copyright in Brazil exists from creation with no registration; committing `nubank.svg` would republish that artwork to everyone who clones.

What survives is most of what the feature wanted: **the bank's name as text is descriptive use and stays**, and a two-letter mark is our own drawing. The user still sees "Nubank" and recognises it.

## No brand colours either, and the design system decided that, not me

The obvious next move was brand colour on the chip. `DESIGN.md` closes it:

> Não há hex solto em componente. Toda cor sai de um token.

and requires contrast measured **over the rendered glass, in both themes**, with `PRODUCT.md` adding that a token's value in isolation is not proof. A brand colour is a fixed hex with no token and no theme variant: Nubank's purple or PicPay's green would pass in one theme and fail in the other. Add Design Principle 2 (*"um brilho só… nunca decoração"*) and the *"banco digital que vende"* anti-reference, and a rainbow of bank colours is precisely what the system was written to prevent.

So the bank sets **the mark**, and the colour keeps coming from the app's own palette, only keyed by the bank slug instead of the wallet name. Two wallets at the same bank now match each other, which is the recognition that actually matters, with no new hex and no contrast to re-prove.

## The test corrected me, and the correction is in the code

My first version asserted that different banks get different colours. **Eleven banks, nine palette slots: collisions are guaranteed by the pigeonhole principle**, and `itau` and `c6` landed on the same one. The test now asserts only what is true, and the catalog says it out loud: *the colour groups, it does not identify.* The mark identifies.

## One option removed from the ticket's own list

The starting list ended with "cash, other". **"Outro" is not here**: the select's empty option already is it, and offering both asks the user to choose between two names for the same thing. "Dinheiro" stays, because it says something no bank says: the wallet is physical.

## Shape

The **catalog lives in the frontend** — label, mark and order are presentation, and keeping the list in the backend would mean deploying the API to add a bank. The backend stores a slug and guarantees only that it is a short, safe token: `^[a-z0-9-]+$`, max 20. It has no opinion about which banks exist, and the tests say so.

The migration is **purely additive**, nullable, no backfill. `NULL` is every wallet that already exists, and the card falls back to the old behaviour for them without a single `UPDATE`.

One limitation written down rather than left to be discovered: the update route applies `exclude_none`, so `bank: null` does not clear a bank. Switching works. Clearing is not a real case now that the catalog carries "Dinheiro" and the select carries "Sem banco".

## Verification

- 163 frontend tests (+8), 309 backend tests (+4), lint and build clean, `alembic check` reports no drift.
- The frontend test that matters most asserts `bank` is **omitted**, not sent empty, when nothing is chosen: `BankSlug` has `min_length=1` and a pattern, so `bank: ""` would be a 422, and "Sem banco" would silently fail to save.
- A backend test rejects five slugs the catalog could never produce, including an over-length one.

## Noted, not fixed

`DESIGN.md` documents `--chart-1..9` as *"paleta categórica, exclusiva de data-viz"*, but the wallet chip has used that ramp since before this ticket. This change neither introduces nor widens that: it swaps which key feeds the same lookup. Worth deciding separately whether the doc is stale or the chip is off-system.
