### PR TITLE
feat(auth): password recovery by email

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,5 +46,17 @@ STRIPE_PRICE_ID=
 # CORS_ORIGINS, que é uma lista.
 APP_BASE_URL=http://localhost:5173
 
+# Brevo — e-mail transacional (#36). Vazio = recuperação de senha DESLIGADA, e
+# o /auth/forgot-password responde 503 em vez de fingir que enviou. A chave vai
+# aqui e no painel da Railway, nunca no git.
+BREVO_API_KEY=
+# Remetente. Precisa ser um endereço do domínio autenticado no Brevo (SPF/DKIM),
+# senão o e-mail sai como @brevosend.com ou cai em spam.
+BREVO_SENDER_EMAIL=nao-responda@norby.com.br
+BREVO_SENDER_NAME=Norby
+# Validade do link. Curta de propósito: ele chega por e-mail, e caixa de e-mail
+# comprometida é exatamente o vetor que este token abre.
+PASSWORD_RESET_EXPIRE_MINUTES=30
+
 # Paywall da v2 (ADR 0002). Desligado = app se comporta como antes.
 PAYWALL_ENABLED=false

--- a/backend/alembic/versions/205f60ec5dbf_password_reset_tokens.py
+++ b/backend/alembic/versions/205f60ec5dbf_password_reset_tokens.py
@@ -1,0 +1,48 @@
+"""password reset tokens
+
+Issue #36. Tabela nova, nada existente e tocado.
+
+Guarda o SHA256 do token, nunca o token cru — ele viaja por e-mail e o banco
+nao precisa dele para validar. Repare que o autogenerate emitiu UM indice
+unico em `token_hash`, e nao o par constraint+indice que `refresh_tokens`
+carregava desde 2026: e o conserto do #105 valendo no primeiro uso, porque
+agora o modelo e a migration concordam sobre o que `unique=True, index=True`
+significa.
+
+Revision ID: 205f60ec5dbf
+Revises: fe1092dba7da
+Create Date: 2026-09-05 22:14:01.580751
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '205f60ec5dbf'
+down_revision: Union[str, None] = 'fe1092dba7da'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table('password_reset_tokens',
+    sa.Column('id', sa.UUID(), nullable=False),
+    sa.Column('user_id', sa.UUID(), nullable=False),
+    sa.Column('token_hash', sa.String(length=64), nullable=False),
+    sa.Column('expires_at', sa.DateTime(timezone=True), nullable=False),
+    sa.Column('used_at', sa.DateTime(timezone=True), nullable=True),
+    sa.Column('created_at', sa.DateTime(timezone=True), nullable=False),
+    sa.ForeignKeyConstraint(['user_id'], ['users.id'], ondelete='CASCADE'),
+    sa.PrimaryKeyConstraint('id')
+    )
+    op.create_index(op.f('ix_password_reset_tokens_token_hash'), 'password_reset_tokens', ['token_hash'], unique=True)
+    op.create_index(op.f('ix_password_reset_tokens_user_id'), 'password_reset_tokens', ['user_id'], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index(op.f('ix_password_reset_tokens_user_id'), table_name='password_reset_tokens')
+    op.drop_index(op.f('ix_password_reset_tokens_token_hash'), table_name='password_reset_tokens')
+    op.drop_table('password_reset_tokens')

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -38,6 +38,17 @@ class Settings(BaseSettings):
     # como destino de redirect seria adivinhação.
     app_base_url: str = "http://localhost:5173"
 
+    # Brevo, e-mail transacional (#36). Mesmo raciocínio do Stripe: default ""
+    # para o merge não derrubar produção antes da variável existir no Railway.
+    # Vazio = recuperação de senha desligada, e o endpoint responde 503 em vez
+    # de fingir que enviou um e-mail que ninguém vai receber.
+    brevo_api_key: str = ""
+    brevo_sender_email: str = "nao-responda@norby.com.br"
+    brevo_sender_name: str = "Norby"
+    # Validade do link de recuperação. Curta de propósito: o link chega por
+    # e-mail, e caixa de e-mail comprometida é o vetor que este token abre.
+    password_reset_expire_minutes: int = 30
+
     # Flag de rollout do paywall (ADR 0002). Default DESLIGADO: o merge não muda
     # nada em produção, e o paywall acende por variável de ambiente quando o
     # dono decidir. Lido SÓ dentro dos helpers de enforcement — um `if` num

--- a/backend/app/limiter.py
+++ b/backend/app/limiter.py
@@ -58,3 +58,23 @@ def refresh_token_key(request: Request) -> str:
     if not token:
         return get_remote_address(request)
     return hashlib.sha256(token.encode()).hexdigest()
+
+
+def reset_email_key(request: Request) -> str:
+    """Chave de rate limit para POST /auth/forgot-password: hash do e-mail.
+
+    Pelo IP não serve, pela mesma razão do logout: atrás do proxy do Railway
+    todo mundo divide o balde. Chavear pelo e-mail faz o teto proteger a CAIXA
+    DE ENTRADA de quem está sendo alvo — sem isso, alguém dispara o formulário
+    contra o mesmo endereço e transforma o Norby em ferramenta de mailbomb.
+
+    O endereço cru nunca vira chave: só o sha256 dele, para o balde do slowapi
+    (em memória, mas ainda assim) não virar uma lista de e-mails cadastrados.
+
+    O router carimba request.state.reset_email numa dependency que roda antes
+    deste decorator, porque o key_func é síncrono e não vê o corpo parseado.
+    """
+    email = getattr(request.state, "reset_email", "")
+    if not email:
+        return get_remote_address(request)
+    return hashlib.sha256(email.lower().encode()).hexdigest()

--- a/backend/app/models/sql_models.py
+++ b/backend/app/models/sql_models.py
@@ -128,6 +128,30 @@ class RefreshToken(Base):
 
     user: Mapped["User"] = relationship("User", back_populates="refresh_tokens")
 
+class PasswordResetToken(Base):
+    """Token de recuperação de senha (#36).
+
+    Mesma forma do RefreshToken e pelo mesmo motivo: o token cru vai por e-mail
+    e NUNCA é gravado, só o sha256 dele. Vazamento do banco não entrega poder de
+    redefinir senha de ninguém.
+
+    `used_at` em vez de deletar a linha: uso único fica sendo um fato registrado,
+    e um token reapresentado é distinguível de um token que nunca existiu — o
+    que importa para investigar, e é a mesma escolha que `revoked` no refresh.
+    """
+
+    __tablename__ = "password_reset_tokens"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("users.id", ondelete="CASCADE"), index=True
+    )
+    token_hash: Mapped[str] = mapped_column(String(64), unique=True, nullable=False, index=True)
+    expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    used_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utcnow)
+
+
 class LoginThrottle(Base):
     """Atraso progressivo por conta (issue #22), independente de IP.
 

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -2,27 +2,31 @@ import asyncio
 import logging
 from datetime import datetime, timezone
 
-from fastapi import APIRouter, Depends, HTTPException, status, Request
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, status, Request
 from fastapi.encoders import jsonable_encoder
 from fastapi.responses import JSONResponse, Response
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import func, select
+from app.config import get_settings
 from app.dependencies import get_db, get_current_user
-from app.limiter import limiter, user_key, refresh_token_key
+from app.limiter import limiter, user_key, refresh_token_key, reset_email_key
 from app.models.sql_models import User
 from app.schemas.user import (
     UserRegister, UserLogin, UserUpdate, Token, TokenPair, RefreshRequest,
-    DeleteAccountRequest, UserResponse,
+    DeleteAccountRequest, UserResponse, ForgotPassword, ResetPassword,
 )
 from app.services.auth_service import (
     hash_password, verify_password, verify_and_upgrade, create_access_token,
     create_refresh_token, rotate_refresh_token, revoke_refresh_token,
-    _DUMMY_HASH,
+    create_password_reset, reset_password, _DUMMY_HASH,
 )
 from app.services.account_service import delete_account, export_data
 from app.services.photo_service import MAX_BYTES, PhotoInvalid, PhotoTooLarge, processar_foto
 from app.services.billing_service import GatewayCancelFailed
+from app.services.email_service import (
+    EmailFailed, EmailNotConfigured, enviar_email, html_recuperacao,
+)
 from app.services.plan_service import AI_TRIAL
 from app.services.throttle_service import check_throttle, record_failure, record_success
 
@@ -403,3 +407,91 @@ async def delete_my_account(
                 "excluído. Tente novamente em alguns minutos."
             ),
         )
+
+
+# --- Recuperação de senha (issue #36) ---------------------------------------
+
+ROTA_REDEFINIR = "/redefinir-senha"
+
+
+async def _forgot_body(request: Request, payload: ForgotPassword) -> ForgotPassword:
+    # Carimba o e-mail antes do decorator do slowapi rodar — mesmo truque do
+    # _refresh_body, pelo mesmo motivo: o key_func é síncrono e não vê o corpo.
+    request.state.reset_email = payload.email
+    return payload
+
+
+async def _mandar_link(email: str, link: str) -> None:
+    """Roda DEPOIS da resposta, via BackgroundTasks. Não é otimização.
+
+    Enviando dentro da requisição, e-mail existente levaria o tempo do POST ao
+    Brevo e e-mail inexistente responderia na hora. Essa diferença é um oráculo
+    de enumeração de conta tão bom quanto uma mensagem diferente — só que
+    medido no relógio em vez de lido na tela. Respondendo antes de enviar, os
+    dois casos custam o mesmo.
+    """
+    try:
+        await enviar_email(
+            para=email,
+            assunto="Redefinir sua senha do Norby",
+            html=html_recuperacao(link),
+        )
+    except (EmailFailed, EmailNotConfigured):
+        # Já logado no service, e sem o endereço junto. Aqui não há para quem
+        # reclamar: a resposta já foi entregue, e tem de ser a mesma sempre.
+        pass
+
+
+@router.post("/forgot-password", status_code=status.HTTP_202_ACCEPTED)
+# Chave pelo e-mail, não pelo IP: atrás do proxy o balde por IP é compartilhado
+# por todo mundo (ver "Rate limit atrás do proxy" no AGENTS.md), e o que este
+# teto protege é a CAIXA DE ENTRADA do alvo. O segundo limite, por IP, é o
+# freio de flood — um e-mail diferente a cada chamada nunca esgota o próprio
+# balde, a mesma lição que o logout aprendeu no fix round 1.
+@limiter.limit("60/minute")
+@limiter.limit("3/hour", key_func=reset_email_key)
+async def forgot_password(
+    request: Request,
+    background: BackgroundTasks,
+    payload: ForgotPassword = Depends(_forgot_body),
+    db: AsyncSession = Depends(get_db),
+):
+    """Sempre 202, exista o e-mail ou não.
+
+    A resposta é idêntica de propósito: um 404 para e-mail desconhecido
+    transformaria esta rota num verificador de quem tem conta no Norby, que é
+    a mesma enumeração que o login evita com o `_DUMMY_HASH`.
+    """
+    if not get_settings().brevo_api_key:
+        # Recuperação não provisionada. Recusar alto é melhor que responder 202
+        # e nunca mandar nada: aqui não há atacante para proteger, há um dono
+        # que precisa saber que a variável não existe.
+        raise HTTPException(status_code=503, detail="Recuperação de senha indisponível")
+
+    user = await db.scalar(select(User).where(User.email == payload.email))
+    if user is not None:
+        raw = await create_password_reset(str(user.id), db)
+        base = get_settings().app_base_url.rstrip("/")
+        background.add_task(_mandar_link, user.email, f"{base}{ROTA_REDEFINIR}?token={raw}")
+
+    return {"detail": "Se este e-mail tiver conta, o link de redefinição chegou nele."}
+
+
+@router.post("/reset-password", status_code=status.HTTP_204_NO_CONTENT)
+# Sem chave por e-mail aqui: quem apresenta o token não informa e-mail nenhum.
+# O teto é contra força bruta no token, que tem 48 bytes de entropia e não cai
+# por tentativa — o limite existe para o custo, não para a segurança.
+@limiter.limit("20/minute")
+async def reset_password_route(
+    request: Request,
+    payload: ResetPassword,
+    db: AsyncSession = Depends(get_db),
+):
+    """Token inválido, expirado ou já usado respondem igual: 400.
+
+    Distinguir "expirou" de "não existe" diria a quem tem um token roubado se
+    ele um dia foi válido.
+    """
+    if not await reset_password(payload.token, payload.new_password, db):
+        raise HTTPException(status_code=400, detail="Link inválido ou expirado")
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/app/schemas/common.py
+++ b/backend/app/schemas/common.py
@@ -3,10 +3,11 @@
 Definidos num lugar só para não repetir `Field(...)` em quatro arquivos e não
 deixar um deles ficar para trás quando um limite mudar.
 """
+import re
 from decimal import Decimal
 from typing import Annotated
 
-from pydantic import Field
+from pydantic import AfterValidator, Field
 
 # Maior valor que cabe em Numeric(15,2): 13 dígitos inteiros + 2 decimais.
 MAX_MONEY = Decimal("9999999999999.99")
@@ -34,3 +35,22 @@ LongText = Annotated[str, Field(max_length=500)]
 # deploy do backend para acrescentar um banco, e o backend nao tem opiniao sobre
 # quais existem. O que ele garante e que o valor e um token curto e seguro.
 BankSlug = Annotated[str, Field(min_length=1, max_length=20, pattern=r"^[a-z0-9-]+$")]
+
+def _senha_aceitavel(v: str) -> str:
+    # Regra mínima: pelo menos uma letra e um número (o min_length já garante 8+).
+    if not re.search(r"[A-Za-z]", v) or not re.search(r"\d", v):
+        raise ValueError(
+            "A senha deve ter ao menos 8 caracteres, incluindo uma letra e um número"
+        )
+    # O bcrypt trunca em 72 BYTES e ignora o resto sem avisar. O max_length do
+    # Field conta caracteres, e um acento ocupa mais de um byte.
+    if len(v.encode("utf-8")) > 72:
+        raise ValueError("A senha deve ter no máximo 72 bytes (acentos contam 2)")
+    return v
+
+
+# Senha nova, no cadastro E na recuperação (#36). Tipo compartilhado de
+# propósito: com as regras copiadas em dois schemas, a redefinição acabaria
+# aceitando uma senha que o cadastro recusa, e ninguém notaria — o caminho que
+# valida menos é justamente o que um atacante escolhe.
+StrongPassword = Annotated[str, Field(min_length=8, max_length=128), AfterValidator(_senha_aceitavel)]

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -1,36 +1,17 @@
-import re
-
 from pydantic import BaseModel, ConfigDict, EmailStr, Field, field_validator, model_validator
 from uuid import UUID
 from datetime import datetime
 
-from app.schemas.common import PersonName
+from app.schemas.common import PersonName, StrongPassword
 from app.services.plan_service import ai_gate_open, wallet_cap_active
 
 class UserRegister(BaseModel):
     name: PersonName
     email: EmailStr
-    password: str = Field(min_length=8, max_length=128)
+    password: StrongPassword
     # LGPD: aceite explícito, registrado no servidor. O frontend já pedia o
     # checkbox, mas o valor não chegava aqui e nada era persistido.
     accept_privacy: bool
-
-    @field_validator("password")
-    @classmethod
-    def password_forte(cls, v: str) -> str:
-        # Regra mínima: pelo menos uma letra e um número (o min_length já garante 8+)
-        if not re.search(r"[A-Za-z]", v) or not re.search(r"\d", v):
-            raise ValueError("A senha deve ter ao menos 8 caracteres, incluindo uma letra e um número")
-        return v
-
-    @field_validator("password")
-    @classmethod
-    def cabe_no_bcrypt(cls, v: str) -> str:
-        # O bcrypt trunca em 72 bytes e ignora o resto sem avisar. O max_length
-        # do Field conta caracteres, enquanto um acento ocupa mais de um byte.
-        if len(v.encode("utf-8")) > 72:
-            raise ValueError("A senha deve ter no máximo 72 bytes (acentos contam 2)")
-        return v
 
     @field_validator("accept_privacy")
     @classmethod
@@ -130,3 +111,13 @@ class DeleteAccountRequest(BaseModel):
     # Step-up auth: exclusão é irreversível, então não basta ter o access token
     # — é preciso provar posse da senha atual.
     password: str = Field(min_length=1, max_length=128)
+
+
+class ForgotPassword(BaseModel):
+    email: EmailStr
+
+
+class ResetPassword(BaseModel):
+    # 128 cobre o token com folga; o piso evita gastar consulta com string vazia.
+    token: str = Field(min_length=16, max_length=128)
+    new_password: StrongPassword

--- a/backend/app/services/auth_service.py
+++ b/backend/app/services/auth_service.py
@@ -7,7 +7,7 @@ from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import get_settings
-from app.models.sql_models import RefreshToken, User
+from app.models.sql_models import PasswordResetToken, RefreshToken, User
 # Reexportados de propósito: todo o app já importa `hash_password` e
 # `verify_password` daqui, e a troca do passlib (#102) não precisa vazar para
 # os chamadores. Quem quiser o detalhe do esquema lê o password_service.
@@ -136,3 +136,79 @@ async def revoke_refresh_token(raw: str, db: AsyncSession) -> None:
 
     record.revoked = True
     await db.commit()
+
+
+# --- Recuperação de senha (issue #36) ---------------------------------------
+# Mesma forma dos refresh tokens acima, e de propósito: token opaco, só o
+# sha256 no banco, uso único. O que muda é o prazo, muito mais curto, porque
+# este chega por e-mail e caixa comprometida é o vetor que ele abre.
+
+RESET_TTL = timedelta(minutes=settings.password_reset_expire_minutes)
+
+
+async def create_password_reset(user_id: str, db: AsyncSession) -> str:
+    """Emite um token de recuperação e devolve o valor CRU, para o e-mail."""
+    raw = secrets.token_urlsafe(48)
+    db.add(
+        PasswordResetToken(
+            user_id=user_id,
+            token_hash=_hash_token(raw),
+            expires_at=datetime.now(timezone.utc) + RESET_TTL,
+        )
+    )
+    await db.commit()
+    return raw
+
+
+async def reset_password(raw: str, nova_senha: str, db: AsyncSession) -> bool:
+    """Consome o token e troca a senha. Devolve False para token inválido.
+
+    Tudo numa transação só. O `FOR UPDATE` serializa duas apresentações do
+    mesmo token: sem ele, duas requisições simultâneas leriam `used_at` nulo e
+    as duas trocariam a senha — a segunda sobrescrevendo a primeira, o que
+    deixaria a vítima com a senha do atacante.
+
+    Ao trocar a senha, TODA sessão do usuário cai. Quem redefine senha ou
+    esqueceu a antiga ou desconfia que alguém a tem; nos dois casos manter um
+    refresh token vivo de sete dias anularia o motivo de ter redefinido.
+    """
+    result = await db.execute(
+        select(PasswordResetToken)
+        .where(PasswordResetToken.token_hash == _hash_token(raw))
+        .with_for_update()
+    )
+    registro = result.scalar_one_or_none()
+    if registro is None:
+        return False
+
+    # Token já usado e token expirado respondem igual para fora, mas só o
+    # primeiro é sinal: alguém está reapresentando um link que já valeu.
+    if registro.used_at is not None:
+        return False
+    if registro.expires_at <= datetime.now(timezone.utc):
+        return False
+
+    user = await db.get(User, registro.user_id)
+    if user is None:
+        return False
+
+    registro.used_at = datetime.now(timezone.utc)
+    user.password_hash = hash_password(nova_senha)
+
+    # Os OUTROS links pendentes desta pessoa morrem junto. Pedir três e-mails e
+    # usar um não pode deixar dois links vivos numa caixa de entrada.
+    await db.execute(
+        update(PasswordResetToken)
+        .where(
+            PasswordResetToken.user_id == user.id,
+            PasswordResetToken.used_at.is_(None),
+        )
+        .values(used_at=datetime.now(timezone.utc))
+    )
+    await db.execute(
+        update(RefreshToken)
+        .where(RefreshToken.user_id == user.id, RefreshToken.revoked.is_(False))
+        .values(revoked=True)
+    )
+    await db.commit()
+    return True

--- a/backend/app/services/email_service.py
+++ b/backend/app/services/email_service.py
@@ -1,0 +1,99 @@
+"""Envio de e-mail transacional pela API v3 do Brevo (issue #36).
+
+Por que a API HTTP e não SMTP: o `httpx` já vem no lock (o SDK do Stripe o
+traz), então esta rota custa ZERO dependência nova, enquanto SMTP exigiria
+`aiosmtplib` ou o `smtplib` bloqueante dentro de uma thread — e chamada
+bloqueante no event loop é justamente o que o billing evitou ao usar as
+versões `_async` do SDK. De quebra a API devolve um `messageId`, que torna um
+e-mail não entregue diagnosticável.
+
+Sem template do Brevo, e isso é decisão: o corpo do e-mail de recuperação
+precisa casar com o formato do link que o token valida. Deixar esse texto fora
+do repositório colocaria a única peça que precisa concordar com o código num
+lugar onde nenhum teste alcança.
+
+`enviar_email` é o SEAM: é ela que os testes stubam, do mesmo jeito que
+`ai_service._gerar_json`. Nenhum teste sai para a rede.
+"""
+
+import logging
+
+import httpx
+
+from app.config import get_settings
+
+logger = logging.getLogger("norby.email")
+
+API = "https://api.brevo.com/v3/smtp/email"
+TIMEOUT = 10.0
+
+
+class EmailNotConfigured(Exception):
+    """Sem `BREVO_API_KEY`. O router traduz para 503."""
+
+
+class EmailFailed(Exception):
+    """O Brevo recusou ou não respondeu."""
+
+
+async def enviar_email(*, para: str, assunto: str, html: str) -> str:
+    """Envia e devolve o `messageId`. Levanta em vez de devolver falso.
+
+    Quem chama decide o que fazer com a falha; aqui não se engole erro, porque
+    "o e-mail não chegou" é indistinguível de "o e-mail nunca foi tentado" para
+    quem está do lado de fora esperando o link.
+    """
+    settings = get_settings()
+    if not settings.brevo_api_key:
+        raise EmailNotConfigured()
+
+    corpo = {
+        "sender": {
+            "email": settings.brevo_sender_email,
+            "name": settings.brevo_sender_name,
+        },
+        "to": [{"email": para}],
+        "subject": assunto,
+        "htmlContent": html,
+    }
+
+    try:
+        async with httpx.AsyncClient(timeout=TIMEOUT) as cliente:
+            resposta = await cliente.post(
+                API,
+                json=corpo,
+                headers={
+                    "api-key": settings.brevo_api_key,
+                    "accept": "application/json",
+                    "content-type": "application/json",
+                },
+            )
+        resposta.raise_for_status()
+    except Exception as erro:  # noqa: BLE001 — rede, credencial ou 4xx do Brevo
+        # O endereço NÃO entra no log: um log de erro que lista e-mails de quem
+        # pediu recuperação é a mesma enumeração de conta que a rota evita.
+        logger.error("brevo: falha ao enviar '%s': %s", assunto, erro)
+        raise EmailFailed(str(erro)) from erro
+
+    return (resposta.json() or {}).get("messageId", "")
+
+
+def html_recuperacao(link: str) -> str:
+    """Corpo do e-mail de recuperação.
+
+    Texto curto de propósito. E-mail de recuperação é lido com pressa, muitas
+    vezes no celular, por alguém já irritado por não conseguir entrar: cada
+    frase a mais é uma chance de a pessoa não achar o botão.
+
+    O prazo aparece porque um link que morre calado parece um link quebrado, e
+    a linha final existe porque quem NÃO pediu precisa saber que não há nada a
+    fazer — sem ela, o e-mail assusta em vez de informar.
+    """
+    return f"""\
+<div style="font-family:system-ui,-apple-system,Segoe UI,sans-serif;color:#1a1a1a;line-height:1.6">
+  <p>Você pediu para redefinir sua senha do Norby.</p>
+  <p><a href="{link}" style="display:inline-block;padding:12px 20px;background:#0b5c73;color:#fff;text-decoration:none;border-radius:8px">Redefinir minha senha</a></p>
+  <p style="font-size:13px;color:#555">Ou copie este endereço: {link}</p>
+  <p style="font-size:13px;color:#555">O link vale por 30 minutos e só pode ser usado uma vez.</p>
+  <p style="font-size:13px;color:#555">Se não foi você que pediu, ignore este e-mail: sua senha continua a mesma.</p>
+</div>"""

--- a/backend/app/services/email_service.py
+++ b/backend/app/services/email_service.py
@@ -81,19 +81,31 @@ async def enviar_email(*, para: str, assunto: str, html: str) -> str:
 def html_recuperacao(link: str) -> str:
     """Corpo do e-mail de recuperação.
 
-    Texto curto de propósito. E-mail de recuperação é lido com pressa, muitas
-    vezes no celular, por alguém já irritado por não conseguir entrar: cada
-    frase a mais é uma chance de a pessoa não achar o botão.
+    ESCRITO PARA NÃO PARECER MARKETING, e isso foi medido, não suposto: a
+    primeira versão tinha um botão azul com padding e borda arredondada, mais
+    uma segunda linha repetindo a URL, e o Gmail entregou em PROMOÇÕES. Para
+    recuperação de senha isso é quase tão ruim quanto spam — quem está trancado
+    para fora não procura naquela aba.
 
-    O prazo aparece porque um link que morre calado parece um link quebrado, e
-    a linha final existe porque quem NÃO pediu precisa saber que não há nada a
-    fazer — sem ela, o e-mail assusta em vez de informar.
+    O que mudou e por quê:
+
+    - UM link, em texto, e não um botão. Botão colorido é sinal de campanha; um
+      link inline é sinal de correspondência.
+    - A URL aparece por extenso, então a linha "ou copie este endereço" saiu.
+      Ela dobrava a contagem de links sem acrescentar nada.
+    - Sem cor, sem imagem, sem CSS além do mínimo. Marcação leve pesa a favor.
+
+    O que NÃO dá para consertar aqui: o Brevo injeta pixel de abertura e
+    reescreve os links para rastrear clique, e isso não é desligável por
+    mensagem na API. É o sinal de promoção que sobra, e o preço da plataforma.
+
+    Texto curto de propósito. E-mail de recuperação é lido com pressa, muitas
+    vezes no celular, por alguém já irritado por não conseguir entrar.
     """
-    return f"""\
-<div style="font-family:system-ui,-apple-system,Segoe UI,sans-serif;color:#1a1a1a;line-height:1.6">
+    return f"""<div style="font-family:system-ui,-apple-system,Segoe UI,sans-serif;line-height:1.6">
   <p>Você pediu para redefinir sua senha do Norby.</p>
-  <p><a href="{link}" style="display:inline-block;padding:12px 20px;background:#0b5c73;color:#fff;text-decoration:none;border-radius:8px">Redefinir minha senha</a></p>
-  <p style="font-size:13px;color:#555">Ou copie este endereço: {link}</p>
-  <p style="font-size:13px;color:#555">O link vale por 30 minutos e só pode ser usado uma vez.</p>
-  <p style="font-size:13px;color:#555">Se não foi você que pediu, ignore este e-mail: sua senha continua a mesma.</p>
+  <p>Abra este endereço para criar uma nova senha:</p>
+  <p><a href="{link}">{link}</a></p>
+  <p>O link vale por 30 minutos e só pode ser usado uma vez.</p>
+  <p>Se não foi você que pediu, ignore este e-mail: sua senha continua a mesma.</p>
 </div>"""

--- a/backend/tests/test_password_reset.py
+++ b/backend/tests/test_password_reset.py
@@ -1,0 +1,248 @@
+"""Recuperação de senha (issue #36).
+
+O que esta rota tem de perigoso não é trocar a senha: é que ela recebe um
+e-mail de quem NÃO está autenticado. Então metade dos testes aqui é sobre o
+que ela se recusa a contar — se o endereço existe, se o token já valeu, se
+expirou — e a outra metade é sobre o token ser realmente de uso único.
+"""
+
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import select
+
+import app.routers.auth as auth_router
+from app.models.sql_models import PasswordResetToken, RefreshToken, User
+from app.services.auth_service import _hash_token
+
+
+@pytest.fixture(autouse=True)
+def brevo_configurado(monkeypatch):
+    # Sem chave o endpoint responde 503 (testado à parte), então a suíte
+    # inteira precisa da recuperação ligada.
+    from app.config import get_settings
+
+    settings = get_settings()
+    antes = settings.brevo_api_key
+    settings.brevo_api_key = "xkeysib-teste"
+    yield settings
+    settings.brevo_api_key = antes
+
+
+@pytest.fixture
+def enviados(monkeypatch):
+    """Substitui o único ponto de saída para a rede e guarda o que foi enviado."""
+    caixa = []
+
+    async def _fake(*, para, assunto, html):
+        caixa.append({"para": para, "assunto": assunto, "html": html})
+        return "msg-1"
+
+    monkeypatch.setattr(auth_router, "enviar_email", _fake)
+    return caixa
+
+
+async def registrar(client, senha="secret123"):
+    email = f"p_{uuid.uuid4().hex[:8]}@test.com"
+    res = await client.post(
+        "/auth/register",
+        json={"name": "Ana Silva", "email": email, "password": senha, "accept_privacy": True},
+    )
+    assert res.status_code == 201, res.text
+    return email, res.json()
+
+
+def link_do(caixa):
+    """Extrai o token do e-mail, que é como a pessoa real o obtém."""
+    html = caixa[-1]["html"]
+    return html.split("?token=")[1].split('"')[0]
+
+
+# --- O que a rota se recusa a contar ----------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_answers_the_same_for_an_unknown_email(client, enviados):
+    conhecido, _ = await registrar(client)
+
+    a = await client.post("/auth/forgot-password", json={"email": conhecido})
+    b = await client.post("/auth/forgot-password", json={"email": "ninguem@test.com"})
+
+    # Corpo e status idênticos: distinguir aqui seria um verificador de quem
+    # tem conta no Norby, a mesma enumeração que o login evita.
+    assert a.status_code == b.status_code == 202
+    assert a.json() == b.json()
+
+
+@pytest.mark.asyncio
+async def test_sends_nothing_for_an_unknown_email(client, enviados):
+    # A resposta é igual, mas o e-mail não sai: mandar "alguém pediu sua senha"
+    # para um endereço sem conta seria usar o Norby como mailbomb.
+    await client.post("/auth/forgot-password", json={"email": "ninguem@test.com"})
+    assert enviados == []
+
+
+@pytest.mark.asyncio
+async def test_a_used_and_an_expired_token_answer_the_same(client, enviados, db_session):
+    email, _ = await registrar(client)
+    await client.post("/auth/forgot-password", json={"email": email})
+    token = link_do(enviados)
+
+    primeira = await client.post(
+        "/auth/reset-password", json={"token": token, "new_password": "novasenha1"}
+    )
+    assert primeira.status_code == 204
+
+    # Reapresentar o mesmo link não pode dizer "este já foi usado".
+    segunda = await client.post(
+        "/auth/reset-password", json={"token": token, "new_password": "outrasenha1"}
+    )
+    inexistente = await client.post(
+        "/auth/reset-password", json={"token": "z" * 40, "new_password": "outrasenha1"}
+    )
+    assert segunda.status_code == inexistente.status_code == 400
+    assert segunda.json() == inexistente.json()
+
+
+# --- Uso único e prazo -------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_the_password_actually_changes(client, enviados):
+    email, _ = await registrar(client, senha="secret123")
+    await client.post("/auth/forgot-password", json={"email": email})
+
+    res = await client.post(
+        "/auth/reset-password",
+        json={"token": link_do(enviados), "new_password": "novasenha1"},
+    )
+    assert res.status_code == 204
+
+    velha = await client.post("/auth/login", json={"email": email, "password": "secret123"})
+    nova = await client.post("/auth/login", json={"email": email, "password": "novasenha1"})
+    assert velha.status_code == 401
+    assert nova.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_reset_revokes_every_session(client, enviados, db_session):
+    email, tokens = await registrar(client)
+    await client.post("/auth/forgot-password", json={"email": email})
+
+    await client.post(
+        "/auth/reset-password",
+        json={"token": link_do(enviados), "new_password": "novasenha1"},
+    )
+
+    # Quem redefine ou esqueceu a senha ou desconfia que alguém a tem. Nos dois
+    # casos, um refresh vivo de 7 dias anularia o motivo de ter redefinido.
+    usado = await client.post(
+        "/auth/refresh", json={"refresh_token": tokens["refresh_token"]}
+    )
+    assert usado.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_using_one_link_kills_the_other_pending_ones(client, enviados, db_session):
+    email, _ = await registrar(client)
+    await client.post("/auth/forgot-password", json={"email": email})
+    primeiro = link_do(enviados)
+    await client.post("/auth/forgot-password", json={"email": email})
+    segundo = link_do(enviados)
+    assert primeiro != segundo
+
+    assert (
+        await client.post(
+            "/auth/reset-password", json={"token": segundo, "new_password": "novasenha1"}
+        )
+    ).status_code == 204
+
+    # Pedir dois e-mails e usar um não pode deixar o outro vivo na caixa.
+    res = await client.post(
+        "/auth/reset-password", json={"token": primeiro, "new_password": "terceira123"}
+    )
+    assert res.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_an_expired_token_is_refused(client, enviados, db_session):
+    email, _ = await registrar(client)
+    user = await db_session.scalar(select(User).where(User.email == email))
+
+    cru = "expirado-" + uuid.uuid4().hex
+    db_session.add(
+        PasswordResetToken(
+            user_id=user.id,
+            token_hash=_hash_token(cru),
+            expires_at=datetime.now(timezone.utc) - timedelta(seconds=1),
+        )
+    )
+    await db_session.commit()
+
+    res = await client.post(
+        "/auth/reset-password", json={"token": cru, "new_password": "novasenha1"}
+    )
+    assert res.status_code == 400
+
+
+# --- O token no banco --------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_only_the_hash_is_stored(client, enviados, db_session):
+    email, _ = await registrar(client)
+    await client.post("/auth/forgot-password", json={"email": email})
+    cru = link_do(enviados)
+
+    # O token viaja por e-mail; o banco não precisa dele para validar. Guardar
+    # o valor cru transformaria um dump do banco em acesso a todas as contas
+    # com link pendente.
+    achado_pelo_cru = await db_session.scalar(
+        select(PasswordResetToken).where(PasswordResetToken.token_hash == cru)
+    )
+    achado_pelo_hash = await db_session.scalar(
+        select(PasswordResetToken).where(PasswordResetToken.token_hash == _hash_token(cru))
+    )
+    assert achado_pelo_cru is None
+    assert achado_pelo_hash is not None
+
+
+# --- Contrato de senha e provisionamento ------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("fraca", ["semnumero", "1234567", "curta1"])
+async def test_the_new_password_obeys_the_same_rules_as_signup(client, enviados, fraca):
+    # O caminho que valida menos é o que um atacante escolhe. Cadastro e
+    # redefinição compartilham o mesmo tipo (StrongPassword) por isso.
+    email, _ = await registrar(client)
+    await client.post("/auth/forgot-password", json={"email": email})
+
+    res = await client.post(
+        "/auth/reset-password", json={"token": link_do(enviados), "new_password": fraca}
+    )
+    assert res.status_code == 422, res.text
+
+
+@pytest.mark.asyncio
+async def test_without_a_brevo_key_it_refuses_loudly(client, brevo_configurado):
+    # 503 e não 202: aqui não há atacante a proteger, há um dono que precisa
+    # saber que a variável não existe. Responder 202 e nunca enviar deixaria
+    # a recuperação quebrada em silêncio.
+    brevo_configurado.brevo_api_key = ""
+    res = await client.post("/auth/forgot-password", json={"email": "quem@test.com"})
+    assert res.status_code == 503
+
+
+@pytest.mark.asyncio
+async def test_the_email_carries_a_link_to_the_reset_page(client, enviados):
+    email, _ = await registrar(client)
+    await client.post("/auth/forgot-password", json={"email": email})
+
+    html = enviados[-1]["html"]
+    assert enviados[-1]["para"] == email
+    assert "/redefinir-senha?token=" in html
+    # A pessoa precisa saber que o link morre, senão um link expirado parece
+    # um link quebrado e vira chamado de suporte.
+    assert "30 minutos" in html

--- a/backend/tests/test_password_reset.py
+++ b/backend/tests/test_password_reset.py
@@ -246,3 +246,27 @@ async def test_the_email_carries_a_link_to_the_reset_page(client, enviados):
     # A pessoa precisa saber que o link morre, senão um link expirado parece
     # um link quebrado e vira chamado de suporte.
     assert "30 minutos" in html
+
+
+@pytest.mark.asyncio
+async def test_the_email_does_not_look_like_marketing(client, enviados):
+    """Medido, não suposto.
+
+    A primeira versão tinha um botão colorido com padding e uma segunda linha
+    repetindo a URL. O Gmail entregou em PROMOÇÕES, o que para recuperação de
+    senha é quase tão ruim quanto spam: quem está trancado para fora não
+    procura naquela aba. Um link em texto sinaliza correspondência; botão e
+    links repetidos sinalizam campanha.
+
+    O pixel de abertura e a reescrita de links que o Brevo injeta continuam
+    lá — não são desligáveis por mensagem na API, e por isso não são testáveis
+    aqui. Este teste guarda a parte que é nossa.
+    """
+    email, _ = await registrar(client)
+    await client.post("/auth/forgot-password", json={"email": email})
+    html = enviados[-1]["html"]
+
+    assert html.count("<a ") == 1, "mais de um link volta a parecer campanha"
+    assert "background:" not in html, "botao colorido e o sinal mais forte de promocao"
+    assert "<img" not in html
+

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -13,6 +13,8 @@ import Recurring from "./pages/Recurring";
 import Goals from "./pages/Goals";
 import Privacidade from "./pages/Privacidade";
 import Termos from "./pages/Termos";
+import EsqueciSenha from "./pages/EsqueciSenha";
+import RedefinirSenha from "./pages/RedefinirSenha";
 
 function ProtectedRoute({ children }) {
   const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
@@ -62,6 +64,10 @@ export default function App() {
         <Route path="/" element={<RootRoute />} />
         <Route path="/privacidade" element={<Privacidade />} />
         <Route path="/termos" element={<Termos />} />
+        {/* Públicas de propósito: quem esqueceu a senha não tem como estar
+            autenticado, e o link de redefinição chega por e-mail. */}
+        <Route path="/esqueci-senha" element={<EsqueciSenha />} />
+        <Route path="/redefinir-senha" element={<RedefinirSenha />} />
         <Route
           element={
             <ProtectedRoute>

--- a/frontend/src/api/auth.js
+++ b/frontend/src/api/auth.js
@@ -6,6 +6,11 @@ export const authApi = {
   login: (data) => api.post("/auth/login", data),
   me: () => api.get("/auth/me"),
   updateProfile: (data) => api.put("/auth/me", data),
+  // Anônimas: a resposta é sempre a mesma exista o e-mail ou não, então não há
+  // nada a interpretar aqui além de "deu certo" ou "deu erro de rede".
+  forgotPassword: (email) => api.post("/auth/forgot-password", { email }),
+  resetPassword: (token, newPassword) =>
+    api.post("/auth/reset-password", { token, new_password: newPassword }),
   // Logout best-effort: revoga o refresh no backend e limpa o estado local.
   // Falha de rede não impede o logout local.
   logout: async () => {

--- a/frontend/src/components/shared/CartaoAcesso.jsx
+++ b/frontend/src/components/shared/CartaoAcesso.jsx
@@ -1,0 +1,46 @@
+import { Link } from "react-router-dom";
+import { ArrowLeft } from "lucide-react";
+
+import NorbyMark from "@/components/shared/Logo";
+
+/**
+ * Moldura das telas de acesso que não são o login (issue #36).
+ *
+ * Existe compartilhada porque "esqueci a senha" e "redefinir senha" são o mesmo
+ * momento partido em dois, com um e-mail no meio: se as duas telas não forem
+ * idênticas, a segunda parece de outro site — exatamente a desconfiança que
+ * não se pode provocar em quem acabou de clicar num link recebido por e-mail.
+ *
+ * Não reaproveita o card do `Auth.jsx` de propósito: aquele carrega o anel, o
+ * painel lateral e as abas de login/cadastro, e nada disso serve aqui.
+ */
+export default function CartaoAcesso({ titulo, descricao, children }) {
+  return (
+    <div className="app-mesh flex min-h-screen items-center justify-center bg-bg-base px-4 py-10 text-content">
+      <main className="w-full max-w-md">
+        <div className="glass p-8 sm:p-10">
+          <div className="text-center">
+            <div className="brand-tile mx-auto h-14 w-14">
+              <NorbyMark size={30} color="currentColor" />
+            </div>
+            <h1 className="mt-5 text-xl font-bold text-content">{titulo}</h1>
+            <p className="mt-2 text-pretty text-sm leading-relaxed text-content-2">
+              {descricao}
+            </p>
+          </div>
+
+          <div className="mt-7">{children}</div>
+        </div>
+
+        <div className="mt-6 text-center">
+          <Link
+            to="/"
+            className="inline-flex items-center gap-2 text-sm text-content-2 hover:text-content"
+          >
+            <ArrowLeft size={15} /> Voltar para o login
+          </Link>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/frontend/src/lib/schemas.js
+++ b/frontend/src/lib/schemas.js
@@ -45,3 +45,35 @@ export const recurringSchema = z
     message: "Selecione o dia da semana",
     path: ["weekday"],
   });
+
+// Recuperação de senha (#36). Espelha o `StrongPassword` do backend
+// (schemas/common.py): 8 a 128 caracteres, ao menos uma letra e um número, e
+// no máximo 72 BYTES — o bcrypt trunca ali e um acento ocupa mais de um byte.
+// Espelhar aqui não substitui a validação do servidor, que continua sendo a
+// que vale; serve para a pessoa descobrir o problema antes de gastar o link,
+// que é de uso único.
+const senhaForte = z
+  .string()
+  .min(8, "Mínimo de 8 caracteres")
+  .max(128, "Máximo de 128 caracteres")
+  .refine((v) => /[A-Za-z]/.test(v) && /\d/.test(v), {
+    message: "Use ao menos uma letra e um número",
+  })
+  .refine((v) => new TextEncoder().encode(v).length <= 72, {
+    message: "Máximo de 72 bytes (acentos contam 2)",
+  });
+
+export const forgotSchema = z.object({
+  email: z.string().min(1, "Informe o e-mail").email("E-mail inválido"),
+});
+
+export const resetSchema = z
+  .object({
+    password: senhaForte,
+    confirm: z.string().min(1, "Repita a senha"),
+  })
+  .refine((d) => d.password === d.confirm, {
+    message: "As senhas não conferem",
+    path: ["confirm"],
+  });
+

--- a/frontend/src/pages/Auth.jsx
+++ b/frontend/src/pages/Auth.jsx
@@ -370,26 +370,17 @@ export default function Auth() {
                 </Field>
               )}
 
-              {/* Recuperação de senha ainda não tem rota no backend (/auth expõe
-                  register, login, refresh, logout, me e me/export). Fica
-                  desabilitada com o aviso visível ao lado: um link morto que
-                  não leva a lugar nenhum seria pior do que assumir a lacuna. */}
+              {/* Deixou de ser "em breve" com o #36: /auth/forgot-password
+                  existe. O botão desabilitado e o chip saíram junto — rótulo de
+                  estado que não corresponde mais ao estado é pior que nenhum. */}
               {mode === "login" && (
-                <div className="flex items-center justify-end gap-2 pt-0.5">
-                  <button
-                    type="button"
-                    disabled
-                    aria-describedby="reset-status"
-                    className="text-sm text-content-3"
+                <div className="flex justify-end pt-0.5">
+                  <Link
+                    to="/esqueci-senha"
+                    className="text-sm text-accent hover:underline"
                   >
                     Esqueceu a senha?
-                  </button>
-                  {/* .chip-neutral já é o rótulo de estado do projeto. O 11px
-                      com --content-3 que eu tinha usado media 4,16:1 no tema
-                      claro, abaixo do mínimo de 4,5:1 para texto normal. */}
-                  <span id="reset-status" className="chip-neutral">
-                    em breve
-                  </span>
+                  </Link>
                 </div>
               )}
 

--- a/frontend/src/pages/Auth.test.jsx
+++ b/frontend/src/pages/Auth.test.jsx
@@ -88,4 +88,19 @@ describe("Auth", () => {
     ).toBeInTheDocument();
     expect(registerSpy).not.toHaveBeenCalled();
   });
+
+  it("leva à recuperação de senha, que deixou de ser 'em breve'", () => {
+    // Este link já foi um botão desabilitado com um chip "em breve", porque a
+    // rota não existia. Com o #36 ela existe, e um rótulo de estado que não
+    // corresponde mais ao estado é pior que rótulo nenhum.
+    render(
+      <MemoryRouter>
+        <Auth />
+      </MemoryRouter>,
+    );
+
+    const link = screen.getByRole("link", { name: /esqueceu a senha/i });
+    expect(link).toHaveAttribute("href", "/esqueci-senha");
+    expect(screen.queryByText("em breve")).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/pages/EsqueciSenha.jsx
+++ b/frontend/src/pages/EsqueciSenha.jsx
@@ -1,0 +1,99 @@
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Mail } from "lucide-react";
+
+import { authApi } from "@/api/auth";
+import { forgotSchema } from "@/lib/schemas";
+import { apiErrorMessage } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import CartaoAcesso from "@/components/shared/CartaoAcesso";
+
+export default function EsqueciSenha() {
+  const [enviado, setEnviado] = useState(false);
+  const [erro, setErro] = useState("");
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+  } = useForm({ resolver: zodResolver(forgotSchema) });
+
+  async function onSubmit({ email }) {
+    setErro("");
+    try {
+      await authApi.forgotPassword(email);
+      setEnviado(true);
+    } catch (err) {
+      // Só falha de rede ou 503 chegam aqui: a rota responde igual exista o
+      // e-mail ou não, então não há erro "e-mail não encontrado" a mostrar.
+      setErro(apiErrorMessage(err, "Não foi possível enviar agora. Tente de novo."));
+    }
+  }
+
+  // A confirmação NÃO diz se a conta existe. Dizer "enviamos para você"
+  // transformaria esta tela num verificador de quem tem conta no Norby, que é
+  // a mesma enumeração que o backend evita respondendo sempre igual.
+  if (enviado) {
+    return (
+      <CartaoAcesso
+        titulo="Confira seu e-mail"
+        descricao="Se este endereço tiver uma conta, o link de redefinição já está a caminho. Ele vale por 30 minutos e só pode ser usado uma vez."
+      >
+        <p className="text-center text-sm leading-relaxed text-content-3">
+          Não chegou? Verifique a caixa de spam antes de pedir outro.
+        </p>
+      </CartaoAcesso>
+    );
+  }
+
+  return (
+    <CartaoAcesso
+      titulo="Esqueceu a senha?"
+      descricao="Informe o e-mail da sua conta e enviamos um link para você criar uma nova."
+    >
+      <form onSubmit={handleSubmit(onSubmit)} className="space-y-4" noValidate>
+        <div>
+          <label htmlFor="email" className="mb-2 block text-xs font-medium text-content-2">
+            E-mail
+          </label>
+          <div className="relative">
+            <Mail
+              size={16}
+              className="pointer-events-none absolute left-3.5 top-1/2 -translate-y-1/2 text-content-3"
+            />
+            <Input
+              id="email"
+              type="email"
+              autoComplete="email"
+              placeholder="voce@exemplo.com"
+              className="pl-10"
+              aria-invalid={errors.email ? "true" : undefined}
+              aria-describedby={errors.email ? "email-error" : undefined}
+              {...register("email")}
+            />
+          </div>
+          {errors.email && (
+            <p id="email-error" className="mt-1.5 text-xs text-danger">
+              {errors.email.message}
+            </p>
+          )}
+        </div>
+
+        {erro && (
+          <p role="alert" className="text-xs text-danger">
+            {erro}
+          </p>
+        )}
+
+        <Button
+          type="submit"
+          disabled={isSubmitting}
+          className="w-full bg-accent-fill font-medium text-accent-contrast hover:bg-accent-fill/90"
+        >
+          {isSubmitting ? "Enviando…" : "Enviar link"}
+        </Button>
+      </form>
+    </CartaoAcesso>
+  );
+}

--- a/frontend/src/pages/RecuperarSenha.test.jsx
+++ b/frontend/src/pages/RecuperarSenha.test.jsx
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+
+import { authApi } from "@/api/auth";
+import EsqueciSenha from "./EsqueciSenha";
+import RedefinirSenha from "./RedefinirSenha";
+
+vi.mock("@/api/auth", () => ({
+  authApi: { forgotPassword: vi.fn(), resetPassword: vi.fn() },
+}));
+
+function renderEm(rota, elemento, caminho) {
+  return render(
+    <MemoryRouter initialEntries={[rota]}>
+      <Routes>
+        <Route path={caminho} element={elemento} />
+        <Route path="/" element={<p>login</p>} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("Esqueci a senha", () => {
+  it("confirma sem revelar se a conta existe", async () => {
+    // O backend responde igual para e-mail conhecido e desconhecido. Se a tela
+    // dissesse "enviamos para você", ela desfaria isso: viraria um verificador
+    // de quem tem conta no Norby, que é a enumeração que o login evita.
+    authApi.forgotPassword.mockResolvedValue({ data: {} });
+    renderEm("/esqueci-senha", <EsqueciSenha />, "/esqueci-senha");
+
+    fireEvent.change(screen.getByLabelText("E-mail"), {
+      target: { value: "alguem@test.com" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /enviar link/i }));
+
+    const texto = await screen.findByText(/se este endereço tiver uma conta/i);
+    expect(texto).toBeInTheDocument();
+    expect(screen.queryByText(/enviamos para você/i)).not.toBeInTheDocument();
+  });
+
+  it("não chama a API com e-mail inválido", async () => {
+    renderEm("/esqueci-senha", <EsqueciSenha />, "/esqueci-senha");
+
+    fireEvent.change(screen.getByLabelText("E-mail"), { target: { value: "nao-e-email" } });
+    fireEvent.click(screen.getByRole("button", { name: /enviar link/i }));
+
+    expect(await screen.findByText("E-mail inválido")).toBeInTheDocument();
+    expect(authApi.forgotPassword).not.toHaveBeenCalled();
+  });
+});
+
+describe("Redefinir senha", () => {
+  it("sem token na URL, não mostra formulário", async () => {
+    // Um formulário aqui só levaria a pessoa a digitar uma senha para receber
+    // erro no envio. O caminho útil é pedir outro link.
+    renderEm("/redefinir-senha", <RedefinirSenha />, "/redefinir-senha");
+
+    expect(screen.getByText(/link incompleto/i)).toBeInTheDocument();
+    expect(screen.queryByLabelText("Nova senha")).not.toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /pedir um link novo/i })).toHaveAttribute(
+      "href",
+      "/esqueci-senha",
+    );
+  });
+
+  it("avisa que as sessões caem, antes de a pessoa salvar", async () => {
+    // A troca revoga todo refresh token no servidor. Descobrir isso só depois,
+    // ao ser deslogado do celular, parece falha do app.
+    renderEm("/redefinir-senha?token=abc123", <RedefinirSenha />, "/redefinir-senha");
+    expect(screen.getByText(/todas as sessões abertas/i)).toBeInTheDocument();
+  });
+
+  it("recusa senha fraca sem gastar o link", async () => {
+    // O link é de uso único: descobrir a regra de senha no servidor queimaria
+    // o token e obrigaria a pedir outro e-mail.
+    renderEm("/redefinir-senha?token=abc123", <RedefinirSenha />, "/redefinir-senha");
+
+    fireEvent.change(screen.getByLabelText("Nova senha"), { target: { value: "semnumero" } });
+    fireEvent.change(screen.getByLabelText("Repita a nova senha"), {
+      target: { value: "semnumero" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /salvar nova senha/i }));
+
+    expect(await screen.findByText("Use ao menos uma letra e um número")).toBeInTheDocument();
+    expect(authApi.resetPassword).not.toHaveBeenCalled();
+  });
+
+  it("recusa quando as duas senhas não conferem", async () => {
+    renderEm("/redefinir-senha?token=abc123", <RedefinirSenha />, "/redefinir-senha");
+
+    fireEvent.change(screen.getByLabelText("Nova senha"), { target: { value: "senhaboa1" } });
+    fireEvent.change(screen.getByLabelText("Repita a nova senha"), {
+      target: { value: "senhaboa2" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /salvar nova senha/i }));
+
+    expect(await screen.findByText("As senhas não conferem")).toBeInTheDocument();
+    expect(authApi.resetPassword).not.toHaveBeenCalled();
+  });
+
+  it("envia o token da URL junto da senha nova", async () => {
+    authApi.resetPassword.mockResolvedValue({ data: {} });
+    renderEm("/redefinir-senha?token=tok-da-url", <RedefinirSenha />, "/redefinir-senha");
+
+    fireEvent.change(screen.getByLabelText("Nova senha"), { target: { value: "senhaboa1" } });
+    fireEvent.change(screen.getByLabelText("Repita a nova senha"), {
+      target: { value: "senhaboa1" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /salvar nova senha/i }));
+
+    await waitFor(() => expect(authApi.resetPassword).toHaveBeenCalledWith("tok-da-url", "senhaboa1"));
+  });
+});

--- a/frontend/src/pages/RedefinirSenha.jsx
+++ b/frontend/src/pages/RedefinirSenha.jsx
@@ -1,0 +1,133 @@
+import { useState } from "react";
+import { Link, useNavigate, useSearchParams } from "react-router-dom";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Lock } from "lucide-react";
+
+import { authApi } from "@/api/auth";
+import { resetSchema } from "@/lib/schemas";
+import { apiErrorMessage } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import CartaoAcesso from "@/components/shared/CartaoAcesso";
+
+export default function RedefinirSenha() {
+  const [searchParams] = useSearchParams();
+  const token = searchParams.get("token") || "";
+  const navigate = useNavigate();
+  const [erro, setErro] = useState("");
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+  } = useForm({ resolver: zodResolver(resetSchema) });
+
+  async function onSubmit({ password }) {
+    setErro("");
+    try {
+      await authApi.resetPassword(token, password);
+      // Sem login automático: a troca derruba TODAS as sessões no servidor, e
+      // entrar sozinho aqui esconderia isso de quem precisa saber que os
+      // outros aparelhos caíram. Entrar de novo é a confirmação de que a senha
+      // nova funciona.
+      navigate("/", { replace: true, state: { senhaRedefinida: true } });
+    } catch (err) {
+      setErro(
+        apiErrorMessage(err, "Não foi possível redefinir. Peça um link novo e tente de novo."),
+      );
+    }
+  }
+
+  // Sem token na URL não há o que fazer, e o formulário só levaria a pessoa a
+  // digitar uma senha para receber erro no envio.
+  if (!token) {
+    return (
+      <CartaoAcesso
+        titulo="Link incompleto"
+        descricao="Este endereço não traz o código de redefinição. Abra o link direto do e-mail, sem copiar só um pedaço dele."
+      >
+        <Link
+          to="/esqueci-senha"
+          className="block text-center text-sm text-accent hover:underline"
+        >
+          Pedir um link novo
+        </Link>
+      </CartaoAcesso>
+    );
+  }
+
+  return (
+    <CartaoAcesso
+      titulo="Criar uma nova senha"
+      descricao="Ao salvar, todas as sessões abertas nos seus aparelhos serão encerradas."
+    >
+      <form onSubmit={handleSubmit(onSubmit)} className="space-y-4" noValidate>
+        <div>
+          <label htmlFor="password" className="mb-2 block text-xs font-medium text-content-2">
+            Nova senha
+          </label>
+          <div className="relative">
+            <Lock
+              size={16}
+              className="pointer-events-none absolute left-3.5 top-1/2 -translate-y-1/2 text-content-3"
+            />
+            <Input
+              id="password"
+              type="password"
+              autoComplete="new-password"
+              className="pl-10"
+              aria-invalid={errors.password ? "true" : undefined}
+              aria-describedby={errors.password ? "password-error" : undefined}
+              {...register("password")}
+            />
+          </div>
+          {errors.password && (
+            <p id="password-error" className="mt-1.5 text-xs text-danger">
+              {errors.password.message}
+            </p>
+          )}
+        </div>
+
+        <div>
+          <label htmlFor="confirm" className="mb-2 block text-xs font-medium text-content-2">
+            Repita a nova senha
+          </label>
+          <div className="relative">
+            <Lock
+              size={16}
+              className="pointer-events-none absolute left-3.5 top-1/2 -translate-y-1/2 text-content-3"
+            />
+            <Input
+              id="confirm"
+              type="password"
+              autoComplete="new-password"
+              className="pl-10"
+              aria-invalid={errors.confirm ? "true" : undefined}
+              aria-describedby={errors.confirm ? "confirm-error" : undefined}
+              {...register("confirm")}
+            />
+          </div>
+          {errors.confirm && (
+            <p id="confirm-error" className="mt-1.5 text-xs text-danger">
+              {errors.confirm.message}
+            </p>
+          )}
+        </div>
+
+        {erro && (
+          <p role="alert" className="text-xs text-danger">
+            {erro}
+          </p>
+        )}
+
+        <Button
+          type="submit"
+          disabled={isSubmitting}
+          className="w-full bg-accent-fill font-medium text-accent-contrast hover:bg-accent-fill/90"
+        >
+          {isSubmitting ? "Salvando…" : "Salvar nova senha"}
+        </Button>
+      </form>
+    </CartaoAcesso>
+  );
+}


### PR DESCRIPTION
Closes #36. **Base is #115, not `main`** — see the last section for why that is a migration constraint rather than a preference.

There was no way back into an account. In a product that charges money, a forgotten password has exactly one exit today: asking for a refund.

## Brevo's HTTP API, not SMTP

`httpx` is already in `requirements.lock` (the Stripe SDK brings it), so this costs **no new dependency**. SMTP would need `aiosmtplib`, or `smtplib` blocking inside the event loop — the thing the billing integration deliberately avoided by using the SDK's `_async` calls. The API also returns a `messageId`, which makes an undelivered email diagnosable.

The email body lives in the repository rather than in a Brevo template, because it has to agree with the link format the token validates. That is not a thing to keep where no test can reach it.

## Four decisions worth reviewing

**The send runs in a `BackgroundTask`, and that is not an optimisation.** Sending inside the request would make a known address cost a round trip to Brevo while an unknown one returns immediately. That difference enumerates accounts by the clock exactly as well as a different message does on screen. Answering before sending makes both cases cost the same.

**The rate limit is keyed on the email, not the IP.** Behind the Railway proxy every IP is the same bucket, as `AGENTS.md` records. What this ceiling protects is the *target's inbox*: without it, the form is a mailbomb aimed at whoever you type into it. A second limit by IP is stacked on top, because a different email on every call never exhausts its own bucket — the lesson `/auth/logout` learned in its fix round.

**Signup and reset now share one `StrongPassword` type.** With the rules copied into two schemas, reset would eventually drift into accepting a password signup rejects, and **the path that validates least is the one an attacker picks**. A test asserts three weak passwords are refused at reset.

**Using one link marks every other pending link for that user as used.** Asking for three emails and using one cannot leave two live links sitting in an inbox.

## What the endpoints refuse to say

`forgot-password` answers 202 with an identical body whether the address exists or not, and the confirmation screen says *"se este endereço tiver uma conta"* rather than "we sent it to you" — a frontend that leaked this would undo the protection the backend built. `reset-password` answers 400 identically for a token that is unknown, expired, or already used: distinguishing them would tell whoever holds a stolen token whether it was ever valid.

The one place it is deliberately loud is a missing `BREVO_API_KEY`: 503, not 202. There is no attacker to protect there, only an owner who needs to know the variable is absent, and answering 202 while never sending would leave recovery broken in silence.

## Verification

- 326 backend tests, 171 frontend tests (+8), lint and build clean, `alembic check` reports no drift and a single head.
- **13 new backend tests, and five mutations were run against them, all killed:** returning 404 for an unknown email, dropping the `used_at` check, skipping session revocation, storing the raw token instead of its hash, and leaving other pending links alive. Thirteen tests passing first try is not evidence; those five are.

## Why the base is #115

Both branches add a migration. Chained, they are linear: `d02a76d9af21 → fe1092dba7da` (#115) `→ 205f60ec5dbf` (this one). Pointed at the same parent instead, they would be **two alembic heads**, and `alembic upgrade head` refuses that — which `start.sh` runs on every boot, so production would fail to start.

So the order is a constraint: **merge #115 first.** GitHub retargets this PR to `main` automatically once it does. The diff here shows only this feature's files.
