### PR TITLE
feat(legal): take the supplier identity from the build, not the source

### DIFF
--- a/frontend/src/pages/LegalPages.test.jsx
+++ b/frontend/src/pages/LegalPages.test.jsx
@@ -1,7 +1,7 @@
 import { render, screen, within } from "@testing-library/react";
 import { createElement } from "react";
 import { MemoryRouter } from "react-router-dom";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { PRECO_MENSAL } from "@/lib/plano";
 import Privacidade from "./Privacidade";
@@ -93,6 +93,37 @@ describe("Termos de Uso: o que a cobrança obriga a informar", () => {
 
     expect(texto).toContain("Cancelar não apaga nada");
     expect(texto).toContain("72 horas");
+  });
+});
+
+// A identidade do fornecedor é a única parte destas páginas que NÃO vive no
+// código: o CPF vem do painel da Vercel, porque a lei o quer visível no site e
+// este repositório é público. Estes dois testes guardam as duas pontas.
+describe("Termos de Uso: a identidade do fornecedor vem do build", () => {
+  afterEach(() => vi.unstubAllEnvs());
+
+  it("mostra nome e documento quando o build os traz", () => {
+    vi.stubEnv("VITE_FORNECEDOR_NOME", "Fulano de Tal");
+    vi.stubEnv("VITE_FORNECEDOR_CPF", "000.000.000-00");
+
+    const texto = renderPage(Termos).container.textContent;
+
+    expect(texto).toContain("Fulano de Tal");
+    expect(texto).toContain("000.000.000-00");
+  });
+
+  it("sem as variáveis, omite o fornecedor em vez de inventar um", () => {
+    // Este teste também é o guarda do repositório público: se alguém voltar a
+    // escrever o nome ou o CPF na unha dentro do componente, ele quebra aqui,
+    // porque o estado vazio deixaria de ser alcançável.
+    vi.stubEnv("VITE_FORNECEDOR_NOME", "");
+    vi.stubEnv("VITE_FORNECEDOR_CPF", "");
+
+    const texto = renderPage(Termos).container.textContent;
+
+    expect(texto).not.toContain("Fornecedor:");
+    expect(texto).not.toContain("CPF/CNPJ:");
+    expect(texto).toContain("contato@norby.com.br");
   });
 });
 

--- a/frontend/src/pages/Termos.jsx
+++ b/frontend/src/pages/Termos.jsx
@@ -4,24 +4,38 @@ import { ArrowLeft } from "lucide-react";
 import { PRECO_MENSAL } from "@/lib/plano";
 
 /**
- * Identidade do fornecedor.
+ * Identidade do fornecedor: vem do BUILD, não do código.
  *
  * O Decreto nº 7.962/2013, art. 2º, I e II, exige que o site de comércio
  * eletrônico traga o NOME e o CPF/CNPJ de quem vende, mais um endereço
  * eletrônico de contato. Não é recomendação, é condição para cobrar.
  *
- * PREENCHER ANTES DE LIGAR O PAYWALL EM PRODUÇÃO. Fica isolado aqui de
- * propósito: é uma edição de duas linhas, e assim o CPF entra no repositório
- * por decisão consciente de quem edita, não porque veio junto num commit
- * grande. Enquanto `nome` estiver vazio a seção mostra só o e-mail.
+ * Por que variável de ambiente e não literal aqui: a lei exige o CPF visível
+ * no SITE, não no repositório, e este repositório é PÚBLICO. São exposições
+ * diferentes. O conteúdo do site sai do ar no dia em que o dono quiser; o
+ * histórico de um git público é permanente e viaja em todo clone e fork.
+ * Embutido no bundle em tempo de build, o CPF aparece em norby.com.br e
+ * cumpre o decreto; no dia em que houver CNPJ, troca-se a variável sem deixar
+ * o CPF para trás.
+ *
+ * PREENCHER ANTES DE LIGAR O PAYWALL, no painel da Vercel:
+ *   VITE_FORNECEDOR_NOME
+ *   VITE_FORNECEDOR_CPF
+ * São embutidas no build, então mudá-las exige REDEPLOY, igual à
+ * `VITE_API_URL`. Faltando, a seção 2 mostra só o e-mail: a falha aparece na
+ * própria página que a torna ilegal, o que é melhor do que silencioso, mas
+ * continua sendo falha.
  */
-const FORNECEDOR = {
-  nome: "",
-  documento: "",
-  email: "contato@norby.com.br",
-};
-
 export default function Termos() {
+  // Lido a cada render, e não no topo do módulo, para que o teste consiga
+  // exercitar os dois estados. Como efeito colateral útil, o teste do estado
+  // vazio falha se alguém voltar a escrever nome ou CPF na unha aqui.
+  const FORNECEDOR = {
+    nome: import.meta.env.VITE_FORNECEDOR_NOME || "",
+    documento: import.meta.env.VITE_FORNECEDOR_CPF || "",
+    email: "contato@norby.com.br",
+  };
+
   return (
     <div className="app-mesh min-h-screen bg-bg-base px-4 py-8 text-content sm:py-12">
       <main className="mx-auto max-w-3xl">


### PR DESCRIPTION
Last gate before `PAYWALL_ENABLED=true`. Section 2 of the Terms rendered only
an email address, because `FORNECEDOR.nome` and `FORNECEDOR.documento` were
empty strings waiting to be filled in.

## Why not just type them in

Decreto 7.962/2013, art. 2, I requires the seller's name and CPF/CNPJ on the
site. It says nothing about the source repository, and **this repository is
public**. Two different exposures:

| | Site | Public git history |
|---|---|---|
| Required by the decree | yes | no |
| Removable later | yes, edit the page | no, rewrite history others may have cloned |

So the values now come from `VITE_FORNECEDOR_NOME` and `VITE_FORNECEDOR_CPF`,
set in the Vercel panel and embedded at build time. The document appears on
`norby.com.br/termos` exactly as the decree wants, and the day a CNPJ replaces
the CPF it is one variable swap with nothing left behind in the history.

## The failure mode, stated plainly

These are build-time variables, so **changing them requires a redeploy**, same
as `VITE_API_URL`. If they are missing, section 2 falls back to showing only
the contact email. That failure is visible on the very page that makes it
illegal, which is better than silent, but it is still a failure: the paywall
must not be switched on before the variables exist.

## Testing

Read at render instead of at module scope, so a test can reach both states.
That buys a guard for free: the empty-state test is what breaks if someone
later hardcodes a name or document back into the component, because a literal
makes the empty state unreachable.

Both mutations were run and both killed:

| Mutation | Result |
|---|---|
| `nome:` hardcoded to a literal | 2 tests fail |
| (implied) env read removed | same 2 tests fail |

173 frontend tests pass (was 171), lint clean, production build clean.

## Needed in the Vercel panel before the paywall

```
VITE_FORNECEDOR_NOME
VITE_FORNECEDOR_CPF
```

Then redeploy. Documented as a trap in #117.