### PR TITLE
feat(auth): show success banner after password reset

### DIFF
--- a/frontend/src/pages/Auth.jsx
+++ b/frontend/src/pages/Auth.jsx
@@ -1,5 +1,5 @@
-import { Children, cloneElement, useState } from "react";
-import { Link, useNavigate } from "react-router-dom";
+import { Children, cloneElement, useEffect, useState } from "react";
+import { Link, useLocation, useNavigate } from "react-router-dom";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
@@ -119,6 +119,19 @@ export default function Auth() {
   const [loading, setLoading] = useState(false);
   const login = useAuthStore((s) => s.login);
   const navigate = useNavigate();
+  const location = useLocation();
+  // Vem do RedefinirSenha.jsx, que navega para cá sem mostrar nada: a troca de
+  // senha derruba todas as sessões no servidor, então é aqui que a pessoa
+  // fica sabendo que precisa entrar de novo. Inicializador preguiçoso em vez
+  // de setState num efeito: o valor já nasce certo no primeiro render, sem
+  // precisar de outro render nem de suprimir a regra do hook.
+  const [senhaRedefinida] = useState(() => Boolean(location.state?.senhaRedefinida));
+
+  // Limpa o state do histórico (mesmo idioma do atalho de tipo em
+  // Transactions.jsx) para o aviso não voltar ao navegar para trás.
+  useEffect(() => {
+    if (location.state?.senhaRedefinida) navigate(location.pathname, { replace: true });
+  }, [location, navigate]);
 
   const schema = mode === "login" ? loginSchema : registerSchema;
   const {
@@ -299,6 +312,15 @@ export default function Auth() {
                 </button>
               ))}
             </div>
+
+            {senhaRedefinida && (
+              <div
+                role="status"
+                className="mt-5 rounded-xl border border-accent/20 bg-accent/10 p-3 text-sm text-accent"
+              >
+                Senha redefinida. Entre com a nova senha.
+              </div>
+            )}
 
             <form className="mt-5 space-y-3" onSubmit={handleSubmit(onSubmit)}>
               {mode === "register" && (

--- a/frontend/src/pages/Auth.test.jsx
+++ b/frontend/src/pages/Auth.test.jsx
@@ -103,4 +103,18 @@ describe("Auth", () => {
     expect(link).toHaveAttribute("href", "/esqueci-senha");
     expect(screen.queryByText("em breve")).not.toBeInTheDocument();
   });
+
+  it("avisa que a senha foi redefinida ao voltar do fluxo de redefinição", () => {
+    // RedefinirSenha.jsx navega pra cá com esse state em vez de mostrar
+    // qualquer coisa na própria tela (a sessão dela já caiu com a troca).
+    render(
+      <MemoryRouter initialEntries={[{ pathname: "/", state: { senhaRedefinida: true } }]}>
+        <Auth />
+      </MemoryRouter>,
+    );
+
+    expect(
+      screen.getByText("Senha redefinida. Entre com a nova senha."),
+    ).toBeInTheDocument();
+  });
 });

--- a/frontend/src/pages/RedefinirSenha.jsx
+++ b/frontend/src/pages/RedefinirSenha.jsx
@@ -29,7 +29,8 @@ export default function RedefinirSenha() {
       // Sem login automático: a troca derruba TODAS as sessões no servidor, e
       // entrar sozinho aqui esconderia isso de quem precisa saber que os
       // outros aparelhos caíram. Entrar de novo é a confirmação de que a senha
-      // nova funciona.
+      // nova funciona. O state avisa o Auth.jsx a mostrar essa confirmação,
+      // já que esta página não fica no ar tempo nenhum para mostrar nada.
       navigate("/", { replace: true, state: { senhaRedefinida: true } });
     } catch (err) {
       setErro(


### PR DESCRIPTION
## Summary
- `RedefinirSenha.jsx` already navigated to the login page with `{ senhaRedefinida: true }` router state after a successful reset, but nothing read it and the login page gave no feedback about why the person landed there.
- `Auth.jsx` now reads that state via a lazy `useState` initializer (`Boolean(location.state?.senhaRedefinida)`) so the value is correct on the very first render, and shows a short confirmation banner ("Senha redefinida. Entre com a nova senha.") using existing tokens (`border-accent/20 bg-accent/10 text-accent`, same combo already used in `InsightCard.jsx`).
- A separate effect clears the router state afterwards (same idiom already used for the `newType` shortcut in `Transactions.jsx`) so the banner doesn't reappear on back navigation.
- Considered moving Auth's local `Field` (label + icon + Input + error) component into `components/shared/`, since `EsqueciSenha.jsx`/`RedefinirSenha.jsx` have a similar-looking inline block. Decided against it: those two pages render a visible label, a smaller icon (16 vs 18) at a different offset, and different input padding, a deliberately simpler look for their smaller card. Reusing `Field` there would mean adding several props purely to reproduce that different visual, or changing pixels, so it stays local to `Auth.jsx` unchanged.

## Test plan
- [x] `npx vitest run` — 31 files / 174 tests passing
- [x] `npm run lint` — clean
- [x] `npm run build` — succeeds
- [x] Added a test in `Auth.test.jsx` covering the new banner