### PR TITLE
Backend review round 2: password recovery, throttle and rate-limit fixes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,6 +88,12 @@ npm run test     # Vitest
 - Exceção do audit: `python-jose` traz `ecdsa`, afetado por
   `PYSEC-2026-1325` sem versão corrigida. `Settings.algorithm` aceita somente
   `HS256`, então o caminho vulnerável de assinatura ECDSA/ECDH não é alcançável.
+- `pip-audit` não tem filtro de severidade: o gate do backend reprova em
+  qualquer advisory, mais estrito que o "só high" da issue #37 (`npm audit
+  --audit-level=high` é quem casa com aquele critério). O job de Lighthouse só
+  roda em push para `main` contra o site já implantado — é alarme pós-deploy,
+  não gate de merge, e disputa corrida com o redeploy da Vercel (documentado
+  no próprio workflow).
 
 ## Skills neste repo
 
@@ -283,7 +289,11 @@ rotacionado, então tem DOIS limites empilhados: por hash do token
 apresentado (não IP — um token velho da vítima não esgota o balde de outra
 sessão) **e** por IP (fix round 1: chavear só pelo token deixava o teto sem
 efeito nenhum contra flood, já que um token aleatório novo a cada chamada
-nunca esgota o próprio balde).
+nunca esgota o próprio balde). `/auth/forgot-password` soma 200/min por IP
+(mesma dívida aceita do login, balde único do proxy) com 3/hora por e-mail
+(HMAC, `reset_email_key`) — este último é quem de fato protege a caixa de
+entrada do alvo. `/auth/reset-password` tem só o teto de 200/min por IP: quem
+protege o token é a entropia dos 48 bytes, não o contador.
 
 **Duas dívidas aceitas nesta reescrita, não pendências esquecidas:**
 - **A vítima pode levar 429 mesmo digitando a senha certa.** `check_throttle`
@@ -291,8 +301,9 @@ nunca esgota o próprio balde).
   verdade (checar a senha primeiro e só depois atrasar não defende contra
   força bruta, só atrasa a resposta depois que o custo real já foi pago).
   Consequência: um atacante que erra a senha da vítima 1x por minuto nega o
-  login dela indefinidamente. A saída da vítima seria recuperação de senha,
-  que não existe (depende de domínio próprio, issue #41).
+  login dela indefinidamente. A saída da vítima existe desde a PR #116: ao
+  redefinir a senha, `reset_password` chama `record_success` e zera o
+  contador da conta, então a vítima recupera o acesso mesmo sob ataque.
 - **O teto global de login continua chaveado no IP do proxy**, o mesmo balde
   pra todo mundo atrás do Railway. Ficou 20x mais caro que antes
   (10/min → 200/min), não foi eliminado: ~3,3 req/s sustentados ainda negam

--- a/backend/app/limiter.py
+++ b/backend/app/limiter.py
@@ -6,6 +6,7 @@ from slowapi.util import get_remote_address
 from starlette.requests import Request
 
 from app.config import get_settings
+from app.services.throttle_service import email_key_hash
 
 settings = get_settings()
 
@@ -68,8 +69,10 @@ def reset_email_key(request: Request) -> str:
     DE ENTRADA de quem está sendo alvo — sem isso, alguém dispara o formulário
     contra o mesmo endereço e transforma o Norby em ferramenta de mailbomb.
 
-    O endereço cru nunca vira chave: só o sha256 dele, para o balde do slowapi
-    (em memória, mas ainda assim) não virar uma lista de e-mails cadastrados.
+    Mesmo `email_key_hash` do throttle_service: strip + lower + HMAC-SHA256
+    com o secret do servidor, não um hash puro. sha256 sozinho é reversível
+    por dicionário (é só rehashear cada e-mail candidato); o HMAC exige o
+    secret, que não sai do servidor.
 
     O router carimba request.state.reset_email numa dependency que roda antes
     deste decorator, porque o key_func é síncrono e não vê o corpo parseado.
@@ -77,4 +80,4 @@ def reset_email_key(request: Request) -> str:
     email = getattr(request.state, "reset_email", "")
     if not email:
         return get_remote_address(request)
-    return hashlib.sha256(email.lower().encode()).hexdigest()
+    return email_key_hash(email)

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -19,7 +19,7 @@ from app.schemas.user import (
 from app.services.auth_service import (
     hash_password, verify_password, verify_and_upgrade, create_access_token,
     create_refresh_token, rotate_refresh_token, revoke_refresh_token,
-    create_password_reset, reset_password, _DUMMY_HASH,
+    create_password_reset, find_user_by_email, reset_password, _DUMMY_HASH,
 )
 from app.services.account_service import delete_account, export_data
 from app.services.photo_service import MAX_BYTES, PhotoInvalid, PhotoTooLarge, processar_foto
@@ -72,14 +72,13 @@ async def register(
     if retry_after is not None:
         raise _throttled(retry_after)
 
-    # Verifica email duplicado. func.lower(): "Joao@x.com" e "joao@x.com" são
-    # a MESMA conta pro throttle (a chave HMAC já normaliza caixa), então
-    # deixar a checagem sensível a caixa permitia criar uma conta-sombra que,
-    # ao logar com sucesso, resetava o balde da vítima (fix round 1, issue
-    # #22 — ver também o índice único funcional em ix_users_email_lower).
-    normalized_email = payload.email.strip().lower()
-    existing = await db.execute(select(User).where(func.lower(User.email) == normalized_email))
-    if existing.scalar_one_or_none():
+    # Verifica email duplicado. find_user_by_email compara por func.lower():
+    # "Joao@x.com" e "joao@x.com" são a MESMA conta pro throttle (a chave HMAC
+    # já normaliza caixa), então deixar a checagem sensível a caixa permitia
+    # criar uma conta-sombra que, ao logar com sucesso, resetava o balde da
+    # vítima (fix round 1, issue #22 — ver também o índice único funcional em
+    # ix_users_email_lower).
+    if await find_user_by_email(payload.email, db):
         await record_failure(payload.email, db)
         raise HTTPException(status_code=400, detail="Email já cadastrado")
 
@@ -131,11 +130,10 @@ async def login(
     if retry_after is not None:
         raise _throttled(retry_after)
 
-    # func.lower(): login precisa aceitar a caixa que o usuário digitar, não
-    # só a caixa exata gravada no cadastro (fix round 1, issue #22).
-    normalized_email = payload.email.strip().lower()
-    result = await db.execute(select(User).where(func.lower(User.email) == normalized_email))
-    user = result.scalar_one_or_none()
+    # find_user_by_email compara por func.lower(): login precisa aceitar a
+    # caixa que o usuário digitar, não só a caixa exata gravada no cadastro
+    # (fix round 1, issue #22).
+    user = await find_user_by_email(payload.email, db)
 
     # bcrypt roda SEMPRE — contra o hash real ou contra o dummy. Sem isso, o
     # e-mail inexistente retorna ~200ms mais rápido e vira oráculo de enumeração.
@@ -447,8 +445,10 @@ async def _mandar_link(email: str, link: str) -> None:
 # por todo mundo (ver "Rate limit atrás do proxy" no AGENTS.md), e o que este
 # teto protege é a CAIXA DE ENTRADA do alvo. O segundo limite, por IP, é o
 # freio de flood — um e-mail diferente a cada chamada nunca esgota o próprio
-# balde, a mesma lição que o logout aprendeu no fix round 1.
-@limiter.limit("60/minute")
+# balde, a mesma lição que o logout aprendeu no fix round 1. Issue #22: mesma
+# dívida aceita do teto global de login, 200/min por ser o balde único do
+# proxy do Railway.
+@limiter.limit("200/minute")
 @limiter.limit("3/hour", key_func=reset_email_key)
 async def forgot_password(
     request: Request,
@@ -468,7 +468,10 @@ async def forgot_password(
         # que precisa saber que a variável não existe.
         raise HTTPException(status_code=503, detail="Recuperação de senha indisponível")
 
-    user = await db.scalar(select(User).where(User.email == payload.email))
+    # find_user_by_email compara por func.lower(): sem isso, quem se cadastrou
+    # como "Joao@x.com" e digita "joao@x.com" aqui não achava a conta e nunca
+    # recebia o link (fix round 2, issue #22).
+    user = await find_user_by_email(payload.email, db)
     if user is not None:
         raw = await create_password_reset(str(user.id), db)
         base = get_settings().app_base_url.rstrip("/")
@@ -479,9 +482,11 @@ async def forgot_password(
 
 @router.post("/reset-password", status_code=status.HTTP_204_NO_CONTENT)
 # Sem chave por e-mail aqui: quem apresenta o token não informa e-mail nenhum.
-# O teto é contra força bruta no token, que tem 48 bytes de entropia e não cai
-# por tentativa — o limite existe para o custo, não para a segurança.
-@limiter.limit("20/minute")
+# Este teto NÃO protege o token — 48 bytes de entropia é que fazem isso, e não
+# caem por tentativa. É só freio de flood no balde único do proxy do Railway
+# (get_remote_address atrás dele devolve o mesmo IP pra todo mundo), a mesma
+# dívida aceita do teto global de login (ver AGENTS.md).
+@limiter.limit("200/minute")
 async def reset_password_route(
     request: Request,
     payload: ResetPassword,

--- a/backend/app/services/auth_service.py
+++ b/backend/app/services/auth_service.py
@@ -1,9 +1,10 @@
+import asyncio
 import hashlib
 import secrets
 from datetime import datetime, timedelta, timezone
 
 from jose import jwt
-from sqlalchemy import select, update
+from sqlalchemy import func, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import get_settings
@@ -16,8 +17,21 @@ from app.services.password_service import (  # noqa: F401
     needs_update,
     verify_password,
 )
+# throttle_service não importa auth_service (sem ciclo): reset_password chama
+# record_success para tirar a vítima do balde de força bruta ao redefinir.
+from app.services.throttle_service import record_success
 
 settings = get_settings()
+
+
+async def find_user_by_email(email: str, db: AsyncSession) -> User | None:
+    """Busca por `func.lower(User.email)`, o mesmo critério usado em toda
+    comparação de email do app (fix round 1, issue #22): "Joao@x.com" e
+    "joao@x.com" são a MESMA conta.
+    """
+    normalized = email.strip().lower()
+    return await db.scalar(select(User).where(func.lower(User.email) == normalized))
+
 
 def verify_and_upgrade(plain: str, hashed: str) -> tuple[bool, str | None]:
     """Verifica a senha e devolve um hash novo quando o esquema está obsoleto."""
@@ -193,7 +207,9 @@ async def reset_password(raw: str, nova_senha: str, db: AsyncSession) -> bool:
         return False
 
     registro.used_at = datetime.now(timezone.utc)
-    user.password_hash = hash_password(nova_senha)
+    # bcrypt é bloqueante (~100-300ms): offload para thread, como auth.py já
+    # faz em register/login/delete.
+    user.password_hash = await asyncio.to_thread(hash_password, nova_senha)
 
     # Os OUTROS links pendentes desta pessoa morrem junto. Pedir três e-mails e
     # usar um não pode deixar dois links vivos numa caixa de entrada.
@@ -211,4 +227,9 @@ async def reset_password(raw: str, nova_senha: str, db: AsyncSession) -> bool:
         .values(revoked=True)
     )
     await db.commit()
+
+    # A vítima de força bruta (check_throttle roda antes da senha na rota de
+    # login, ver AGENTS.md) precisa de uma saída: redefinir a senha zera o
+    # contador da conta, senão o 429 sobrevive à própria correção.
+    await record_success(user.email, db)
     return True

--- a/backend/app/services/email_service.py
+++ b/backend/app/services/email_service.py
@@ -29,7 +29,14 @@ TIMEOUT = 10.0
 
 
 class EmailNotConfigured(Exception):
-    """Sem `BREVO_API_KEY`. O router traduz para 503."""
+    """Sem `BREVO_API_KEY` no momento do envio.
+
+    O router já barra isso alto, ANTES de agendar o envio (checagem em
+    `auth.py`, resposta 503) — na prática esta exceção é a última linha de
+    defesa, só alcançável se a chave sumir entre o pre-check e a BackgroundTask
+    rodar. `_mandar_link` a engole em silêncio, sem logar: a resposta já foi
+    entregue e não há para quem reportar o erro.
+    """
 
 
 class EmailFailed(Exception):
@@ -102,10 +109,11 @@ def html_recuperacao(link: str) -> str:
     Texto curto de propósito. E-mail de recuperação é lido com pressa, muitas
     vezes no celular, por alguém já irritado por não conseguir entrar.
     """
+    minutos = get_settings().password_reset_expire_minutes
     return f"""<div style="font-family:system-ui,-apple-system,Segoe UI,sans-serif;line-height:1.6">
   <p>Você pediu para redefinir sua senha do Norby.</p>
   <p>Abra este endereço para criar uma nova senha:</p>
   <p><a href="{link}">{link}</a></p>
-  <p>O link vale por 30 minutos e só pode ser usado uma vez.</p>
+  <p>O link vale por {minutos} minutos e só pode ser usado uma vez.</p>
   <p>Se não foi você que pediu, ignore este e-mail: sua senha continua a mesma.</p>
 </div>"""

--- a/backend/app/services/throttle_service.py
+++ b/backend/app/services/throttle_service.py
@@ -20,8 +20,15 @@ _MAX_WAIT_SECONDS = 60
 _PURGE_AFTER = timedelta(hours=24)
 
 
-def _key_hash(email: str) -> str:
-    """HMAC-SHA256 do email normalizado. Nunca gravar o email cru na tabela."""
+def email_key_hash(email: str) -> str:
+    """Chave por conta: strip + lower, depois HMAC-SHA256 com o secret do servidor.
+
+    Pública porque `limiter.py` reusa a MESMA chave para `reset_email_key`
+    (POST /auth/forgot-password) — throttle de login e teto de recuperação
+    protegem a mesma conta, então a chave tem que ser idêntica. HMAC, não
+    sha256 puro: sem o secret, ninguém reconstrói a chave rehasheando uma
+    lista de e-mails candidatos (o que um hash sozinho permitiria).
+    """
     normalized = email.strip().lower()
     return hmac.new(
         settings.secret_key.encode(), normalized.encode(), hashlib.sha256
@@ -44,7 +51,7 @@ async def _purge_expired(db: AsyncSession) -> None:
 async def check_throttle(email: str, db: AsyncSession) -> int | None:
     """None = pode prosseguir. Caso contrário, segundos restantes de espera."""
     row = await db.scalar(
-        select(LoginThrottle).where(LoginThrottle.key_hash == _key_hash(email))
+        select(LoginThrottle).where(LoginThrottle.key_hash == email_key_hash(email))
     )
     if row is None:
         return None
@@ -75,7 +82,7 @@ async def record_failure(email: str, db: AsyncSession) -> None:
     é resolvido pelo índice único que já existe em key_hash, sem exception.
     """
     await _purge_expired(db)
-    key = _key_hash(email)
+    key = email_key_hash(email)
     now = datetime.now(timezone.utc)
     stmt = pg_insert(LoginThrottle).values(key_hash=key, failure_count=1, last_failure_at=now)
     stmt = stmt.on_conflict_do_update(
@@ -91,5 +98,5 @@ async def record_failure(email: str, db: AsyncSession) -> None:
 
 async def record_success(email: str, db: AsyncSession) -> None:
     """Login/cadastro bem-sucedido reseta o contador daquela chave."""
-    await db.execute(delete(LoginThrottle).where(LoginThrottle.key_hash == _key_hash(email)))
+    await db.execute(delete(LoginThrottle).where(LoginThrottle.key_hash == email_key_hash(email)))
     await db.commit()

--- a/backend/requirements-dev.lock
+++ b/backend/requirements-dev.lock
@@ -77,7 +77,7 @@ httptools==0.8.0
     # via uvicorn
 httpx==0.28.1
     # via
-    #   -r requirements-dev.txt
+    #   -r requirements.txt
     #   google-genai
 idna==3.18
     # via

--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -2,5 +2,6 @@
 -r requirements.txt
 pytest==9.1.1
 pytest-asyncio==1.4.0
-httpx==0.28.1  # cliente de teste (AsyncClient); não é dep de produção
+# httpx virou dep de produção (email_service/Brevo, ver requirements.txt);
+# o AsyncClient de teste é o mesmo pacote, sem pin duplicado aqui.
 pip-audit==2.10.1

--- a/backend/requirements.lock
+++ b/backend/requirements.lock
@@ -65,7 +65,9 @@ httpcore==1.0.9
 httptools==0.8.0
     # via uvicorn
 httpx==0.28.1
-    # via google-genai
+    # via
+    #   -r requirements.txt
+    #   google-genai
 idna==3.18
     # via
     #   anyio

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -16,6 +16,7 @@ google-genai==2.22.0
 email-validator==2.3.0
 bcrypt==5.0.0
 slowapi==0.1.10
+httpx==0.28.1  # email_service (Brevo)
 # Billing (ADR 0001). O SDK entra por causa da verificação de assinatura do
 # webhook: ela precisa ser timing-safe e checar a tolerância de timestamp
 # contra replay, e isso não é lugar para HMAC feito à mão.

--- a/backend/tests/test_auth_throttle.py
+++ b/backend/tests/test_auth_throttle.py
@@ -87,9 +87,9 @@ async def test_stale_rows_are_purged_on_write(client, db_session):
     from datetime import datetime, timedelta, timezone
 
     from app.models.sql_models import LoginThrottle
-    from app.services.throttle_service import _key_hash
+    from app.services.throttle_service import email_key_hash
 
-    stale_key = _key_hash("velho@test.com")
+    stale_key = email_key_hash("velho@test.com")
     stale = LoginThrottle(
         key_hash=stale_key,
         failure_count=5,
@@ -225,7 +225,7 @@ async def test_after_waiting_the_retry_after_window_the_attempt_goes_through(cli
     from sqlalchemy import select
 
     from app.models.sql_models import LoginThrottle
-    from app.services.throttle_service import _key_hash
+    from app.services.throttle_service import email_key_hash
 
     email = "espera@test.com"
     for _ in range(3):
@@ -239,7 +239,7 @@ async def test_after_waiting_the_retry_after_window_the_attempt_goes_through(cli
     # Simula a espera empurrando last_failure_at pra trás, sem dormir de
     # verdade no teste.
     row = (
-        await db_session.execute(select(LoginThrottle).where(LoginThrottle.key_hash == _key_hash(email)))
+        await db_session.execute(select(LoginThrottle).where(LoginThrottle.key_hash == email_key_hash(email)))
     ).scalar_one()
     row.last_failure_at = datetime.now(timezone.utc) - timedelta(seconds=retry_after + 1)
     await db_session.commit()
@@ -253,11 +253,11 @@ async def test_wait_is_capped_at_60_seconds(client, db_session):
     from datetime import datetime, timezone
 
     from app.models.sql_models import LoginThrottle
-    from app.services.throttle_service import _key_hash
+    from app.services.throttle_service import email_key_hash
 
     email = "capado@test.com"
     db_session.add(LoginThrottle(
-        key_hash=_key_hash(email), failure_count=20, last_failure_at=datetime.now(timezone.utc),
+        key_hash=email_key_hash(email), failure_count=20, last_failure_at=datetime.now(timezone.utc),
     ))
     await db_session.commit()
 
@@ -276,11 +276,11 @@ async def test_retry_after_stays_capped_when_the_clock_walks_backwards(client, d
     from datetime import datetime, timedelta, timezone
 
     from app.models.sql_models import LoginThrottle
-    from app.services.throttle_service import _key_hash
+    from app.services.throttle_service import email_key_hash
 
     email = "relogio-torto@test.com"
     db_session.add(LoginThrottle(
-        key_hash=_key_hash(email),
+        key_hash=email_key_hash(email),
         failure_count=20,
         last_failure_at=datetime.now(timezone.utc) + timedelta(minutes=5),
     ))
@@ -300,11 +300,11 @@ async def test_repeated_429_does_not_extend_the_wait(client, db_session):
     from datetime import datetime, timezone
 
     from app.models.sql_models import LoginThrottle
-    from app.services.throttle_service import _key_hash
+    from app.services.throttle_service import email_key_hash
 
     email = "sempre-bloqueado@test.com"
     db_session.add(LoginThrottle(
-        key_hash=_key_hash(email), failure_count=10, last_failure_at=datetime.now(timezone.utc),
+        key_hash=email_key_hash(email), failure_count=10, last_failure_at=datetime.now(timezone.utc),
     ))
     await db_session.commit()
 
@@ -337,7 +337,7 @@ async def test_concurrent_first_failures_do_not_500_or_lose_count(db_session):
     from sqlalchemy import select
 
     from app.models.sql_models import LoginThrottle
-    from app.services.throttle_service import _key_hash, record_failure
+    from app.services.throttle_service import email_key_hash, record_failure
     from tests.conftest import TestSessionLocal
 
     email = "concorrente@test.com"
@@ -352,6 +352,6 @@ async def test_concurrent_first_failures_do_not_500_or_lose_count(db_session):
     await asyncio.gather(*[_fail() for _ in range(5)])
 
     row = (
-        await db_session.execute(select(LoginThrottle).where(LoginThrottle.key_hash == _key_hash(email)))
+        await db_session.execute(select(LoginThrottle).where(LoginThrottle.key_hash == email_key_hash(email)))
     ).scalar_one()
     assert row.failure_count == 5

--- a/backend/tests/test_password_reset.py
+++ b/backend/tests/test_password_reset.py
@@ -13,8 +13,9 @@ import pytest
 from sqlalchemy import select
 
 import app.routers.auth as auth_router
-from app.models.sql_models import PasswordResetToken, RefreshToken, User
+from app.models.sql_models import LoginThrottle, PasswordResetToken, RefreshToken, User
 from app.services.auth_service import _hash_token
+from app.services.throttle_service import email_key_hash
 
 
 @pytest.fixture(autouse=True)
@@ -24,10 +25,8 @@ def brevo_configurado(monkeypatch):
     from app.config import get_settings
 
     settings = get_settings()
-    antes = settings.brevo_api_key
-    settings.brevo_api_key = "xkeysib-teste"
+    monkeypatch.setattr(settings, "brevo_api_key", "xkeysib-teste")
     yield settings
-    settings.brevo_api_key = antes
 
 
 @pytest.fixture
@@ -73,6 +72,20 @@ async def test_answers_the_same_for_an_unknown_email(client, enviados):
     # tem conta no Norby, a mesma enumeração que o login evita.
     assert a.status_code == b.status_code == 202
     assert a.json() == b.json()
+
+
+@pytest.mark.asyncio
+async def test_forgot_password_is_case_insensitive_on_email(client, enviados):
+    # A rota é a única das quatro (register/login/PUT me/forgot-password) que
+    # não normalizava caixa: quem se cadastrou como "Joao@x.com" e digitava
+    # "joao@x.com" aqui recebia 202 e nenhum e-mail (fix round 2, issue #22).
+    email, _ = await registrar(client)
+    outra_caixa = email.upper()
+
+    res = await client.post("/auth/forgot-password", json={"email": outra_caixa})
+
+    assert res.status_code == 202
+    assert enviados[-1]["para"] == email
 
 
 @pytest.mark.asyncio
@@ -186,6 +199,32 @@ async def test_an_expired_token_is_refused(client, enviados, db_session):
     assert res.status_code == 400
 
 
+@pytest.mark.asyncio
+async def test_reset_clears_the_victims_throttle(client, enviados, db_session):
+    # Sem isso, uma vítima sob ataque (alguém errando a senha dela 1x/min)
+    # continuava recebendo 429 do check_throttle mesmo depois de trocar a
+    # senha — a única saída que a issue #22 prometia pra vítima não saía do
+    # papel (fix round 2).
+    email, _ = await registrar(client, senha="secret123")
+    await client.post("/auth/forgot-password", json={"email": email})
+    token = link_do(enviados)
+
+    # Arma o throttle igual a test_auth_throttle.py: contador alto direto na
+    # tabela, sem esperar as falhas de verdade.
+    db_session.add(LoginThrottle(
+        key_hash=email_key_hash(email), failure_count=20, last_failure_at=datetime.now(timezone.utc),
+    ))
+    await db_session.commit()
+
+    reset = await client.post(
+        "/auth/reset-password", json={"token": token, "new_password": "novasenha1"}
+    )
+    assert reset.status_code == 204
+
+    res = await client.post("/auth/login", json={"email": email, "password": "novasenha1"})
+    assert res.status_code == 200
+
+
 # --- O token no banco --------------------------------------------------------
 
 
@@ -237,6 +276,8 @@ async def test_without_a_brevo_key_it_refuses_loudly(client, brevo_configurado):
 
 @pytest.mark.asyncio
 async def test_the_email_carries_a_link_to_the_reset_page(client, enviados):
+    from app.config import get_settings
+
     email, _ = await registrar(client)
     await client.post("/auth/forgot-password", json={"email": email})
 
@@ -244,8 +285,10 @@ async def test_the_email_carries_a_link_to_the_reset_page(client, enviados):
     assert enviados[-1]["para"] == email
     assert "/redefinir-senha?token=" in html
     # A pessoa precisa saber que o link morre, senão um link expirado parece
-    # um link quebrado e vira chamado de suporte.
-    assert "30 minutos" in html
+    # um link quebrado e vira chamado de suporte. O número vem de
+    # `settings.password_reset_expire_minutes`, não de um literal no texto.
+    minutos = get_settings().password_reset_expire_minutes
+    assert f"{minutos} minutos" in html
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

One fix commit addressing the backend findings of the round-2 code review of wave 2 (rate limiting, password recovery, CI):

- `forgot-password` looks up the account case-insensitively (new `find_user_by_email` helper in `auth_service.py`, also used by `register` and `login`); it was the only one of the four email lookups still comparing case-sensitively, so a user registered as `Joao@x.com` typing `joao@x.com` got a silent 202 with no e-mail
- `reset_password` now calls `record_success` after changing the password, clearing the login throttle so a victim under brute-force is not stuck at 429 after resetting
- `/auth/forgot-password` and `/auth/reset-password` IP ceilings raised from 60/min and 20/min to 200/min, matching issue #22's design (flood protection only, well above legitimate peak); the 3/hour per-e-mail limit is unchanged
- `reset_email_key` (in `limiter.py`) now reuses `throttle_service`'s HMAC (`_key_hash` renamed to public `email_key_hash`) instead of a separate plain sha256, so the login throttle and the recovery ceiling key the same account identically
- `httpx` pinned as a production dependency (`email_service`/Brevo) instead of riding in only as a transitive dep of `google-genai`; both locks regenerated
- `hash_password` in `reset_password` moved off the event loop via `asyncio.to_thread`, matching the rest of `auth.py`
- password reset e-mail body interpolates `password_reset_expire_minutes` instead of a hardcoded "30 minutos"
- `EmailNotConfigured` docstring corrected to describe it as the last line of defense behind the router's loud 503 pre-check, silently swallowed by `_mandar_link`
- `brevo_configurado` test fixture uses `monkeypatch.setattr` instead of manual attribute mutation/restore
- `AGENTS.md`: recovery is now documented as the victim's way out of the throttle (since PR #116), the new forgot/reset-password rate limits are listed next to the other accepted flood-only ceilings, and a short note documents that `pip-audit` (no severity filter) is stricter than issue #37's "high only" while the Lighthouse job is a post-deploy alarm, not a merge gate

## Test plan

- [x] `docker exec norby_backend pytest tests/test_password_reset.py tests/test_auth_throttle.py tests/test_refresh.py -q` — 43 passed
- [x] `docker exec norby_backend python -c "import app.main"` — no circular import after the `throttle_service` ⇄ `auth_service`/`limiter` wiring
- [x] `docker exec -w /app norby_backend python scripts/check_locks.py` — locks in sync after pinning `httpx`
- [x] `docker exec norby_backend pytest -q` — full suite, 329 passed
