### PR TITLE
fix(api): close /docs, /redoc and /openapi.json in production

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -59,4 +59,10 @@ BREVO_SENDER_NAME=Norby
 PASSWORD_RESET_EXPIRE_MINUTES=30
 
 # Paywall da v2 (ADR 0002). Desligado = app se comporta como antes.
+# /docs, /redoc e /openapi.json. Ligado aqui porque em DESENVOLVIMENTO eles são
+# a ferramenta principal para explorar a API. Em produção NÃO crie esta
+# variável: o default do código é `false`, e o lado seguro tem de ser o que
+# acontece quando alguém esquece.
+DOCS_ENABLED=true
+
 PAYWALL_ENABLED=false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -347,6 +347,11 @@ protege o token é a entropia dos 48 bytes, não o contador.
   E como `/auth/forgot-password` responde 202 exista ou não a conta, a falha não
   aparece para quem pediu o link: some no log do servidor. Manter DESLIGADO
   enquanto o egresso não for estático. Teto do plano gratuito: 300 e-mails/dia.
+- **`DOCS_ENABLED` não existe em produção, e é assim de propósito.** O default
+  do código é `false`, então esquecer a variável mantém `/docs`, `/redoc` e
+  `/openapi.json` FECHADOS (issue #29). Criá-la com `true` no Railway publica
+  todas as rotas, todos os campos e todos os formatos de erro da API. Em
+  desenvolvimento ela vem ligada pelo `.env.example`, que é onde ela serve.
 - **Ligar `PAYWALL_ENABLED` sem `VITE_FORNECEDOR_NOME` e `VITE_FORNECEDOR_CPF`
   na Vercel é cobrar com Termos incompletos.** O Decreto 7.962/2013, art. 2º, I
   exige nome e CPF/CNPJ do vendedor no site; sem as variáveis, a seção 2 dos

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -49,6 +49,13 @@ class Settings(BaseSettings):
     # e-mail, e caixa de e-mail comprometida é o vetor que este token abre.
     password_reset_expire_minutes: int = 30
 
+    # /docs, /redoc e /openapi.json (issue #29). Default DESLIGADO, ao contrário
+    # de quase todo flag de conveniência: esquecer a variável em produção tem de
+    # deixar o estado SEGURO, não o exposto. O openapi publica todas as rotas,
+    # todos os campos e todos os formatos de erro; com dinheiro de terceiro em
+    # jogo, isso é mapa de graça. Em dev vem ligado pelo `.env.example`.
+    docs_enabled: bool = False
+
     # Flag de rollout do paywall (ADR 0002). Default DESLIGADO: o merge não muda
     # nada em produção, e o paywall acende por variável de ambiente quando o
     # dono decidir. Lido SÓ dentro dos helpers de enforcement — um `if` num

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -35,10 +35,19 @@ logger = logging.getLogger("norby")
 
 settings = get_settings()
 
+# `None` remove a rota inteira, e não apenas a página: sem `openapi_url` não há
+# schema para servir, então /docs e /redoc não teriam o que renderizar de todo
+# jeito. Os três são explícitos porque um leitor futuro precisa ver que a
+# decisão foi tomada, e não deduzir que o FastAPI cuidou disso sozinho.
+_docs = settings.docs_enabled
+
 app = FastAPI(
     title="Norby API",
     description="Backend do Organizador Financeiro com IA",
     version="0.1.0",
+    docs_url="/docs" if _docs else None,
+    redoc_url="/redoc" if _docs else None,
+    openapi_url="/openapi.json" if _docs else None,
 )
 
 # Rate limiting (anti brute-force). Respostas 429 passam pelo CORS normalmente.

--- a/backend/tests/test_ai_contract.py
+++ b/backend/tests/test_ai_contract.py
@@ -1,9 +1,11 @@
 import pytest
 
+from app.main import app
+
 
 @pytest.mark.asyncio
-async def test_ai_routes_expose_response_models_in_openapi(client):
-    spec = (await client.get("/openapi.json")).json()
+async def test_ai_routes_expose_response_models_in_openapi():
+    spec = app.openapi()
     schemas = spec["components"]["schemas"]
 
     def resp_schema(path, method="get"):
@@ -25,6 +27,6 @@ async def test_ai_routes_expose_response_models_in_openapi(client):
 
 
 @pytest.mark.asyncio
-async def test_ai_chat_documents_503_in_openapi(client):
-    spec = (await client.get("/openapi.json")).json()
+async def test_ai_chat_documents_503_in_openapi():
+    spec = app.openapi()
     assert "503" in spec["paths"]["/ai/chat"]["post"]["responses"]

--- a/backend/tests/test_ai_history.py
+++ b/backend/tests/test_ai_history.py
@@ -62,8 +62,8 @@ async def test_get_session_404_for_other_user(client, monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_session_detail_route_in_openapi(client):
-    spec = (await client.get("/openapi.json")).json()
+async def test_session_detail_route_in_openapi():
+    spec = app.openapi()
     path = spec["paths"]["/ai/chat/sessions/{session_id}"]["get"]
     ref = path["responses"]["200"]["content"]["application/json"]["schema"].get("$ref", "")
     assert ref.endswith("/ChatSessionDetail")

--- a/backend/tests/test_docs_exposure.py
+++ b/backend/tests/test_docs_exposure.py
@@ -1,0 +1,62 @@
+"""A superfície de documentação da API (issue #29).
+
+O `/openapi.json` publica todas as rotas, todos os campos de todos os schemas e
+todos os formatos de erro. Enquanto o Norby não cobrava, isso era conveniência.
+Com dinheiro e dado financeiro de terceiros, virou mapa entregue de graça. E
+fechar o repositório NÃO resolveria: o endpoint é servido em produção,
+independente de o código ser público ou não.
+
+Os dois testes guardam coisas diferentes. O primeiro trava o DEFAULT, que é
+onde mora a segurança de verdade. O segundo trava a LIGAÇÃO entre a variável e
+o app, que é o que um refactor quebra sem perceber.
+
+Por que são `async` sem tocar em I/O: o `conftest` tem uma fixture `autouse`
+assíncrona que cria e derruba o schema a cada teste. Um teste síncrono no meio
+da suíte não fecha o ciclo dela, o `drop_all` não roda, e o teste SEGUINTE
+morre em `CREATE TYPE ... already exists`. O sintoma aparece longe da causa,
+então não "simplifique" isto para `def`.
+"""
+
+import pytest
+
+from app.config import Settings
+from app.main import app, settings
+
+
+def _settings_limpo(**extra) -> Settings:
+    """Settings sem ler o `.env`, senão o teste mede a máquina de quem roda."""
+    return Settings(
+        database_url="postgresql://localhost/norby",
+        mongodb_url="mongodb://localhost/norby",
+        secret_key="test-secret",
+        gemini_api_key="test-key",
+        _env_file=None,
+        **extra,
+    )
+
+
+@pytest.mark.asyncio
+async def test_docs_are_closed_unless_someone_asks_for_them():
+    # ESTE é o teste que importa. Se alguém trocar o default para `True`
+    # achando que "documentação aberta é boa prática", produção volta a expor
+    # o schema inteiro no primeiro deploy, sem ninguém mudar variável nenhuma
+    # e sem nada falhar em lugar algum. O default é a única defesa contra o
+    # esquecimento, porque a variável não existe no Railway de propósito.
+    assert _settings_limpo().docs_enabled is False
+    assert _settings_limpo(docs_enabled=True).docs_enabled is True
+
+
+@pytest.mark.asyncio
+async def test_the_setting_actually_reaches_the_app():
+    # Um default seguro não serve de nada se o `FastAPI(...)` ignorar a
+    # variável. Os três precisam concordar com ela nos dois sentidos: ligada,
+    # existem; desligada, somem.
+    ligado = settings.docs_enabled
+
+    assert (app.openapi_url is not None) is ligado
+    assert (app.docs_url is not None) is ligado
+    assert (app.redoc_url is not None) is ligado
+
+    # E o schema continua sendo gerado em memória com a rota fechada, que é o
+    # que permite aos testes de contrato lerem `app.openapi()` sem HTTP.
+    assert app.openapi()["paths"]


### PR DESCRIPTION
Closes #29's open decision.

## The finding

```
api.norby.com.br/docs          -> 200
api.norby.com.br/redoc         -> 200
api.norby.com.br/openapi.json  -> 200
```

The schema publishes every route, every field of every model and every error
shape. That was convenience while nothing was being charged. Now that the
paywall is on and real money moves through it, it is a free map.

Worth stating because it came out of a question about repository visibility:
**making the repo private would not have fixed this.** The endpoint is served
from production regardless of who can read the source. The two exposures are
unrelated, and only one of them had a two-line fix.

## The default is the actual security control

`DOCS_ENABLED` defaults to **false**, which is the opposite of what a
convenience flag usually does. The reason is the failure mode: forgetting the
variable in production has to leave the SAFE state, not the exposed one. This
matches how `paywall_enabled` and the Stripe secrets already behave in this
codebase, where absence always means off.

Production therefore gets no new variable at all. Development gets them from
`.env.example`, which is where they are useful.

## Contract tests no longer go over HTTP

`test_ai_contract.py` and `test_ai_history.py` fetched `/openapi.json` through
the client. They were verifying the generated contract, not its public
exposure, so they now read `app.openapi()` directly. FastAPI still builds the
schema in memory when the route is closed.

## Testing

Two mutations, each killed by the test that owns it:

| Mutation | Fails |
|---|---|
| default flipped to `True` | `test_docs_are_closed_unless_someone_asks_for_them` |
| `docs_url="/docs"` hardcoded | `test_the_setting_actually_reaches_the_app` |

Full backend suite: **331 passed**.

One gotcha worth recording, because it cost time here: the new tests are
`async` despite touching no I/O. The `conftest` schema fixture is `autouse` and
asynchronous, so a synchronous test skips its `drop_all` and the *next* test
dies with `CREATE TYPE ... already exists`. The symptom lands far from the
cause. There is a comment in the file saying so.

## After merge

Nothing to set in the Railway panel. Confirm with:

```
curl -o /dev/null -w '%{http_code}\n' https://api.norby.com.br/openapi.json
```

Expected: **404**.