### PR TITLE
chore(auth): replace python-jose with PyJWT

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,10 +85,7 @@ jobs:
         run: pytest
 
       - name: pip-audit
-        # PYSEC-2026-1325 é uma exceção aceita, documentada no AGENTS.md:
-        # python-jose puxa o ecdsa, e Settings.algorithm só permite HS256,
-        # então o caminho de assinatura ECDSA/ECDH vulnerável é inatingível.
-        run: pip-audit -r requirements.lock --ignore-vuln PYSEC-2026-1325
+        run: pip-audit -r requirements.lock
 
   frontend:
     name: Frontend lint + test + build

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@
 
 - **Backend:** FastAPI 0.139 + SQLAlchemy 2.0 async + Alembic · PostgreSQL 16
   (relacional) + MongoDB 7 via Motor (blocos de texto da IA) · Auth JWT
-  (python-jose) · IA **Gemini 3.5 Flash Lite** (`models/gemini-3.5-flash-lite`,
+  (PyJWT) · IA **Gemini 3.5 Flash Lite** (`models/gemini-3.5-flash-lite`,
   ver `services/ai_service.py`) · gerenciador de pacotes **uv**.
 - **Frontend:** React 19 + Vite 8 · TailwindCSS + shadcn/ui · Zustand ·
   React Router v7 · React Hook Form + Zod · axios.
@@ -41,7 +41,7 @@ alembic revision -m "descricao"                             # nova migration (pr
 uv pip compile --universal --python-version 3.12 requirements.txt -o requirements.lock
 uv pip compile --universal --python-version 3.12 requirements-dev.txt -o requirements-dev.lock
 uv pip install -r requirements-dev.lock                     # deps + ferramentas de dev/CI
-pip-audit -r requirements.lock --ignore-vuln PYSEC-2026-1325 # audit; exceção abaixo
+pip-audit -r requirements.lock                               # audit de vulnerabilidades
 ```
 Banco de teste (uma vez, apenas em dev): criar um banco `norby_test` no Postgres local usando um usuário com permissão de criar bancos. Essa permissão é específica do ambiente de desenvolvimento — não replicar em produção.
 
@@ -85,9 +85,6 @@ npm run test     # Vitest
   Existe porque quem instala é o `.lock` — bumpar só o `.txt` deixa o container
   na versão antiga com a CI verde. É exatamente o que os PRs de pip do
   Dependabot fazem: eles não sabem regenerar lock de `uv`.
-- Exceção do audit: `python-jose` traz `ecdsa`, afetado por
-  `PYSEC-2026-1325` sem versão corrigida. `Settings.algorithm` aceita somente
-  `HS256`, então o caminho vulnerável de assinatura ECDSA/ECDH não é alcançável.
 - `pip-audit` não tem filtro de severidade: o gate do backend reprova em
   qualquer advisory, mais estrito que o "só high" da issue #37 (`npm audit
   --audit-level=high` é quem casa com aquele critério). O job de Lighthouse só

--- a/backend/app/dependencies.py
+++ b/backend/app/dependencies.py
@@ -3,7 +3,7 @@ from fastapi import Depends, HTTPException, status
 from fastapi.security import OAuth2PasswordBearer
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select
-from jose import JWTError, jwt
+import jwt  # PyJWT. Era: from jose import JWTError, jwt
 from app.database import AsyncSessionLocal
 from app.models.sql_models import User
 from app.services.billing_service import reconcile_subscription
@@ -42,7 +42,7 @@ async def get_current_user( # Autenticação
             raise credentials_exception
         # Converte o sub p/ UUID aqui: um sub forjado/corrompido vira 401, não 500
         user_uuid = uuid.UUID(user_id)
-    except (JWTError, ValueError, TypeError):
+    except (jwt.PyJWTError, ValueError, TypeError):
         raise credentials_exception
 
     result = await db.execute(select(User).where(User.id == user_uuid)) # Busca usuário no banco

--- a/backend/app/limiter.py
+++ b/backend/app/limiter.py
@@ -1,6 +1,6 @@
 import hashlib
 
-from jose import JWTError, jwt
+import jwt  # PyJWT. Era: from jose import JWTError, jwt
 from slowapi import Limiter
 from slowapi.util import get_remote_address
 from starlette.requests import Request
@@ -37,7 +37,7 @@ def user_key(request: Request) -> str:
             sub = payload.get("sub")
             if sub:
                 return f"user:{sub}"
-        except JWTError:
+        except jwt.PyJWTError:
             pass
     return get_remote_address(request)
 

--- a/backend/app/services/auth_service.py
+++ b/backend/app/services/auth_service.py
@@ -3,7 +3,7 @@ import hashlib
 import secrets
 from datetime import datetime, timedelta, timezone
 
-from jose import jwt
+import jwt  # PyJWT. Era: from jose import jwt
 from sqlalchemy import func, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 

--- a/backend/requirements-dev.lock
+++ b/backend/requirements-dev.lock
@@ -40,7 +40,6 @@ cryptography==50.0.0
     # via
     #   -r requirements.txt
     #   google-auth
-    #   python-jose
 cyclonedx-python-lib==11.11.0
     # via pip-audit
 defusedxml==0.7.1
@@ -53,8 +52,6 @@ dnspython==2.8.0
     # via
     #   email-validator
     #   pymongo
-ecdsa==0.19.2
-    # via python-jose
 email-validator==2.3.0
     # via -r requirements.txt
 fastapi==0.141.1
@@ -128,10 +125,7 @@ pluggy==1.6.0
 py-serializable==2.1.0
     # via cyclonedx-python-lib
 pyasn1==0.6.4
-    # via
-    #   pyasn1-modules
-    #   python-jose
-    #   rsa
+    # via pyasn1-modules
 pyasn1-modules==0.4.2
     # via google-auth
 pycparser==3.0 ; implementation_name != 'PyPy' and platform_python_implementation != 'PyPy'
@@ -149,6 +143,8 @@ pygments==2.20.0
     # via
     #   pytest
     #   rich
+pyjwt==2.13.0
+    # via -r requirements.txt
 pymongo==4.9.2
     # via motor
 pyparsing==3.3.2
@@ -164,8 +160,6 @@ python-dotenv==1.2.3
     #   -r requirements.txt
     #   pydantic-settings
     #   uvicorn
-python-jose==3.5.0
-    # via -r requirements.txt
 python-multipart==0.0.32
     # via -r requirements.txt
 pyyaml==6.0.3
@@ -179,10 +173,6 @@ requests==2.34.2
     #   stripe
 rich==15.0.0
     # via pip-audit
-rsa==4.9.1
-    # via python-jose
-six==1.17.0
-    # via ecdsa
 slowapi==0.1.10
     # via -r requirements.txt
 sniffio==1.3.1

--- a/backend/requirements.lock
+++ b/backend/requirements.lock
@@ -35,7 +35,6 @@ cryptography==50.0.0
     # via
     #   -r requirements.txt
     #   google-auth
-    #   python-jose
 deprecated==1.3.1
     # via limits
 distro==1.9.0
@@ -44,8 +43,6 @@ dnspython==2.8.0
     # via
     #   email-validator
     #   pymongo
-ecdsa==0.19.2
-    # via python-jose
 email-validator==2.3.0
     # via -r requirements.txt
 fastapi==0.141.1
@@ -87,10 +84,7 @@ packaging==26.2
 pillow==12.3.0
     # via -r requirements.txt
 pyasn1==0.6.4
-    # via
-    #   pyasn1-modules
-    #   python-jose
-    #   rsa
+    # via pyasn1-modules
 pyasn1-modules==0.4.2
     # via google-auth
 pycparser==3.0 ; implementation_name != 'PyPy' and platform_python_implementation != 'PyPy'
@@ -104,6 +98,8 @@ pydantic-core==2.46.4
     # via pydantic
 pydantic-settings==2.15.0
     # via -r requirements.txt
+pyjwt==2.13.0
+    # via -r requirements.txt
 pymongo==4.9.2
     # via motor
 python-dotenv==1.2.3
@@ -111,8 +107,6 @@ python-dotenv==1.2.3
     #   -r requirements.txt
     #   pydantic-settings
     #   uvicorn
-python-jose==3.5.0
-    # via -r requirements.txt
 python-multipart==0.0.32
     # via -r requirements.txt
 pyyaml==6.0.3
@@ -122,10 +116,6 @@ requests==2.34.2
     #   google-auth
     #   google-genai
     #   stripe
-rsa==4.9.1
-    # via python-jose
-six==1.17.0
-    # via ecdsa
 slowapi==0.1.10
     # via -r requirements.txt
 sniffio==1.3.1

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -4,15 +4,14 @@ sqlalchemy[asyncio]==2.0.52
 asyncpg==0.30.0
 alembic==1.19.1
 motor==3.7.1
-python-jose[cryptography]==3.5.0
-# Pin de transitiva por seguranca: o python-jose puxa cryptography, e a 49.0.0
-# tem PYSEC-2026-3552 (oraculo em decrypt PKCS7). O Norby nao usa PKCS7 e o JWT
-# e so HS256, entao nao ha caminho alcancavel, mas o gate de release do
-# AGENTS.md exige o pip-audit limpo.
-cryptography==50.0.0
+PyJWT==2.13.0  # JWT HS256 do access token. Substituiu o python-jose (issue #29): sem ecdsa, sem cryptography.
 python-dotenv==1.2.3
 pydantic-settings==2.15.0
 google-genai==2.22.0
+# Pin de transitiva: nao e o python-jose que puxa mais (removido, issue #29),
+# e sim o google-auth (dependencia do google-genai). Fixado so pra deixar o
+# dependente real documentado; sem CVE aberto pendente sobre ela hoje.
+cryptography==50.0.0
 email-validator==2.3.0
 bcrypt==5.0.0
 slowapi==0.1.10

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -1,4 +1,10 @@
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import jwt  # PyJWT. Caracterização (Step 2, ver task-2-report.md): passou igual com `from jose import jwt`.
 import pytest
+
+from app.config import get_settings
 
 REG = {
     "name": "Alice",
@@ -85,6 +91,30 @@ async def test_me_requires_token(client):
 @pytest.mark.asyncio
 async def test_me_with_invalid_token_401(client):
     res = await client.get("/auth/me", headers={"Authorization": "Bearer not.a.jwt"})
+    assert res.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_expired_access_token_is_rejected(client):
+    s = get_settings()
+    token = jwt.encode(
+        {"sub": str(uuid.uuid4()), "exp": datetime.now(timezone.utc) - timedelta(minutes=1)},
+        s.secret_key,
+        algorithm=s.algorithm,
+    )
+    res = await client.get("/auth/me", headers={"Authorization": f"Bearer {token}"})
+    assert res.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_token_signed_with_another_key_is_rejected(client):
+    s = get_settings()
+    token = jwt.encode(
+        {"sub": str(uuid.uuid4()), "exp": datetime.now(timezone.utc) + timedelta(minutes=5)},
+        "outra-chave-que-nao-e-a-do-servidor",
+        algorithm=s.algorithm,
+    )
+    res = await client.get("/auth/me", headers={"Authorization": f"Bearer {token}"})
     assert res.status_code == 401
 
 

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -1,7 +1,8 @@
 import uuid
 from datetime import datetime, timedelta, timezone
 
-import jwt  # PyJWT. Caracterização (Step 2, ver task-2-report.md): passou igual com `from jose import jwt`.
+import jwt  # PyJWT. Os dois testes abaixo são de caracterização: foram escritos e
+# passaram com o python-jose antes da troca, e têm de continuar passando aqui.
 import pytest
 
 from app.config import get_settings


### PR DESCRIPTION
HS256 only, so PyJWT covers it without pulling ecdsa or cryptography. Removes the standing PYSEC-2026-1325 exception from CI and AGENTS.md. Two characterization tests (expired token, wrong key) written before the swap and green on both libraries.