### PR TITLE
docs(agents): the fourth Stripe event, and the live billing cycle validated

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -183,6 +183,36 @@ Start em produção: `backend/start.sh` roda `alembic upgrade head` + uvicorn na
 `$PORT` do provedor (o `CMD` do `backend/Dockerfile`; o `docker-compose.yml` de
 dev sobrescreve com `--reload`).
 
+**O endpoint do Stripe assina QUATRO eventos, e o quarto é fácil de esquecer
+(2026-09-06):**
+
+```
+checkout.session.completed
+customer.subscription.created   <- o que move o premium_until na PRIMEIRA compra
+customer.subscription.updated
+customer.subscription.deleted
+```
+
+O `checkout.session.completed` **não traz período nenhum**: ele só amarra
+`stripe_customer_id` e `stripe_subscription_id`. Quem escreve o `premium_until`
+da primeira assinatura é o `created`. Assinar só três eventos, omitindo ele,
+NÃO derruba nada de forma visível: o retorno do Checkout chama
+`/billing/confirm-checkout` (#46), que busca a assinatura pela API e preenche o
+portão. O caminho principal fica desligado e ninguém percebe, porque a rede de
+segurança segura a primeira compra.
+
+Quebra de verdade para quem fecha a aba antes de voltar do Stripe. Aí só a
+reconciliação preguiçosa (#48) salva, e só no próximo request autenticado.
+Conferir a lista de eventos no painel é mais rápido do que diagnosticar isso
+depois.
+
+**Ciclo de cobrança validado em produção com dinheiro real (2026-09-06):**
+compra de R$ 20,00 em modo live, premium ativado, Portal do cliente aberto,
+cancelamento imediato via `DELETE /v1/subscriptions` e estorno integral. Cobre
+o art. 49 do CDC (arrependimento com devolução integral) e a exigência do
+Decreto 7.962/2013 de cancelar ser tão fácil quanto contratar. Taxa do Stripe
+na operação: R$ 1,19 sobre R$ 20,00, **não devolvida no estorno**.
+
 **Reembolso são DUAS ações, sempre (2026-09-05):** estornar a cobrança no
 painel do Stripe **não cancela a assinatura**. Os quatro eventos que o webhook
 assina não incluem nada de estorno, então só devolver o dinheiro deixa


### PR DESCRIPTION
Documentation only. No code touched.

## The fourth event

While configuring the live-mode webhook endpoint today I gave a three-event
list. The code handles **four**, and the missing one was the one that matters
most on a first purchase:

```
checkout.session.completed
customer.subscription.created   <- writes premium_until on the FIRST purchase
customer.subscription.updated
customer.subscription.deleted
```

`checkout.session.completed` carries no period. It only binds
`stripe_customer_id` and `stripe_subscription_id`; the code says so in a
comment. `customer.subscription.created` is what moves the gate.

**The reason this is worth a permanent note: omitting it fails silently.** The
Checkout return path (#46) fetches the subscription over the API and fills
`premium_until` anyway, so a first purchase succeeds and nothing looks wrong.
The primary path is simply dead. It only surfaces for someone who closes the
tab before returning from Stripe, and then only lazy reconciliation (#48)
rescues them, on their next authenticated request.

Checking the event list in the panel takes ten seconds. Diagnosing this later,
from a user saying "I paid and nothing happened", does not.

## The cycle ran in production with real money

Recorded with a date because it covers two legal obligations, not just two
features:

| Step | Result |
|---|---|
| Purchase, live mode, real card | R$ 20.00 accepted |
| Premium | activated |
| Customer Portal | opened and used |
| Cancellation | immediate, `DELETE /v1/subscriptions` |
| Refund | full |

CDC art. 49 gives a 7-day withdrawal right with full repayment; Decreto
7.962/2013 requires cancelling to be as easy as subscribing. Both were
exercised end to end before the first real customer exists.

Stripe's fee on the operation was R$ 1.19 on R$ 20.00, **not returned on the
refund**. Noted because it is the real cost of every refund the project ever
issues.