### PR TITLE
feat(auth): refresh token as an HttpOnly cookie (1/3, backend emits both)

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -13,7 +13,16 @@ class Settings(BaseSettings):
     algorithm: Literal["HS256"] = "HS256"
     access_token_expire_minutes: int = 15
     refresh_token_expire_days: int = 7
-    
+
+    # #110: o refresh token viaja num cookie HttpOnly do host da API, restrito
+    # a /auth. `Secure` acompanha o esquema da app: em produção é https; em
+    # localhost o navegador recusaria um cookie Secure sobre http.
+    refresh_cookie_name: str = "norby_refresh"
+
+    @property
+    def refresh_cookie_secure(self) -> bool:
+        return self.app_base_url.startswith("https://")
+
     # Gemini
     gemini_api_key: str
 

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -32,6 +32,7 @@ from app.services.throttle_service import check_throttle, record_failure, record
 
 router = APIRouter(prefix="/auth", tags=["Auth"])
 logger = logging.getLogger("norby.auth")
+settings = get_settings()
 
 
 def _throttled(retry_after: int) -> HTTPException:
@@ -56,6 +57,42 @@ def _log_xff(request: Request) -> None:
         request.url.path,
     )
 
+
+def _set_refresh_cookie(response: Response, raw: str) -> None:
+    # HttpOnly tira o token do alcance de qualquer script na página; Lax é o
+    # que fecha o CSRF, porque um POST cross-site não leva o cookie; Path=/auth
+    # mantém o cookie fora de todas as outras rotas.
+    response.set_cookie(
+        key=settings.refresh_cookie_name,
+        value=raw,
+        max_age=settings.refresh_token_expire_days * 86400,
+        httponly=True,
+        secure=settings.refresh_cookie_secure,
+        samesite="lax",
+        path="/auth",
+    )
+
+
+def _clear_refresh_cookie(response: Response) -> None:
+    response.delete_cookie(
+        settings.refresh_cookie_name,
+        path="/auth",
+        httponly=True,
+        secure=settings.refresh_cookie_secure,
+        samesite="lax",
+    )
+
+
+async def _refresh_body(request: Request, payload: RefreshRequest | None = None) -> str:
+    # Cookie primeiro (#110), corpo como transição para builds antigos do
+    # frontend. Carimba em request.state ANTES do decorator do slowapi rodar,
+    # porque refresh_token_key é síncrono e não vê o corpo parseado.
+    raw = request.cookies.get(settings.refresh_cookie_name) or (payload.refresh_token if payload else None)
+    if not raw:
+        raise HTTPException(status_code=401, detail="Refresh token ausente")
+    request.state.refresh_token = raw
+    return raw
+
 @router.post("/register", response_model=Token, status_code=status.HTTP_201_CREATED)
 # Teto global 60/min: só proteção contra flood, não é a defesa principal (ver
 # check_throttle abaixo). Compartilha o balde por-conta do login: tentativas
@@ -64,6 +101,7 @@ def _log_xff(request: Request) -> None:
 @limiter.limit("60/minute")
 async def register(
     request: Request,
+    response: Response,
     payload: UserRegister,
     db: AsyncSession = Depends(get_db),
     _xff: None = Depends(_log_xff),
@@ -113,6 +151,7 @@ async def register(
 
     access = create_access_token(str(user.id))
     refresh = await create_refresh_token(str(user.id), db)
+    _set_refresh_cookie(response, refresh)
     return Token(access_token=access, refresh_token=refresh, user=UserResponse.model_validate(user))
 
 @router.post("/login", response_model=Token)
@@ -122,6 +161,7 @@ async def register(
 @limiter.limit("200/minute")
 async def login(
     request: Request,
+    response: Response,
     payload: UserLogin,
     db: AsyncSession = Depends(get_db),
     _xff: None = Depends(_log_xff),
@@ -157,6 +197,7 @@ async def login(
 
     access = create_access_token(str(user.id))
     refresh = await create_refresh_token(str(user.id), db)
+    _set_refresh_cookie(response, refresh)
     return Token(access_token=access, refresh_token=refresh, user=UserResponse.model_validate(user))
 
 @router.post("/refresh", response_model=TokenPair)
@@ -168,22 +209,17 @@ async def login(
 @limiter.limit("600/minute")
 async def refresh_token(
     request: Request,
-    payload: RefreshRequest,
+    response: Response,
+    raw: str = Depends(_refresh_body),
     db: AsyncSession = Depends(get_db),
     _xff: None = Depends(_log_xff),
 ):
-    result = await rotate_refresh_token(payload.refresh_token, db)
+    result = await rotate_refresh_token(raw, db)
     if result is None:
         raise HTTPException(status_code=401, detail="Refresh token inválido ou expirado")
     access, new_refresh, _user = result
+    _set_refresh_cookie(response, new_refresh)
     return TokenPair(access_token=access, refresh_token=new_refresh)
-
-async def _refresh_body(request: Request, payload: RefreshRequest) -> RefreshRequest:
-    # Carimba o token em request.state ANTES do decorator do slowapi rodar,
-    # pra refresh_token_key (limiter.py) conseguir ler: o key_func é síncrono
-    # e só recebe `request`, sem acesso ao corpo já parseado pelo Pydantic.
-    request.state.refresh_token = payload.refresh_token
-    return payload
 
 @router.post("/logout", status_code=status.HTTP_204_NO_CONTENT)
 # Desde que o logout passou a derrubar TODAS as sessões ao receber um token já
@@ -200,12 +236,14 @@ async def _refresh_body(request: Request, payload: RefreshRequest) -> RefreshReq
 @limiter.limit("120/minute", key_func=refresh_token_key)
 async def logout(
     request: Request,
-    payload: RefreshRequest = Depends(_refresh_body),
+    response: Response,
+    raw: str = Depends(_refresh_body),
     db: AsyncSession = Depends(get_db),
     _xff: None = Depends(_log_xff),
 ):
     # Revoga o refresh recebido. Idempotente: token inexistente também retorna 204.
-    await revoke_refresh_token(payload.refresh_token, db)
+    await revoke_refresh_token(raw, db)
+    _clear_refresh_cookie(response)
 
 @router.get("/me", response_model=UserResponse)
 async def me(current_user: User = Depends(get_current_user)):

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -104,7 +104,8 @@ class TokenPair(BaseModel):
     token_type: str = "bearer"
 
 class RefreshRequest(BaseModel):
-    refresh_token: str
+    # Opcional desde o #110: o token pode vir no cookie. Some no passo 3.
+    refresh_token: str | None = None
 
 class DeleteAccountRequest(BaseModel):
     confirm: bool

--- a/backend/tests/test_refresh.py
+++ b/backend/tests/test_refresh.py
@@ -2,12 +2,16 @@ import asyncio
 
 import pytest
 
+from app.config import get_settings
+
 REG = {
     "name": "Bob",
     "email": "bob@test.com",
     "password": "secret123",
     "accept_privacy": True,
 }
+
+COOKIE = get_settings().refresh_cookie_name
 
 
 async def _register(client):
@@ -43,7 +47,11 @@ async def test_refresh_rotates_and_invalidates_old_token(client):
     again = await client.post("/auth/refresh", json={"refresh_token": new["refresh_token"]})
     assert again.status_code == 200
 
-    # O refresh antigo foi rotacionado: usá-lo de novo deve falhar.
+    # O refresh antigo foi rotacionado: usá-lo de novo deve falhar. O cookie
+    # tem precedência sobre o corpo (#110), e o jar do httpx já guarda o
+    # cookie mais recente; limpa antes para garantir que É o corpo antigo
+    # quem chega no servidor.
+    client.cookies.clear()
     reused = await client.post("/auth/refresh", json={"refresh_token": old_refresh})
     assert reused.status_code == 401
 
@@ -207,6 +215,9 @@ async def test_reusing_rotated_token_revokes_all_sessions(client):
         "refresh_token"
     ]
 
+    # Cookie tem precedência sobre o corpo (#110); limpa o jar para garantir
+    # que r1 (já rotacionado) chega pelo corpo, não pelo cookie mais recente.
+    client.cookies.clear()
     assert (await client.post("/auth/refresh", json={"refresh_token": r1})).status_code == 401
     # O sucessor legítimo também morre: a sessão inteira foi invalidada.
     assert (await client.post("/auth/refresh", json={"refresh_token": r2})).status_code == 401
@@ -231,3 +242,46 @@ async def test_logout_with_rotated_token_revokes_successor(client):
     # O sucessor do atacante tem que estar morto.
     after = await client.post("/auth/refresh", json={"refresh_token": r1})
     assert after.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_login_sets_an_httponly_refresh_cookie(client):
+    await _register(client)
+    res = await client.post("/auth/login", json={"email": REG["email"], "password": REG["password"]})
+    assert res.status_code == 200
+    set_cookie = res.headers["set-cookie"]
+    assert f"{COOKIE}=" in set_cookie
+    assert "HttpOnly" in set_cookie
+    assert "SameSite=lax" in set_cookie
+    assert "Path=/auth" in set_cookie
+    # O cookie leva o MESMO token do corpo durante a transição (passo 1 de 3).
+    assert res.json()["refresh_token"] in set_cookie
+
+
+@pytest.mark.asyncio
+async def test_refresh_works_from_the_cookie_alone(client):
+    body = await _register(client)
+    antigo = client.cookies.get(COOKIE)
+    assert antigo == body["refresh_token"]
+
+    res = await client.post("/auth/refresh")  # sem corpo: só o cookie
+    assert res.status_code == 200, res.text
+    assert res.json()["access_token"]
+    # Rotacionou: o cookie novo é outro, e o antigo já não vale. O jar do
+    # httpx reenviaria o cookie novo (que tem precedência sobre o corpo), por
+    # isso ele é limpo antes de apresentar o token antigo pelo corpo.
+    novo = client.cookies.get(COOKIE)
+    assert novo and novo != antigo
+    client.cookies.clear()
+    reused = await client.post("/auth/refresh", json={"refresh_token": antigo})
+    assert reused.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_logout_clears_the_cookie(client):
+    await _register(client)
+    res = await client.post("/auth/logout")  # sem corpo: só o cookie
+    assert res.status_code == 204
+    assert "Max-Age=0" in res.headers["set-cookie"]
+    # Sem cookie e sem corpo não há o que renovar.
+    assert (await client.post("/auth/refresh")).status_code == 401

--- a/backend/tests/test_refresh.py
+++ b/backend/tests/test_refresh.py
@@ -236,6 +236,10 @@ async def test_logout_with_rotated_token_revokes_successor(client):
     ]
     assert r1
 
+    # Cookie tem precedência sobre o corpo (#110); limpa o jar para garantir
+    # que r0 (o token roubado e já rotacionado) chega pelo corpo, não pelo
+    # cookie mais recente que o jar reenviaria.
+    client.cookies.clear()
     res = await client.post("/auth/logout", json={"refresh_token": r0})
     assert res.status_code == 204
 


### PR DESCRIPTION
Part of #110. Login, register and refresh now set norby_refresh (HttpOnly, SameSite=Lax, Path=/auth, Secure on https) and still return the token in the body. Refresh and logout accept the cookie first, the body as fallback, so the current frontend build keeps working. Frontend switch is 2/3; dropping the body is 3/3.