### PR TITLE
feat(auth): refresh from the HttpOnly cookie (2/3, frontend)

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -30,20 +30,18 @@ function RootRoute() {
 }
 
 export default function App() {
-  const token = useAuthStore((s) => s.token);
-  // Sem token não há o que validar, então já nasce liberado. Antes isto era
-  // `useState(true)` mais um `setBooting(false)` dentro do efeito, o que
-  // gastava uma renderização extra em TODA visita anônima só para desfazer um
-  // estado que nunca precisou existir. A regra
-  // `react-hooks/set-state-in-effect` apontou isto, e estava certa.
-  const [booting, setBooting] = useState(() => Boolean(token));
+  const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
+  const [booting, setBooting] = useState(isAuthenticated);
 
-  // No boot: se há token persistido, valida no backend antes de liberar as rotas.
-  // Token expirado/inválido -> logout, evitando o "flash" de tela protegida.
+  // No boot: se a sessão sobreviveu à recarga, pede um access token novo com o
+  // cookie de refresh e revalida o usuário antes de liberar as rotas (#110,
+  // #100). Cookie expirado ou revogado -> logout, sem "flash" de tela protegida.
   useEffect(() => {
-    if (!token) return;
+    if (!isAuthenticated) return;
     authApi
-      .me()
+      .refresh()
+      .then((res) => useAuthStore.getState().setToken(res.data.access_token))
+      .then(() => authApi.me())
       .then((res) => useAuthStore.getState().updateUser(res.data))
       .catch(() => useAuthStore.getState().logout())
       .finally(() => setBooting(false));

--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -6,7 +6,10 @@ import { authApi } from "@/api/auth";
 import App from "./App";
 
 vi.mock("@/api/auth", () => ({
-  authApi: { me: vi.fn(() => Promise.resolve({ data: { name: "Alice" } })) },
+  authApi: {
+    refresh: vi.fn(() => Promise.resolve({ data: { access_token: "novo" } })),
+    me: vi.fn(() => Promise.resolve({ data: { name: "Alice" } })),
+  },
 }));
 // Este teste cobre routing, não a tela em si: o redirect de sessão válida
 // monta o Dashboard de verdade, que dispara chamadas reais de rede (rejeitam
@@ -26,7 +29,7 @@ describe("rota raiz", () => {
   });
 
   it("manda para o dashboard quem já tem sessão", async () => {
-    useAuthStore.getState().login("t", "r", { name: "Alice" });
+    useAuthStore.getState().login("t", { name: "Alice" });
 
     render(<App />);
 
@@ -46,7 +49,7 @@ describe("rota raiz", () => {
     // /auth/me, que rejeita -> logout() -> raiz precisa mostrar Auth uma
     // única vez, sem re-navegar (RootRoute não redireciona quando desloga).
     authApi.me.mockRejectedValueOnce(new Error("401"));
-    useAuthStore.getState().login("token-invalido", "r", { name: "Alice" });
+    useAuthStore.getState().login("token-invalido", { name: "Alice" });
 
     render(<App />);
 

--- a/frontend/src/api/auth.js
+++ b/frontend/src/api/auth.js
@@ -6,21 +6,19 @@ export const authApi = {
   login: (data) => api.post("/auth/login", data),
   me: () => api.get("/auth/me"),
   updateProfile: (data) => api.put("/auth/me", data),
+  refresh: () => api.post("/auth/refresh"),
   // Anônimas: a resposta é sempre a mesma exista o e-mail ou não, então não há
   // nada a interpretar aqui além de "deu certo" ou "deu erro de rede".
   forgotPassword: (email) => api.post("/auth/forgot-password", { email }),
   resetPassword: (token, newPassword) =>
     api.post("/auth/reset-password", { token, new_password: newPassword }),
-  // Logout best-effort: revoga o refresh no backend e limpa o estado local.
-  // Falha de rede não impede o logout local.
+  // Logout best-effort: revoga o refresh (que vai no cookie) e limpa o estado
+  // local. Falha de rede não impede o logout local.
   logout: async () => {
-    const refreshToken = useAuthStore.getState().refreshToken;
-    if (refreshToken) {
-      try {
-        await api.post("/auth/logout", { refresh_token: refreshToken });
-      } catch {
-        /* ignora: o importante é limpar o estado local abaixo */
-      }
+    try {
+      await api.post("/auth/logout");
+    } catch {
+      /* ignora: o importante é limpar o estado local abaixo */
     }
     useAuthStore.getState().logout();
   },

--- a/frontend/src/api/axios.js
+++ b/frontend/src/api/axios.js
@@ -8,6 +8,9 @@ const api = axios.create({
   headers: {
     "Content-Type": "application/json",
   },
+  // O cookie de refresh só existe em /auth (Path=/auth), então isso não muda
+  // nada nas outras rotas (#110).
+  withCredentials: true,
 });
 
 // Interceptor para adicionar o token de autenticação em cada requisição
@@ -53,12 +56,6 @@ api.interceptors.response.use(
       return Promise.reject(error);
     }
 
-    const refreshToken = useAuthStore.getState().refreshToken;
-    if (!refreshToken) {
-      forceLogout();
-      return Promise.reject(error);
-    }
-
     // Já existe um refresh em andamento: enfileira esta request.
     if (isRefreshing) {
       return new Promise((resolve, reject) => {
@@ -72,11 +69,10 @@ api.interceptors.response.use(
     original._retry = true;
     isRefreshing = true;
     try {
-      // Chamada "crua" (sem interceptors) para evitar recursão.
-      const { data } = await axios.post(`${baseURL}/auth/refresh`, {
-        refresh_token: refreshToken,
-      });
-      useAuthStore.getState().setTokens(data.access_token, data.refresh_token);
+      // Chamada "crua" (sem interceptors) para evitar recursão. Sem corpo: o
+      // refresh token vai no cookie HttpOnly (#110).
+      const { data } = await axios.post(`${baseURL}/auth/refresh`, null, { withCredentials: true });
+      useAuthStore.getState().setToken(data.access_token);
       flushQueue(null, data.access_token);
       original.headers.Authorization = `Bearer ${data.access_token}`;
       return api(original);

--- a/frontend/src/api/axios.test.js
+++ b/frontend/src/api/axios.test.js
@@ -33,7 +33,6 @@ describe("interceptor de refresh", () => {
     instancia.mockResolvedValue({ data: "ok" });
     useAuthStore.setState({
       token: "velho",
-      refreshToken: "refresh-valido",
       user: { name: "Alice" },
       isAuthenticated: true,
     });
@@ -48,7 +47,7 @@ describe("interceptor de refresh", () => {
 
   it("renova o token no 401 e repete a requisição", async () => {
     axios.post.mockResolvedValue({
-      data: { access_token: "novo", refresh_token: "refresh-novo" },
+      data: { access_token: "novo" },
     });
 
     await onRejected(erro401());
@@ -75,7 +74,7 @@ describe("interceptor de refresh", () => {
     let liberar;
     axios.post.mockReturnValue(
       new Promise((r) => {
-        liberar = () => r({ data: { access_token: "novo", refresh_token: "rn" } });
+        liberar = () => r({ data: { access_token: "novo" } });
       }),
     );
 
@@ -93,12 +92,15 @@ describe("interceptor de refresh", () => {
     expect(axios.post).not.toHaveBeenCalled();
   });
 
-  it("desloga direto quando não há refresh token guardado", async () => {
-    useAuthStore.setState({ refreshToken: null });
+  it("chama o refresh sem corpo, com credenciais, e guarda só o access token", async () => {
+    axios.post.mockResolvedValue({ data: { access_token: "novo" } });
 
-    await expect(onRejected(erro401())).rejects.toBeTruthy();
+    await onRejected(erro401());
 
-    expect(axios.post).not.toHaveBeenCalled();
-    expect(window.location.href).toBe("/");
+    const [url, corpo, opcoes] = axios.post.mock.calls[0];
+    expect(url).toMatch(/\/auth\/refresh$/);
+    expect(corpo).toBeNull();
+    expect(opcoes).toEqual({ withCredentials: true });
+    expect(useAuthStore.getState().token).toBe("novo");
   });
 });

--- a/frontend/src/components/layout/AppLayout.test.jsx
+++ b/frontend/src/components/layout/AppLayout.test.jsx
@@ -52,7 +52,7 @@ describe("AppLayout", () => {
     // 403 do backend enquanto a tela, lendo um `plan` velho do localStorage,
     // continua sem oferecer o upgrade. Uma chamada por carga do app resolve.
     recurringApi.run.mockResolvedValue({});
-    useAuthStore.getState().login("access", "refresh", {
+    useAuthStore.getState().login("access", {
       name: "Alice",
       plan: { ai_allowed: true, wallet_cap_applies: false },
     });

--- a/frontend/src/components/shared/PlanCard.test.jsx
+++ b/frontend/src/components/shared/PlanCard.test.jsx
@@ -30,7 +30,7 @@ const LIBERADO = {
 };
 
 function renderCard(plan, { url = "/settings" } = {}) {
-  useAuthStore.getState().login("access", "refresh", {
+  useAuthStore.getState().login("access", {
     name: "Alice",
     email: "alice@test.com",
     plan,

--- a/frontend/src/pages/Auth.jsx
+++ b/frontend/src/pages/Auth.jsx
@@ -154,7 +154,7 @@ export default function Auth() {
               accept_privacy: data.acceptedTerms,
             });
 
-      login(res.data.access_token, res.data.refresh_token, res.data.user);
+      login(res.data.access_token, res.data.user);
       navigate("/dashboard");
     } catch (err) {
       if (!err.response) {

--- a/frontend/src/pages/DashboardHero.test.jsx
+++ b/frontend/src/pages/DashboardHero.test.jsx
@@ -31,7 +31,7 @@ function renderDashboard() {
 describe("Dashboard hero", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    useAuthStore.getState().login("access", "refresh", {
+    useAuthStore.getState().login("access", {
       name: "Alice",
       email: "alice@test.com",
     });

--- a/frontend/src/pages/Settings.test.jsx
+++ b/frontend/src/pages/Settings.test.jsx
@@ -42,7 +42,7 @@ function fillDeleteConfirmation(password = "secret123") {
 describe("Settings", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    useAuthStore.getState().login("access", "refresh", {
+    useAuthStore.getState().login("access", {
       name: "Alice",
       email: "alice@test.com",
     });
@@ -102,7 +102,7 @@ describe("Settings", () => {
 describe("Settings, foto de perfil", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    useAuthStore.getState().login("access", "refresh", {
+    useAuthStore.getState().login("access", {
       name: "Alice",
       email: "alice@test.com",
       photo_updated_at: null,

--- a/frontend/src/store/authStore.js
+++ b/frontend/src/store/authStore.js
@@ -4,8 +4,10 @@ import { persist } from "zustand/middleware";
 export const useAuthStore = create(
   persist(
     (set) => ({
+      // Access token só em memória (#110): o refresh vive num cookie HttpOnly
+      // que o JavaScript não lê. Recarregou a página, o App pede um access
+      // token novo em /auth/refresh antes de liberar as rotas.
       token: null,
-      refreshToken: null,
       user: null,
       isAuthenticated: false,
       // Foto de perfil como data URI (#35). Fica no store, e não numa <img>
@@ -15,26 +17,26 @@ export const useAuthStore = create(
       photo: null,
       photoFor: null,
 
-      login: (token, refreshToken, user) =>
+      login: (token, user) =>
         // A foto do dono anterior não pode sobreviver a um login: sem zerar
         // aqui, quem entrasse em seguida veria o rosto de quem saiu.
-        set({ token, refreshToken, user, isAuthenticated: true, photo: null, photoFor: null }),
+        set({ token, user, isAuthenticated: true, photo: null, photoFor: null }),
       setPhoto: (photo, photoFor) => set({ photo, photoFor }),
-      // Atualiza só o par de tokens (usado na rotação do refresh), mantém o user.
-      setTokens: (token, refreshToken) => set({ token, refreshToken }),
+      setToken: (token) => set({ token }),
       logout: () =>
-        set({
-          token: null, refreshToken: null, user: null, isAuthenticated: false,
-          photo: null, photoFor: null,
-        }),
+        set({ token: null, user: null, isAuthenticated: false, photo: null, photoFor: null }),
       updateUser: (userData) =>
-        set((state) => ({
-          // Atualiza apenas os campos fornecidos, mantendo os outros intactos
-          user: { ...state.user, ...userData },
-        })),
+        set((state) => ({ user: { ...state.user, ...userData } })),
     }),
     {
-      name: "norby-auth", // Salva no localStorage automaticamente
+      name: "norby-auth",
+      // O que sobrevive à recarga. O token fica de fora de propósito.
+      partialize: (s) => ({
+        user: s.user,
+        isAuthenticated: s.isAuthenticated,
+        photo: s.photo,
+        photoFor: s.photoFor,
+      }),
     },
   ),
 );

--- a/frontend/src/store/authStore.test.js
+++ b/frontend/src/store/authStore.test.js
@@ -10,30 +10,37 @@ describe("authStore", () => {
     expect(useAuthStore.getState().isAuthenticated).toBe(false);
   });
 
-  it("login sets tokens, user and flag", () => {
-    useAuthStore.getState().login("tok123", "ref123", { name: "Al" });
+  it("login sets token, user and flag", () => {
+    useAuthStore.getState().login("tok123", { name: "Al" });
     const s = useAuthStore.getState();
     expect(s.token).toBe("tok123");
-    expect(s.refreshToken).toBe("ref123");
     expect(s.user.name).toBe("Al");
     expect(s.isAuthenticated).toBe(true);
   });
 
-  it("setTokens rotates the token pair, keeping the user", () => {
-    useAuthStore.getState().login("tok123", "ref123", { name: "Al" });
-    useAuthStore.getState().setTokens("tok456", "ref456");
+  it("setToken rotates the access token, keeping the user", () => {
+    useAuthStore.getState().login("tok123", { name: "Al" });
+    useAuthStore.getState().setToken("tok456");
     const s = useAuthStore.getState();
     expect(s.token).toBe("tok456");
-    expect(s.refreshToken).toBe("ref456");
     expect(s.user.name).toBe("Al");
   });
 
+  it("never persists the access token", () => {
+    // #110: o token vive em memória. O que sobrevive à recarga é o usuário e
+    // a flag; o access token novo vem do /auth/refresh com o cookie.
+    useAuthStore.getState().login("tok123", { name: "Al" });
+    const persistido = JSON.parse(localStorage.getItem("norby-auth")).state;
+    expect(persistido).not.toHaveProperty("token");
+    expect(persistido).not.toHaveProperty("refreshToken");
+    expect(persistido.isAuthenticated).toBe(true);
+  });
+
   it("logout clears everything", () => {
-    useAuthStore.getState().login("tok123", "ref123", { name: "Al" });
+    useAuthStore.getState().login("tok123", { name: "Al" });
     useAuthStore.getState().logout();
     const s = useAuthStore.getState();
     expect(s.token).toBeNull();
-    expect(s.refreshToken).toBeNull();
     expect(s.isAuthenticated).toBe(false);
   });
 });


### PR DESCRIPTION
Part of #110. The store no longer persists any token: the access token lives in memory and the page boot asks /auth/refresh with the cookie before revalidating the user. Requires 1/3 deployed on Railway first.

Existing sessions: PR 1 could not seed the cookie for the old frontend build (cross-origin XHR without credentials ignores Set-Cookie), so on first load after this deploy every existing session is logged out once; logging in again sets the cookie. Boot refreshes are single-flight per tab and serialized across tabs with the Web Locks API, because presenting an already-rotated refresh token trips the backend's reuse detection and revokes every session.
