### PR TITLE
fix(auth): single-flight the refresh and serialize it across tabs

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -39,8 +39,9 @@ export default function App() {
   useEffect(() => {
     if (!isAuthenticated) return;
     authApi
+      // authApi.refresh() já guarda o token novo no store (single-flight em
+      // ./axios); aqui só encadeamos o /auth/me depois que ele resolve.
       .refresh()
-      .then((res) => useAuthStore.getState().setToken(res.data.access_token))
       .then(() => authApi.me())
       .then((res) => useAuthStore.getState().updateUser(res.data))
       .catch(() => useAuthStore.getState().logout())

--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -45,9 +45,10 @@ describe("rota raiz", () => {
   });
 
   it("cai na autenticação sem loop quando o token persistido é inválido", async () => {
-    // Simula sessão persistida com token adulterado/expirado: o boot chama
-    // /auth/me, que rejeita -> logout() -> raiz precisa mostrar Auth uma
-    // única vez, sem re-navegar (RootRoute não redireciona quando desloga).
+    // Simula sessão persistida com o access token adulterado/expirado: o boot
+    // chama /auth/refresh (que aqui sucede), depois /auth/me, que rejeita ->
+    // logout() -> raiz precisa mostrar Auth uma única vez, sem re-navegar
+    // (RootRoute não redireciona quando desloga).
     authApi.me.mockRejectedValueOnce(new Error("401"));
     useAuthStore.getState().login("token-invalido", { name: "Alice" });
 
@@ -56,5 +57,19 @@ describe("rota raiz", () => {
     expect(await screen.findAllByRole("button", { name: /entrar/i })).not.toHaveLength(0);
     expect(useAuthStore.getState().isAuthenticated).toBe(false);
     expect(window.location.pathname).toBe("/");
+  });
+
+  it("cai na autenticação sem chamar /auth/me quando o cookie de refresh expirou ou não existe", async () => {
+    // O boot chama /auth/refresh primeiro. Se ele falha (cookie ausente ou
+    // revogado), não há token novo para validar, então /auth/me nem deveria
+    // ser chamado.
+    authApi.refresh.mockRejectedValueOnce(new Error("401"));
+    useAuthStore.getState().login("token-velho", { name: "Alice" });
+
+    render(<App />);
+
+    expect(await screen.findAllByRole("button", { name: /entrar/i })).not.toHaveLength(0);
+    expect(authApi.me).not.toHaveBeenCalled();
+    expect(useAuthStore.getState().isAuthenticated).toBe(false);
   });
 });

--- a/frontend/src/api/auth.js
+++ b/frontend/src/api/auth.js
@@ -1,4 +1,4 @@
-import api from "./axios";
+import api, { refreshAccessToken } from "./axios";
 import { useAuthStore } from "../store/authStore";
 
 export const authApi = {
@@ -6,7 +6,7 @@ export const authApi = {
   login: (data) => api.post("/auth/login", data),
   me: () => api.get("/auth/me"),
   updateProfile: (data) => api.put("/auth/me", data),
-  refresh: () => api.post("/auth/refresh"),
+  refresh: () => refreshAccessToken(),
   // Anônimas: a resposta é sempre a mesma exista o e-mail ou não, então não há
   // nada a interpretar aqui além de "deu certo" ou "deu erro de rede".
   forgotPassword: (email) => api.post("/auth/forgot-password", { email }),

--- a/frontend/src/api/axios.js
+++ b/frontend/src/api/axios.js
@@ -24,14 +24,28 @@ api.interceptors.request.use((config) => {
 
 // --- Refresh token automático em 401 ---
 // Ao receber 401 num endpoint não-auth, tenta UMA vez renovar o access token via
-// /auth/refresh. Requests concorrentes durante a renovação entram numa fila para
-// não disparar N refreshes ao mesmo tempo.
-let isRefreshing = false;
-let pendingQueue = [];
+// /auth/refresh.
 
-function flushQueue(error, token) {
-  pendingQueue.forEach(({ resolve, reject }) => (error ? reject(error) : resolve(token)));
-  pendingQueue = [];
+// Renovação única por aba e serializada entre abas (#110). O refresh
+// rotaciona o token do cookie, e apresentar o token antigo de novo é lido
+// pelo backend como roubo: derruba TODAS as sessões. Duas abas restaurando
+// ao mesmo tempo (ou o StrictMode em dev) fariam exatamente isso sem isto.
+let inflightRefresh = null;
+
+export async function refreshAccessToken() {
+  if (inflightRefresh) return inflightRefresh;
+  const run = async () => {
+    // Chamada "crua" (sem interceptors) para evitar recursão. Sem corpo: o
+    // refresh token vai no cookie HttpOnly.
+    const { data } = await axios.post(`${baseURL}/auth/refresh`, null, { withCredentials: true });
+    useAuthStore.getState().setToken(data.access_token);
+    return data.access_token;
+  };
+  const locks = typeof navigator !== "undefined" ? navigator.locks : undefined;
+  inflightRefresh = (locks?.request ? locks.request("norby-auth-refresh", run) : run()).finally(() => {
+    inflightRefresh = null;
+  });
+  return inflightRefresh;
 }
 
 function forceLogout() {
@@ -56,32 +70,14 @@ api.interceptors.response.use(
       return Promise.reject(error);
     }
 
-    // Já existe um refresh em andamento: enfileira esta request.
-    if (isRefreshing) {
-      return new Promise((resolve, reject) => {
-        pendingQueue.push({ resolve, reject });
-      }).then((token) => {
-        original.headers.Authorization = `Bearer ${token}`;
-        return api(original);
-      });
-    }
-
     original._retry = true;
-    isRefreshing = true;
     try {
-      // Chamada "crua" (sem interceptors) para evitar recursão. Sem corpo: o
-      // refresh token vai no cookie HttpOnly (#110).
-      const { data } = await axios.post(`${baseURL}/auth/refresh`, null, { withCredentials: true });
-      useAuthStore.getState().setToken(data.access_token);
-      flushQueue(null, data.access_token);
-      original.headers.Authorization = `Bearer ${data.access_token}`;
+      const token = await refreshAccessToken();
+      original.headers.Authorization = `Bearer ${token}`;
       return api(original);
     } catch (refreshError) {
-      flushQueue(refreshError, null);
       forceLogout();
       return Promise.reject(refreshError);
-    } finally {
-      isRefreshing = false;
     }
   },
 );

--- a/frontend/src/api/axios.test.js
+++ b/frontend/src/api/axios.test.js
@@ -18,7 +18,7 @@ vi.mock("axios", () => {
 
 const { useAuthStore } = await import("@/store/authStore");
 const axios = (await import("axios")).default;
-await import("./axios");
+const { refreshAccessToken } = await import("./axios");
 
 const erro401 = (url = "/transactions/") => ({
   response: { status: 401 },
@@ -102,5 +102,30 @@ describe("interceptor de refresh", () => {
     expect(corpo).toBeNull();
     expect(opcoes).toEqual({ withCredentials: true });
     expect(useAuthStore.getState().token).toBe("novo");
+  });
+
+  it("o boot disparado duas vezes ao mesmo tempo renova uma vez só", async () => {
+    // StrictMode (dev) ou duas abas restaurando juntas chamam o refresh do
+    // boot em paralelo. Sem o single-flight, a segunda chamada apresentaria o
+    // refresh token já rotacionado pela primeira, e o backend lê isso como
+    // reuso: derruba todas as sessões (#110).
+    axios.post.mockResolvedValue({ data: { access_token: "novo" } });
+
+    const [a, b] = await Promise.all([refreshAccessToken(), refreshAccessToken()]);
+
+    expect(axios.post).toHaveBeenCalledTimes(1);
+    expect(a).toBe("novo");
+    expect(b).toBe("novo");
+    expect(useAuthStore.getState().token).toBe("novo");
+  });
+
+  it("serializa a renovação entre abas com navigator.locks quando existe", async () => {
+    axios.post.mockResolvedValue({ data: { access_token: "novo" } });
+    navigator.locks = { request: vi.fn((name, cb) => cb()) };
+
+    await refreshAccessToken();
+
+    expect(navigator.locks.request).toHaveBeenCalledWith("norby-auth-refresh", expect.any(Function));
+    delete navigator.locks;
   });
 });


### PR DESCRIPTION
Follow-up to #127, which was merged before this fix round landed on its branch. Presenting an already-rotated refresh token trips the backend's reuse detection and revokes every session; React StrictMode in dev and two or more tabs restoring together in production both fire concurrent boot refreshes. One exported refreshAccessToken() is now shared by the boot flow and the 401 interceptor, single-flight per tab and serialized across tabs with the Web Locks API. Adds a negative-path boot test. Verified end to end against the local stack: one POST /auth/refresh on reload, session kept, logout clears the cookie.