### PR TITLE
feat(auth): refresh token only in the cookie (3/3)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,6 +44,9 @@ STRIPE_PRICE_ID=
 # Para onde o Stripe devolve a pessoa depois do Checkout e do Portal. Em produção,
 # a URL do frontend na Vercel (https, sem barra final) — NÃO é derivada do
 # CORS_ORIGINS, que é uma lista.
+# O esquema desta URL também decide a flag Secure do cookie de refresh
+# (refresh_cookie_secure em config.py): um valor http:// em produção derruba
+# o Secure de um cookie de autenticação.
 APP_BASE_URL=http://localhost:5173
 
 # Brevo — e-mail transacional (#36). Vazio = recuperação de senha DESLIGADA, e

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -259,12 +259,13 @@ fica só em memória (`authStore` sem `persist` para o `token`). No boot, o
 `App` chama `/auth/refresh` (que lê só o cookie) antes do primeiro `/auth/me`
 — sobrevive a recarga sem tocar em `localStorage` (`frontend/src/App.jsx`).
 Pré-requisito para sair do `localStorage`: API e frontend no mesmo site
-registrável, cumprido em 2026-09-05 com o `norby.com.br`. Requisições
-concorrentes de UMA aba entram numa fila (`frontend/src/api/axios.js`) para
-não disparar dois refreshes ao mesmo tempo: apresentar um token já rotacionado
-aciona a detecção de reuso (`rotate_refresh_token`) e derruba TODAS as
-sessões, inclusive a que venceu a corrida. Essa fila não cobre duas ABAS
-refrescando ao mesmo tempo — dívida aceita, sem trava entre abas ainda.
+registrável, cumprido em 2026-09-05 com o `norby.com.br`. `refreshAccessToken`
+(`frontend/src/api/axios.js`) faz uma renovação só por aba — a mesma promise
+em voo atende o boot e o interceptor de 401 — e serializa entre abas com a Web
+Locks API (`navigator.locks.request("norby-auth-refresh", ...)`; sem suporte
+no navegador, chama direto, sem trava), porque apresentar um refresh token já
+rotacionado aciona a detecção de reuso (`rotate_refresh_token`) e derruba
+TODAS as sessões, inclusive a que venceu a corrida.
 O deploy do passo 2 (access só em memória) deslogou de uma vez as sessões que
 não tinham passado por login/refresh desde o passo 1: o build antigo nunca
 recebeu o cookie, e sem `localStorage` para recorrer não sobrou refresh para

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -251,18 +251,24 @@ dele vira `$bcrypt-sha256$`, formato que o código anterior a 2026-08-15 não sa
 verificar — reverter tranca esses usuários para fora com a senha correta. Em
 qualquer rollback, `bcrypt_sha256` tem de continuar sendo verificado.
 
-**Tokens no navegador — decisão consciente (2026-07-21):** access e refresh
-ficam no `localStorage` (Zustand persist). A correção canônica seria refresh em
-cookie `HttpOnly` + access só em memória, mas o frontend (`vercel.app`) e a API
-(`railway.app`) são *sites* diferentes: o cookie exigiria `SameSite=None` e
-seria bloqueado pelo Safari ITP e pelo Chrome, deslogando o usuário a cada
-recarga. Mitigações no lugar: CSP restritiva no `vercel.json`, access token de
-15 min e revogação de todas as sessões quando um refresh token é reusado.
-**Pré-requisito para migrar: CUMPRIDO em 2026-09-05.** `norby.com.br` foi
-adquirido, então API e frontend podem passar a viver no mesmo site registrável
-(`norby.com.br` + `api.norby.com.br`) e o cookie vira `SameSite=Lax`. Os dois
-domínios já estão no ar, então não sobrou passo de infraestrutura: falta só o
-código, rastreado no #110.
+**Tokens no navegador — refresh em cookie, access em memória (2026-07-21,
+migrado em 2026-09-05/06, issue #110):** o refresh token vive no cookie
+`norby_refresh` (`HttpOnly; SameSite=Lax; Path=/auth`, `Secure` quando
+`app_base_url` é https) do host da API; o access token nunca é persistido,
+fica só em memória (`authStore` sem `persist` para o `token`). No boot, o
+`App` chama `/auth/refresh` (que lê só o cookie) antes do primeiro `/auth/me`
+— sobrevive a recarga sem tocar em `localStorage` (`frontend/src/App.jsx`).
+Pré-requisito para sair do `localStorage`: API e frontend no mesmo site
+registrável, cumprido em 2026-09-05 com o `norby.com.br`. Requisições
+concorrentes de UMA aba entram numa fila (`frontend/src/api/axios.js`) para
+não disparar dois refreshes ao mesmo tempo: apresentar um token já rotacionado
+aciona a detecção de reuso (`rotate_refresh_token`) e derruba TODAS as
+sessões, inclusive a que venceu a corrida. Essa fila não cobre duas ABAS
+refrescando ao mesmo tempo — dívida aceita, sem trava entre abas ainda.
+O deploy do passo 2 (access só em memória) deslogou de uma vez as sessões que
+não tinham passado por login/refresh desde o passo 1: o build antigo nunca
+recebeu o cookie, e sem `localStorage` para recorrer não sobrou refresh para
+apresentar.
 
 **Rate limit atrás do proxy — reescrito em 2026-08-16 (issue #22, fix round 1
 incluído):** o uvicorn só honra `X-Forwarded-For` quando o peer é

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ O Norby junta os lançamentos num lugar só (recorrências incluídas), mantém 
 
 | Camada | Tecnologias |
 |---|---|
-| Backend | FastAPI 0.139 · SQLAlchemy 2.0 (async) + asyncpg · Alembic · Pydantic v2 · python-jose (JWT) · slowapi (rate limit) · uv |
+| Backend | FastAPI 0.141 · SQLAlchemy 2.0 (async) + asyncpg · Alembic · Pydantic v2 · PyJWT (JWT) · slowapi (rate limit) · uv |
 | Bancos | PostgreSQL 16 (núcleo relacional) · MongoDB 7 via Motor (insights e chat da IA) |
-| IA | Google Gemini 3.5 Flash-Lite (`google-generativeai`) |
+| IA | Google Gemini 3.5 Flash-Lite (`google-genai`) |
 | Frontend | React 19 · Vite 8 · TailwindCSS · componentes estilo shadcn/ui · Zustand · React Router v7 · React Hook Form + Zod · axios · Recharts |
 | Testes | pytest + pytest-asyncio (backend) · Vitest + Testing Library (frontend) |
 | Infra | Docker Compose (dev) · Railway (backend, Docker) · Neon (Postgres) · MongoDB Atlas · Vercel (frontend) |

--- a/README.md
+++ b/README.md
@@ -84,7 +84,9 @@ flowchart LR
 
 - **Auditoria de segurança: o que foi corrigido e o que foi assumido.** O projeto passou por uma revisão de segurança e cada achado virou um commit rastreável. Os dois mais interessantes são de concorrência: a edição simultânea da mesma transação revertia o valor antigo duas vezes e deixava o saldo divergente do registro gravado ([`75e6998`](https://github.com/DigoDuck/Norby/commit/75e6998)), e a rotação de refresh token emitia dois sucessores válidos quando chamada em paralelo ([`f97fff4`](https://github.com/DigoDuck/Norby/commit/f97fff4)). Os dois têm teste que falha sem a correção. Entraram junto limites de valor e tamanho no Pydantic com CHECK constraints espelhadas no Postgres, headers de segurança e CSP, senha obrigatória para excluir a conta, login com tempo constante e o consentimento LGPD persistido com timestamp.
 
-  Duas decisões foram de **não** corrigir, com o motivo registrado no [AGENTS.md](AGENTS.md). Os tokens seguem no `localStorage`: a correção canônica é cookie `HttpOnly`, mas o frontend (`vercel.app`) e a API (`railway.app`) são sites registráveis distintos, então o cookie exigiria `SameSite=None` e seria bloqueado pelo Safari e pelo Chrome, deslogando o usuário a cada recarga. Migrar dependia de domínio próprio, pré-requisito **cumprido em setembro de 2026** com o `norby.com.br`: o front no apex e a API em `api.norby.com.br` são o mesmo site registrável, então o cookie vira `SameSite=Lax` e a correção canônica passou a caber ([#110](https://github.com/DigoDuck/Norby/issues/110)). E o rate limit de login continua por IP: ligar `--forwarded-allow-ips="*"` faria o uvicorn confiar no *primeiro* item do `X-Forwarded-For`, que é justamente o que o cliente controla, tornando o limite spoofável — a correção óbvia seria pior que o problema. As rotas autenticadas passaram a ser chaveadas pelo id do usuário ([`1e8b8bd`](https://github.com/DigoDuck/Norby/commit/1e8b8bd)), o que resolve o caso real sem abrir esse buraco.
+  O refresh token, que ficava no `localStorage` por depender de domínio próprio, migrou para um cookie `HttpOnly; SameSite=Lax; Path=/auth` assim que esse pré-requisito foi **cumprido em setembro de 2026** com o `norby.com.br`: o front no apex e a API em `api.norby.com.br` viraram o mesmo site registrável, o que tirou a necessidade de `SameSite=None` (bloqueado pelo Safari e pelo Chrome) e destravou a correção canônica. O access token passou a viver só em memória, nunca em disco. O porquê da espera e o desenho final estão no [AGENTS.md](AGENTS.md) ([#110](https://github.com/DigoDuck/Norby/issues/110)).
+
+  Uma decisão segue sendo de **não** corrigir, com o motivo registrado no [AGENTS.md](AGENTS.md): o rate limit de login continua por IP. Ligar `--forwarded-allow-ips="*"` faria o uvicorn confiar no *primeiro* item do `X-Forwarded-For`, que é justamente o que o cliente controla, tornando o limite spoofável — a correção óbvia seria pior que o problema. As rotas autenticadas passaram a ser chaveadas pelo id do usuário ([`1e8b8bd`](https://github.com/DigoDuck/Norby/commit/1e8b8bd)), o que resolve o caso real sem abrir esse buraco.
 
 ## Como usei IA no desenvolvimento
 
@@ -147,8 +149,7 @@ Limitações conhecidas, aceitas conscientemente na v1:
 
 - Recorrências só materializam quando o usuário abre o app (sem scheduler server-side).
 - Rate limiting em memória. As rotas autenticadas são limitadas por usuário; login e cadastro, por IP — e atrás do proxy do Railway esse IP é o mesmo para todo mundo, então o balde é compartilhado. Não sobrevive a múltiplas instâncias nem a restart.
-- Access e refresh tokens no `localStorage`, com CSP como mitigação (o porquê está em "Auditoria de segurança").
 - Sem CI e sem linter no backend (o frontend tem ESLint).
 - Fora do escopo da v1: multi-moeda, Open Finance, export CSV/PDF, CRUD de categorias, notificações e metas compartilhadas.
 
-Próximos passos: CI, i18n e a migração dos tokens para cookie `HttpOnly`, que depende de um domínio próprio com API e frontend no mesmo site registrável.
+Próximos passos: CI e i18n.

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1,3 +1,4 @@
+from pydantic import field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from functools import lru_cache
 from typing import Literal
@@ -28,6 +29,19 @@ class Settings(BaseSettings):
 
     # CORS — origens permitidas (separadas por vírgula). Default cobre o dev local.
     cors_origins: str = "http://localhost:5173"
+
+    @field_validator("cors_origins")
+    @classmethod
+    def _rejeita_wildcard_cors(cls, v: str) -> str:
+        # Com allow_credentials=True (main.py), "*" faria o navegador aceitar
+        # QUALQUER origem enviando credenciais — e o cookie de refresh, que só
+        # devia ser lido por norby.com.br, ficaria legível por qualquer site.
+        if any(origem.strip() == "*" for origem in v.split(",")):
+            raise ValueError(
+                "CORS_ORIGINS não pode conter '*': com allow_credentials=True "
+                "isso libera qualquer origem a ler o cookie de refresh."
+            )
+        return v
 
     # Stripe (ADR 0001). Default "" DE PROPÓSITO, ao contrário de gemini_api_key:
     # torná-los obrigatórios derrubaria a produção no instante do merge, já que

--- a/backend/app/limiter.py
+++ b/backend/app/limiter.py
@@ -37,7 +37,7 @@ def user_key(request: Request) -> str:
             sub = payload.get("sub")
             if sub:
                 return f"user:{sub}"
-        except jwt.PyJWTError:
+        except (jwt.PyJWTError, ValueError, TypeError):
             pass
     return get_remote_address(request)
 

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -59,16 +59,20 @@ def _log_xff(request: Request) -> None:
 
 
 def _set_refresh_cookie(response: Response, raw: str) -> None:
-    # HttpOnly tira o token do alcance de qualquer script na página; Lax é o
-    # que fecha o CSRF, porque um POST cross-site não leva o cookie; Path=/auth
-    # mantém o cookie fora de todas as outras rotas.
+    # HttpOnly tira o token do alcance de qualquer script na página; Path=/auth
+    # mantém o cookie fora de todas as outras rotas. SameSite=Strict, e não
+    # Lax: o Lax do Chrome ("Lax-allowing-unsafe") ainda manda o cookie num
+    # POST cross-site de navegação de topo enquanto ele tem menos de 2 minutos
+    # — e este cookie nunca é lido por uma navegação, só por XHR same-site
+    # disparado pelo próprio norby.com.br. Strict cobre exatamente os mesmos
+    # casos legítimos e fecha também essa janela de 2 minutos.
     response.set_cookie(
         key=settings.refresh_cookie_name,
         value=raw,
         max_age=settings.refresh_token_expire_days * 86400,
         httponly=True,
         secure=settings.refresh_cookie_secure,
-        samesite="lax",
+        samesite="strict",
         path="/auth",
     )
 
@@ -79,7 +83,7 @@ def _clear_refresh_cookie(response: Response) -> None:
         path="/auth",
         httponly=True,
         secure=settings.refresh_cookie_secure,
-        samesite="lax",
+        samesite="strict",
     )
 
 

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -13,7 +13,7 @@ from app.dependencies import get_db, get_current_user
 from app.limiter import limiter, user_key, refresh_token_key, reset_email_key
 from app.models.sql_models import User
 from app.schemas.user import (
-    UserRegister, UserLogin, UserUpdate, Token, TokenPair, RefreshRequest,
+    UserRegister, UserLogin, UserUpdate, Token, TokenPair,
     DeleteAccountRequest, UserResponse, ForgotPassword, ResetPassword,
 )
 from app.services.auth_service import (
@@ -83,11 +83,11 @@ def _clear_refresh_cookie(response: Response) -> None:
     )
 
 
-async def _refresh_body(request: Request, payload: RefreshRequest | None = None) -> str:
-    # Cookie primeiro (#110), corpo como transição para builds antigos do
-    # frontend. Carimba em request.state ANTES do decorator do slowapi rodar,
-    # porque refresh_token_key é síncrono e não vê o corpo parseado.
-    raw = request.cookies.get(settings.refresh_cookie_name) or (payload.refresh_token if payload else None)
+async def _refresh_body(request: Request) -> str:
+    # Passo 3 de 3 do #110: só o cookie, o corpo não existe mais. Carimba em
+    # request.state ANTES do decorator do slowapi rodar, porque
+    # refresh_token_key é síncrono e não vê o corpo parseado.
+    raw = request.cookies.get(settings.refresh_cookie_name)
     if not raw:
         raise HTTPException(status_code=401, detail="Refresh token ausente")
     request.state.refresh_token = raw
@@ -152,7 +152,7 @@ async def register(
     access = create_access_token(str(user.id))
     refresh = await create_refresh_token(str(user.id), db)
     _set_refresh_cookie(response, refresh)
-    return Token(access_token=access, refresh_token=refresh, user=UserResponse.model_validate(user))
+    return Token(access_token=access, user=UserResponse.model_validate(user))
 
 @router.post("/login", response_model=Token)
 # Teto global 200/min: só flood. A defesa contra força bruta é o atraso
@@ -198,7 +198,7 @@ async def login(
     access = create_access_token(str(user.id))
     refresh = await create_refresh_token(str(user.id), db)
     _set_refresh_cookie(response, refresh)
-    return Token(access_token=access, refresh_token=refresh, user=UserResponse.model_validate(user))
+    return Token(access_token=access, user=UserResponse.model_validate(user))
 
 @router.post("/refresh", response_model=TokenPair)
 # Issue #22: 20/min era teto de CAPACIDADE, não defesa — com access token de
@@ -219,7 +219,7 @@ async def refresh_token(
         raise HTTPException(status_code=401, detail="Refresh token inválido ou expirado")
     access, new_refresh, _user = result
     _set_refresh_cookie(response, new_refresh)
-    return TokenPair(access_token=access, refresh_token=new_refresh)
+    return TokenPair(access_token=access)
 
 @router.post("/logout", status_code=status.HTTP_204_NO_CONTENT)
 # Desde que o logout passou a derrubar TODAS as sessões ao receber um token já

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -94,18 +94,12 @@ class UserResponse(BaseModel):
 
 class Token(BaseModel):
     access_token: str
-    refresh_token: str
     token_type: str = "bearer"
     user: UserResponse # Retorna os dados do usuário junto com o token
 
 class TokenPair(BaseModel):
     access_token: str
-    refresh_token: str
     token_type: str = "bearer"
-
-class RefreshRequest(BaseModel):
-    # Opcional desde o #110: o token pode vir no cookie. Some no passo 3.
-    refresh_token: str | None = None
 
 class DeleteAccountRequest(BaseModel):
     confirm: bool

--- a/backend/requirements-dev.lock
+++ b/backend/requirements-dev.lock
@@ -37,9 +37,7 @@ colorama==0.4.6 ; sys_platform == 'win32'
     #   pytest
     #   uvicorn
 cryptography==50.0.0
-    # via
-    #   -r requirements.txt
-    #   google-auth
+    # via google-auth
 cyclonedx-python-lib==11.11.0
     # via pip-audit
 defusedxml==0.7.1

--- a/backend/requirements.lock
+++ b/backend/requirements.lock
@@ -32,9 +32,7 @@ colorama==0.4.6 ; sys_platform == 'win32'
     #   click
     #   uvicorn
 cryptography==50.0.0
-    # via
-    #   -r requirements.txt
-    #   google-auth
+    # via google-auth
 deprecated==1.3.1
     # via limits
 distro==1.9.0

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -8,10 +8,9 @@ PyJWT==2.13.0  # JWT HS256 do access token. Substituiu o python-jose (issue #29)
 python-dotenv==1.2.3
 pydantic-settings==2.15.0
 google-genai==2.22.0
-# Pin de transitiva: nao e o python-jose que puxa mais (removido, issue #29),
-# e sim o google-auth (dependencia do google-genai). Fixado so pra deixar o
-# dependente real documentado; sem CVE aberto pendente sobre ela hoje.
-cryptography==50.0.0
+# cryptography entra como transitiva do google-auth (dependência do
+# google-genai) — sem pin direto aqui de propósito; quem fixa a versão
+# resolvida é o lock (requirements.lock), checado por scripts/check_locks.py.
 email-validator==2.3.0
 bcrypt==5.0.0
 slowapi==0.1.10

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -14,3 +14,15 @@ def test_settings_rejects_asymmetric_jwt_algorithm():
             gemini_api_key="test-key",
             _env_file=None,
         )
+
+
+def test_settings_rejects_wildcard_cors_origin():
+    with pytest.raises(ValidationError):
+        Settings(
+            database_url="postgresql://localhost/norby",
+            mongodb_url="mongodb://localhost/norby",
+            secret_key="test-secret",
+            gemini_api_key="test-key",
+            cors_origins="*",
+            _env_file=None,
+        )

--- a/backend/tests/test_password_reset.py
+++ b/backend/tests/test_password_reset.py
@@ -154,6 +154,10 @@ async def test_reset_revokes_every_session(client, enviados, db_session):
 
     # Quem redefine ou esqueceu a senha ou desconfia que alguém a tem. Nos dois
     # casos, um refresh vivo de 7 dias anularia o motivo de ter redefinido.
+    # Limpa antes de setar: o cookie que o servidor emitiu vive em Path=/auth,
+    # o setado aqui explicitamente vai pra "/", e isso deixa claro qual dos
+    # dois o servidor de fato recebe.
+    client.cookies.clear()
     client.cookies.set(COOKIE, refresh)
     usado = await client.post("/auth/refresh")
     assert usado.status_code == 401

--- a/backend/tests/test_password_reset.py
+++ b/backend/tests/test_password_reset.py
@@ -13,9 +13,12 @@ import pytest
 from sqlalchemy import select
 
 import app.routers.auth as auth_router
+from app.config import get_settings
 from app.models.sql_models import LoginThrottle, PasswordResetToken, RefreshToken, User
 from app.services.auth_service import _hash_token
 from app.services.throttle_service import email_key_hash
+
+COOKIE = get_settings().refresh_cookie_name
 
 
 @pytest.fixture(autouse=True)
@@ -140,7 +143,8 @@ async def test_the_password_actually_changes(client, enviados):
 
 @pytest.mark.asyncio
 async def test_reset_revokes_every_session(client, enviados, db_session):
-    email, tokens = await registrar(client)
+    email, _ = await registrar(client)
+    refresh = client.cookies.get(COOKIE)
     await client.post("/auth/forgot-password", json={"email": email})
 
     await client.post(
@@ -150,9 +154,8 @@ async def test_reset_revokes_every_session(client, enviados, db_session):
 
     # Quem redefine ou esqueceu a senha ou desconfia que alguém a tem. Nos dois
     # casos, um refresh vivo de 7 dias anularia o motivo de ter redefinido.
-    usado = await client.post(
-        "/auth/refresh", json={"refresh_token": tokens["refresh_token"]}
-    )
+    client.cookies.set(COOKIE, refresh)
+    usado = await client.post("/auth/refresh")
     assert usado.status_code == 401
 
 

--- a/backend/tests/test_refresh.py
+++ b/backend/tests/test_refresh.py
@@ -21,57 +21,56 @@ async def _register(client):
 
 
 @pytest.mark.asyncio
-async def test_register_and_login_return_refresh_token(client):
+async def test_the_refresh_token_never_travels_in_the_body(client):
     body = await _register(client)
-    assert body["refresh_token"]
-
-    res = await client.post(
-        "/auth/login", json={"email": REG["email"], "password": REG["password"]}
-    )
+    assert "refresh_token" not in body
+    res = await client.post("/auth/refresh")
     assert res.status_code == 200
-    assert res.json()["refresh_token"]
+    assert "refresh_token" not in res.json()
 
 
 @pytest.mark.asyncio
 async def test_refresh_rotates_and_invalidates_old_token(client):
-    body = await _register(client)
-    old_refresh = body["refresh_token"]
+    await _register(client)
+    old_refresh = client.cookies.get(COOKIE)
 
-    res = await client.post("/auth/refresh", json={"refresh_token": old_refresh})
+    res = await client.post("/auth/refresh")
     assert res.status_code == 200
     new = res.json()
     assert new["access_token"]
-    assert new["refresh_token"] and new["refresh_token"] != old_refresh
+    novo_refresh = client.cookies.get(COOKIE)
+    assert novo_refresh and novo_refresh != old_refresh
 
     # O novo refresh continua válido.
-    again = await client.post("/auth/refresh", json={"refresh_token": new["refresh_token"]})
+    again = await client.post("/auth/refresh")
     assert again.status_code == 200
 
-    # O refresh antigo foi rotacionado: usá-lo de novo deve falhar. O cookie
-    # tem precedência sobre o corpo (#110), e o jar do httpx já guarda o
-    # cookie mais recente; limpa antes para garantir que É o corpo antigo
-    # quem chega no servidor.
-    client.cookies.clear()
-    reused = await client.post("/auth/refresh", json={"refresh_token": old_refresh})
+    # O refresh antigo foi rotacionado: usá-lo de novo deve falhar. O jar do
+    # httpx já guarda o cookie mais recente; apresenta o antigo explicitamente
+    # para garantir que É ele quem chega no servidor.
+    client.cookies.set(COOKIE, old_refresh)
+    reused = await client.post("/auth/refresh")
     assert reused.status_code == 401
 
 
 @pytest.mark.asyncio
 async def test_logout_revokes_refresh_token(client):
-    body = await _register(client)
-    refresh = body["refresh_token"]
+    await _register(client)
+    refresh = client.cookies.get(COOKIE)
 
-    res = await client.post("/auth/logout", json={"refresh_token": refresh})
+    res = await client.post("/auth/logout")
     assert res.status_code == 204
 
     # Depois do logout o refresh não vale mais.
-    after = await client.post("/auth/refresh", json={"refresh_token": refresh})
+    client.cookies.set(COOKIE, refresh)
+    after = await client.post("/auth/refresh")
     assert after.status_code == 401
 
 
 @pytest.mark.asyncio
 async def test_logout_is_idempotent_for_unknown_token(client):
-    res = await client.post("/auth/logout", json={"refresh_token": "inexistente"})
+    client.cookies.set(COOKIE, "inexistente")
+    res = await client.post("/auth/logout")
     assert res.status_code == 204
 
 
@@ -90,9 +89,14 @@ async def test_logout_is_rate_limited(client):
     limiter.enabled = True
     try:
         for _ in range(120):
-            res = await client.post("/auth/logout", json={"refresh_token": "nao-existe"})
+            # Logout limpa o cookie a cada chamada; reapresenta o mesmo token
+            # antes de cada uma, senão a segunda já cairia em 401 por falta
+            # de cookie em vez de medir o balde.
+            client.cookies.set(COOKIE, "nao-existe")
+            res = await client.post("/auth/logout")
             assert res.status_code == 204
-        estourou = await client.post("/auth/logout", json={"refresh_token": "nao-existe"})
+        client.cookies.set(COOKIE, "nao-existe")
+        estourou = await client.post("/auth/logout")
         assert estourou.status_code == 429
     finally:
         limiter.enabled = False
@@ -114,9 +118,13 @@ async def test_logout_bucket_is_keyed_by_the_refresh_token_not_ip(client):
     limiter.enabled = True
     try:
         for _ in range(120):
-            res = await client.post("/auth/logout", json={"refresh_token": "token-a"})
+            # Logout limpa o cookie a cada chamada; reapresenta o mesmo token
+            # antes de cada uma para não cair em 401 por falta de cookie.
+            client.cookies.set(COOKIE, "token-a")
+            res = await client.post("/auth/logout")
             assert res.status_code == 204
-        estourou = await client.post("/auth/logout", json={"refresh_token": "token-a"})
+        client.cookies.set(COOKIE, "token-a")
+        estourou = await client.post("/auth/logout")
         assert estourou.status_code == 429
 
         # Fix round 3: aqui havia um limiter.reset() antes da chamada com
@@ -127,14 +135,12 @@ async def test_logout_bucket_is_keyed_by_the_refresh_token_not_ip(client):
         # duas chaves.
         de_outro_ip = ASGITransport(app=app, client=("10.0.0.2", 1234))
         async with AsyncClient(transport=de_outro_ip, base_url="http://test") as outro_ip:
-            mesmo_token = await outro_ip.post(
-                "/auth/logout", json={"refresh_token": "token-a"}
-            )
+            outro_ip.cookies.set(COOKIE, "token-a")
+            mesmo_token = await outro_ip.post("/auth/logout")
             assert mesmo_token.status_code == 429  # IP novo não livra o token saturado
 
-            outro_token = await outro_ip.post(
-                "/auth/logout", json={"refresh_token": "token-b"}
-            )
+            outro_ip.cookies.set(COOKIE, "token-b")
+            outro_token = await outro_ip.post("/auth/logout")
             assert outro_token.status_code == 204  # token diferente = balde diferente
     finally:
         limiter.enabled = False
@@ -155,12 +161,11 @@ async def test_logout_has_an_ip_wide_flood_ceiling(client):
     limiter.enabled = True
     try:
         for _ in range(120):
-            token = uuid_mod.uuid4().hex
-            res = await client.post("/auth/logout", json={"refresh_token": token})
+            client.cookies.set(COOKIE, uuid_mod.uuid4().hex)
+            res = await client.post("/auth/logout")
             assert res.status_code == 204
-        estourou = await client.post(
-            "/auth/logout", json={"refresh_token": uuid_mod.uuid4().hex}
-        )
+        client.cookies.set(COOKIE, uuid_mod.uuid4().hex)
+        estourou = await client.post("/auth/logout")
         assert estourou.status_code == 429
     finally:
         limiter.enabled = False
@@ -176,9 +181,10 @@ async def test_refresh_no_longer_throttles_at_20_per_minute(client):
 
     limiter.reset()
     limiter.enabled = True
+    client.cookies.set(COOKIE, "nao-existe")
     try:
         for _ in range(25):
-            res = await client.post("/auth/refresh", json={"refresh_token": "nao-existe"})
+            res = await client.post("/auth/refresh")
             assert res.status_code == 401
     finally:
         limiter.enabled = False
@@ -187,7 +193,8 @@ async def test_refresh_no_longer_throttles_at_20_per_minute(client):
 
 @pytest.mark.asyncio
 async def test_refresh_with_invalid_token_401(client):
-    res = await client.post("/auth/refresh", json={"refresh_token": "nao-existe"})
+    client.cookies.set(COOKIE, "nao-existe")
+    res = await client.post("/auth/refresh")
     assert res.status_code == 401
 
 
@@ -196,12 +203,11 @@ async def test_concurrent_rotation_issues_only_one_successor(client):
     # Duas rotações simultâneas do MESMO refresh: só uma pode vencer.
     # Sem FOR UPDATE, as duas validam o token ainda não revogado e emitem
     # dois sucessores válidos — o token roubado mantém sessão paralela.
-    body = await _register(client)
-    old = body["refresh_token"]
+    await _register(client)
 
     res_a, res_b = await asyncio.gather(
-        client.post("/auth/refresh", json={"refresh_token": old}),
-        client.post("/auth/refresh", json={"refresh_token": old}),
+        client.post("/auth/refresh"),
+        client.post("/auth/refresh"),
     )
     assert sorted([res_a.status_code, res_b.status_code]) == [200, 401]
 
@@ -209,18 +215,17 @@ async def test_concurrent_rotation_issues_only_one_successor(client):
 @pytest.mark.asyncio
 async def test_reusing_rotated_token_revokes_all_sessions(client):
     # Reuso de um token já rotacionado = sinal de roubo. Derruba tudo.
-    body = await _register(client)
-    r1 = body["refresh_token"]
-    r2 = (await client.post("/auth/refresh", json={"refresh_token": r1})).json()[
-        "refresh_token"
-    ]
+    await _register(client)
+    r1 = client.cookies.get(COOKIE)
+    await client.post("/auth/refresh")
+    r2 = client.cookies.get(COOKIE)
 
-    # Cookie tem precedência sobre o corpo (#110); limpa o jar para garantir
-    # que r1 (já rotacionado) chega pelo corpo, não pelo cookie mais recente.
-    client.cookies.clear()
-    assert (await client.post("/auth/refresh", json={"refresh_token": r1})).status_code == 401
+    # r1 já foi rotacionado; reapresentá-lo é o sinal de roubo.
+    client.cookies.set(COOKIE, r1)
+    assert (await client.post("/auth/refresh")).status_code == 401
     # O sucessor legítimo também morre: a sessão inteira foi invalidada.
-    assert (await client.post("/auth/refresh", json={"refresh_token": r2})).status_code == 401
+    client.cookies.set(COOKIE, r2)
+    assert (await client.post("/auth/refresh")).status_code == 401
 
 
 @pytest.mark.asyncio
@@ -228,23 +233,21 @@ async def test_logout_with_rotated_token_revokes_successor(client):
     # SEC-01: atacante rouba R0 e rotaciona para R1. A vítima desloga com R0.
     # O logout precisa tratar isso como reuso e derrubar R1 também, senão o
     # atacante mantém sessão viva por 7 dias depois do logout da vítima.
-    body = await _register(client)
-    r0 = body["refresh_token"]
+    await _register(client)
+    r0 = client.cookies.get(COOKIE)
 
-    r1 = (await client.post("/auth/refresh", json={"refresh_token": r0})).json()[
-        "refresh_token"
-    ]
-    assert r1
+    await client.post("/auth/refresh")
+    r1 = client.cookies.get(COOKIE)
+    assert r1 and r1 != r0
 
-    # Cookie tem precedência sobre o corpo (#110); limpa o jar para garantir
-    # que r0 (o token roubado e já rotacionado) chega pelo corpo, não pelo
-    # cookie mais recente que o jar reenviaria.
-    client.cookies.clear()
-    res = await client.post("/auth/logout", json={"refresh_token": r0})
+    # A vítima desloga apresentando R0, o token roubado e já rotacionado.
+    client.cookies.set(COOKIE, r0)
+    res = await client.post("/auth/logout")
     assert res.status_code == 204
 
     # O sucessor do atacante tem que estar morto.
-    after = await client.post("/auth/refresh", json={"refresh_token": r1})
+    client.cookies.set(COOKIE, r1)
+    after = await client.post("/auth/refresh")
     assert after.status_code == 401
 
 
@@ -253,31 +256,27 @@ async def test_login_sets_an_httponly_refresh_cookie(client):
     await _register(client)
     res = await client.post("/auth/login", json={"email": REG["email"], "password": REG["password"]})
     assert res.status_code == 200
+    assert "refresh_token" not in res.json()
     set_cookie = res.headers["set-cookie"]
     assert f"{COOKIE}=" in set_cookie
     assert "HttpOnly" in set_cookie
     assert "SameSite=lax" in set_cookie
     assert "Path=/auth" in set_cookie
-    # O cookie leva o MESMO token do corpo durante a transição (passo 1 de 3).
-    assert res.json()["refresh_token"] in set_cookie
 
 
 @pytest.mark.asyncio
 async def test_refresh_works_from_the_cookie_alone(client):
-    body = await _register(client)
+    await _register(client)
     antigo = client.cookies.get(COOKIE)
-    assert antigo == body["refresh_token"]
 
     res = await client.post("/auth/refresh")  # sem corpo: só o cookie
     assert res.status_code == 200, res.text
     assert res.json()["access_token"]
-    # Rotacionou: o cookie novo é outro, e o antigo já não vale. O jar do
-    # httpx reenviaria o cookie novo (que tem precedência sobre o corpo), por
-    # isso ele é limpo antes de apresentar o token antigo pelo corpo.
+    # Rotacionou: o cookie novo é outro, e o antigo já não vale.
     novo = client.cookies.get(COOKIE)
     assert novo and novo != antigo
-    client.cookies.clear()
-    reused = await client.post("/auth/refresh", json={"refresh_token": antigo})
+    client.cookies.set(COOKIE, antigo)
+    reused = await client.post("/auth/refresh")
     assert reused.status_code == 401
 
 

--- a/backend/tests/test_refresh.py
+++ b/backend/tests/test_refresh.py
@@ -47,7 +47,10 @@ async def test_refresh_rotates_and_invalidates_old_token(client):
 
     # O refresh antigo foi rotacionado: usá-lo de novo deve falhar. O jar do
     # httpx já guarda o cookie mais recente; apresenta o antigo explicitamente
-    # para garantir que É ele quem chega no servidor.
+    # para garantir que É ele quem chega no servidor. O cookie que o servidor
+    # setou vive em Path=/auth e o que setamos aqui explicitamente vai pra "/"
+    # — limpar antes deixa claro qual token o servidor efetivamente recebe.
+    client.cookies.clear()
     client.cookies.set(COOKIE, old_refresh)
     reused = await client.post("/auth/refresh")
     assert reused.status_code == 401
@@ -62,6 +65,7 @@ async def test_logout_revokes_refresh_token(client):
     assert res.status_code == 204
 
     # Depois do logout o refresh não vale mais.
+    client.cookies.clear()
     client.cookies.set(COOKIE, refresh)
     after = await client.post("/auth/refresh")
     assert after.status_code == 401
@@ -69,6 +73,7 @@ async def test_logout_revokes_refresh_token(client):
 
 @pytest.mark.asyncio
 async def test_logout_is_idempotent_for_unknown_token(client):
+    client.cookies.clear()
     client.cookies.set(COOKIE, "inexistente")
     res = await client.post("/auth/logout")
     assert res.status_code == 204
@@ -92,9 +97,11 @@ async def test_logout_is_rate_limited(client):
             # Logout limpa o cookie a cada chamada; reapresenta o mesmo token
             # antes de cada uma, senão a segunda já cairia em 401 por falta
             # de cookie em vez de medir o balde.
+            client.cookies.clear()
             client.cookies.set(COOKIE, "nao-existe")
             res = await client.post("/auth/logout")
             assert res.status_code == 204
+        client.cookies.clear()
         client.cookies.set(COOKIE, "nao-existe")
         estourou = await client.post("/auth/logout")
         assert estourou.status_code == 429
@@ -120,9 +127,11 @@ async def test_logout_bucket_is_keyed_by_the_refresh_token_not_ip(client):
         for _ in range(120):
             # Logout limpa o cookie a cada chamada; reapresenta o mesmo token
             # antes de cada uma para não cair em 401 por falta de cookie.
+            client.cookies.clear()
             client.cookies.set(COOKIE, "token-a")
             res = await client.post("/auth/logout")
             assert res.status_code == 204
+        client.cookies.clear()
         client.cookies.set(COOKIE, "token-a")
         estourou = await client.post("/auth/logout")
         assert estourou.status_code == 429
@@ -135,10 +144,12 @@ async def test_logout_bucket_is_keyed_by_the_refresh_token_not_ip(client):
         # duas chaves.
         de_outro_ip = ASGITransport(app=app, client=("10.0.0.2", 1234))
         async with AsyncClient(transport=de_outro_ip, base_url="http://test") as outro_ip:
+            outro_ip.cookies.clear()
             outro_ip.cookies.set(COOKIE, "token-a")
             mesmo_token = await outro_ip.post("/auth/logout")
             assert mesmo_token.status_code == 429  # IP novo não livra o token saturado
 
+            outro_ip.cookies.clear()
             outro_ip.cookies.set(COOKIE, "token-b")
             outro_token = await outro_ip.post("/auth/logout")
             assert outro_token.status_code == 204  # token diferente = balde diferente
@@ -161,9 +172,11 @@ async def test_logout_has_an_ip_wide_flood_ceiling(client):
     limiter.enabled = True
     try:
         for _ in range(120):
+            client.cookies.clear()
             client.cookies.set(COOKIE, uuid_mod.uuid4().hex)
             res = await client.post("/auth/logout")
             assert res.status_code == 204
+        client.cookies.clear()
         client.cookies.set(COOKIE, uuid_mod.uuid4().hex)
         estourou = await client.post("/auth/logout")
         assert estourou.status_code == 429
@@ -181,6 +194,7 @@ async def test_refresh_no_longer_throttles_at_20_per_minute(client):
 
     limiter.reset()
     limiter.enabled = True
+    client.cookies.clear()
     client.cookies.set(COOKIE, "nao-existe")
     try:
         for _ in range(25):
@@ -193,6 +207,7 @@ async def test_refresh_no_longer_throttles_at_20_per_minute(client):
 
 @pytest.mark.asyncio
 async def test_refresh_with_invalid_token_401(client):
+    client.cookies.clear()
     client.cookies.set(COOKIE, "nao-existe")
     res = await client.post("/auth/refresh")
     assert res.status_code == 401
@@ -221,9 +236,11 @@ async def test_reusing_rotated_token_revokes_all_sessions(client):
     r2 = client.cookies.get(COOKIE)
 
     # r1 já foi rotacionado; reapresentá-lo é o sinal de roubo.
+    client.cookies.clear()
     client.cookies.set(COOKIE, r1)
     assert (await client.post("/auth/refresh")).status_code == 401
     # O sucessor legítimo também morre: a sessão inteira foi invalidada.
+    client.cookies.clear()
     client.cookies.set(COOKIE, r2)
     assert (await client.post("/auth/refresh")).status_code == 401
 
@@ -241,11 +258,13 @@ async def test_logout_with_rotated_token_revokes_successor(client):
     assert r1 and r1 != r0
 
     # A vítima desloga apresentando R0, o token roubado e já rotacionado.
+    client.cookies.clear()
     client.cookies.set(COOKIE, r0)
     res = await client.post("/auth/logout")
     assert res.status_code == 204
 
     # O sucessor do atacante tem que estar morto.
+    client.cookies.clear()
     client.cookies.set(COOKIE, r1)
     after = await client.post("/auth/refresh")
     assert after.status_code == 401
@@ -260,7 +279,7 @@ async def test_login_sets_an_httponly_refresh_cookie(client):
     set_cookie = res.headers["set-cookie"]
     assert f"{COOKIE}=" in set_cookie
     assert "HttpOnly" in set_cookie
-    assert "SameSite=lax" in set_cookie
+    assert "SameSite=strict" in set_cookie
     assert "Path=/auth" in set_cookie
 
 
@@ -275,6 +294,7 @@ async def test_refresh_works_from_the_cookie_alone(client):
     # Rotacionou: o cookie novo é outro, e o antigo já não vale.
     novo = client.cookies.get(COOKIE)
     assert novo and novo != antigo
+    client.cookies.clear()
     client.cookies.set(COOKIE, antigo)
     reused = await client.post("/auth/refresh")
     assert reused.status_code == 401
@@ -286,5 +306,19 @@ async def test_logout_clears_the_cookie(client):
     res = await client.post("/auth/logout")  # sem corpo: só o cookie
     assert res.status_code == 204
     assert "Max-Age=0" in res.headers["set-cookie"]
+    # Um delete_cookie que esquecesse o path deixaria um cookie vivo no
+    # navegador (Path=/ != Path=/auth) e a checagem de revogação no banco
+    # acima passaria do mesmo jeito, escondendo o vazamento.
+    assert "Path=/auth" in res.headers["set-cookie"]
     # Sem cookie e sem corpo não há o que renovar.
     assert (await client.post("/auth/refresh")).status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_the_cookie_alone_does_not_authenticate_a_route(client):
+    # O cookie tem Path=/auth, então o navegador manda ele pra /auth/me também
+    # (e para qualquer outra rota sob /auth). Só /auth/refresh e /auth/logout
+    # podem lê-lo; todo o resto autentica exclusivamente pelo bearer token.
+    await _register(client)  # o client agora carrega o cookie
+    res = await client.get("/auth/me")  # sem header Authorization
+    assert res.status_code == 401


### PR DESCRIPTION
Closes #110. Drops refresh_token from the login, register and refresh responses and from the request body. Requires 2/3 live on Vercel first.

## Follow-ups from the final review

1. README stack table: `python-jose (JWT)` -> `PyJWT (JWT)`, `FastAPI 0.139` -> `FastAPI 0.141`, `google-generativeai` -> `google-genai`, matching the pins in `requirements.txt`.
2. Refresh cookie now sets `SameSite=Strict` instead of `Lax` in both `_set_refresh_cookie` and `_clear_refresh_cookie`; the cookie is only ever read by same-site XHR, never by a navigation, so Strict closes the "Lax-allowing-unsafe" window Chrome opens for the first 2 minutes of a cookie's life.
3. New test `test_the_cookie_alone_does_not_authenticate_a_route`: the cookie's `Path=/auth` means the browser also sends it to `/auth/me`, and that route must still reject the request without a bearer token.
4. `test_logout_clears_the_cookie` now also asserts `Path=/auth` on the cleared cookie, catching a `delete_cookie` that forgot the path.
5. Explicit `client.cookies.clear()` before every `client.cookies.set(COOKIE, ...)` in the refresh/logout/password-reset tests, making it unambiguous which token the server receives when the server-set cookie (`Path=/auth`) and the test-set one (`Path=/`) could otherwise coexist in the jar.
6. `limiter.py`'s `user_key` now catches `(jwt.PyJWTError, ValueError, TypeError)`, matching `dependencies.py`, so an unexpected decode error falls back to the IP key instead of a 500.
7. `.env.example`: documented that `APP_BASE_URL`'s scheme also drives the refresh cookie's `Secure` flag.
8. Dropped the direct `cryptography==50.0.0` pin from `requirements.txt` (it's transitive via `google-auth`/`google-genai`); regenerated both locks, `scripts/check_locks.py` and `pip-audit -r requirements.lock` both pass clean with `cryptography` still resolving to `50.0.0`.
9. `config.py` now rejects `CORS_ORIGINS=*` via a Pydantic validator, since `allow_credentials=True` would otherwise let any origin read the refresh cookie; covered by `test_settings_rejects_wildcard_cors_origin`.
