### PR TITLE
fix(auth): frontend refresh hygiene from the final review

### DIFF
--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -7,7 +7,10 @@ import App from "./App";
 
 vi.mock("@/api/auth", () => ({
   authApi: {
-    refresh: vi.fn(() => Promise.resolve({ data: { access_token: "novo" } })),
+    // O refreshAccessToken de verdade resolve com o access token cru
+    // (string), não com a resposta axios inteira — quem guarda o token no
+    // store é a própria função, não quem chama authApi.refresh().
+    refresh: vi.fn(() => Promise.resolve("novo")),
     me: vi.fn(() => Promise.resolve({ data: { name: "Alice" } })),
   },
 }));

--- a/frontend/src/api/axios.js
+++ b/frontend/src/api/axios.js
@@ -36,8 +36,13 @@ export async function refreshAccessToken() {
   if (inflightRefresh) return inflightRefresh;
   const run = async () => {
     // Chamada "crua" (sem interceptors) para evitar recursão. Sem corpo: o
-    // refresh token vai no cookie HttpOnly.
-    const { data } = await axios.post(`${baseURL}/auth/refresh`, null, { withCredentials: true });
+    // refresh token vai no cookie HttpOnly. timeout: uma requisição que trava
+    // não pode segurar o Web Lock "norby-auth-refresh" para sempre — sem
+    // limite, uma aba com rede ruim travaria o refresh de todas as outras.
+    const { data } = await axios.post(`${baseURL}/auth/refresh`, null, {
+      withCredentials: true,
+      timeout: 15000,
+    });
     useAuthStore.getState().setToken(data.access_token);
     return data.access_token;
   };
@@ -58,13 +63,16 @@ api.interceptors.response.use(
   async (error) => {
     const original = error.config || {};
     const url = original.url || "";
-    // login/register/refresh não passam pelo fluxo de renovação:
+    // login/register/refresh/logout não passam pelo fluxo de renovação:
     // - login/register: o catch do componente exibe a mensagem de erro;
-    // - refresh: se ele falha, não há o que renovar.
+    // - refresh: se ele falha, não há o que renovar;
+    // - logout: um 401 aqui só significa "sem cookie", não motivo pra tentar
+    //   renovar um token que a própria chamada está encerrando.
     const isAuthEndpoint =
       url.includes("/auth/login") ||
       url.includes("/auth/register") ||
-      url.includes("/auth/refresh");
+      url.includes("/auth/refresh") ||
+      url.includes("/auth/logout");
 
     if (error.response?.status !== 401 || isAuthEndpoint || original._retry) {
       return Promise.reject(error);

--- a/frontend/src/api/axios.test.js
+++ b/frontend/src/api/axios.test.js
@@ -25,6 +25,13 @@ const erro401 = (url = "/transactions/") => ({
   config: { url, headers: {} },
 });
 
+// Roda ANTES do describe abaixo (a ordem de declaração é a ordem de
+// execução): axios.create só é chamado uma vez, no import do módulo lá em
+// cima, e o beforeEach do describe seguinte limpa o histórico dos mocks.
+it("cria a instância do axios com credenciais habilitadas", () => {
+  expect(axios.create).toHaveBeenCalledWith(expect.objectContaining({ withCredentials: true }));
+});
+
 describe("interceptor de refresh", () => {
   let hrefOriginal;
 
@@ -43,6 +50,7 @@ describe("interceptor de refresh", () => {
 
   afterEach(() => {
     window.location = { href: hrefOriginal };
+    delete navigator.locks;
   });
 
   it("renova o token no 401 e repete a requisição", async () => {
@@ -100,7 +108,7 @@ describe("interceptor de refresh", () => {
     const [url, corpo, opcoes] = axios.post.mock.calls[0];
     expect(url).toMatch(/\/auth\/refresh$/);
     expect(corpo).toBeNull();
-    expect(opcoes).toEqual({ withCredentials: true });
+    expect(opcoes).toEqual({ withCredentials: true, timeout: 15000 });
     expect(useAuthStore.getState().token).toBe("novo");
   });
 
@@ -126,6 +134,5 @@ describe("interceptor de refresh", () => {
     await refreshAccessToken();
 
     expect(navigator.locks.request).toHaveBeenCalledWith("norby-auth-refresh", expect.any(Function));
-    delete navigator.locks;
   });
 });


### PR DESCRIPTION
Small follow-ups from the final review of the cookie-refresh series (#110), frontend-only.

- `axios.js`: the raw `/auth/refresh` call now passes `{ withCredentials: true, timeout: 15000 }` — a hung request must not hold the `norby-auth-refresh` Web Lock forever. `isAuthEndpoint` now also matches `/auth/logout`, so a cookie-less logout 401 does not trigger a refresh attempt.
- `axios.test.js`: asserts `axios.create` was called with `withCredentials: true`; the refresh-call assertion now expects `{ withCredentials: true, timeout: 15000 }`; the `navigator.locks` stub is now cleaned up in `afterEach` instead of at the end of one test body.
- `App.test.jsx`: the `authApi.refresh` mock now resolves to a bare string, matching what the real `refreshAccessToken` resolves with (it stores the token internally; callers never see `{ data: { access_token } }`).