### PR TITLE
fix(auth): 30-second reuse grace on refresh token rotation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -271,6 +271,17 @@ não tinham passado por login/refresh desde o passo 1: o build antigo nunca
 recebeu o cookie, e sem `localStorage` para recorrer não sobrou refresh para
 apresentar.
 
+**Janela de tolerância a reuso na rotação (#130):** o refresh no boot (acima)
+tornou comum um navegador ficar com o token antecessor depois de uma resposta
+perdida (conexão caída, aba fechada em voo, 502 depois do commit) ou de duas
+abas restaurando juntas. `ROTATION_REUSE_GRACE` (30s, `auth_service.py`) trata
+isso como sessão legítima: reapresentar um token rotacionado há menos de 30s
+ganha um sucessor novo em vez de derrubar a família. Fora da janela, reuso
+continua sinal de roubo e cascateia como antes; o logout **nunca** consulta a
+janela (SEC-01 continua valendo). A coluna `refresh_tokens.revoked_at`
+(migration desta task) fica NULL em toda revogação em cascata — de propósito,
+para que um cascateamento nunca vire elegível para a própria graça.
+
 **Rate limit atrás do proxy — reescrito em 2026-08-16 (issue #22, fix round 1
 incluído):** o uvicorn só honra `X-Forwarded-For` quando o peer é
 `127.0.0.1` (default de `forwarded_allow_ips`), e o proxy do Railway não é

--- a/backend/alembic/versions/ac5c445ac949_refresh_token_revoked_at_for_the_reuse_.py
+++ b/backend/alembic/versions/ac5c445ac949_refresh_token_revoked_at_for_the_reuse_.py
@@ -1,0 +1,35 @@
+"""refresh token revoked_at for the reuse grace
+
+Issue #130. Aditiva, nada existente é tocado.
+
+Hoje `revoked` (booleano) marca um refresh como morto, mas não guarda QUANDO.
+A janela de tolerância a reuso (`ROTATION_REUSE_GRACE`, 30s) precisa desse
+instante para distinguir resposta perdida de roubo de token. Linhas já
+revogadas antes desta migration ficam com `revoked_at` NULL, e a tolerância
+trata NULL como "fora da janela" — comportamento antigo preservado para o
+histórico.
+
+Revision ID: ac5c445ac949
+Revises: 205f60ec5dbf
+Create Date: 2026-09-06 13:53:38.871760
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'ac5c445ac949'
+down_revision: Union[str, None] = '205f60ec5dbf'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column('refresh_tokens', sa.Column('revoked_at', sa.DateTime(timezone=True), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column('refresh_tokens', 'revoked_at')

--- a/backend/app/models/sql_models.py
+++ b/backend/app/models/sql_models.py
@@ -124,6 +124,9 @@ class RefreshToken(Base):
     token_hash: Mapped[str] = mapped_column(String(64), unique=True, nullable=False, index=True)  # sha256 hex do token cru
     expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
     revoked: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
+    # #130: instante da revogação. Dentro de ROTATION_REUSE_GRACE a partir
+    # daqui, reapresentar o token vale como resposta perdida, não como roubo.
+    revoked_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utcnow)
 
     user: Mapped["User"] = relationship("User", back_populates="refresh_tokens")

--- a/backend/app/services/auth_service.py
+++ b/backend/app/services/auth_service.py
@@ -90,19 +90,34 @@ async def rotate_refresh_token(raw: str, db: AsyncSession) -> tuple[str, str, Us
     if record is None:
         return None
 
-    # Token já rotacionado sendo reapresentado é sinal de possível roubo.
-    # Revogar todas as sessões evita manter um sucessor comprometido ativo.
     if record.revoked:
-        await db.execute(
-            update(RefreshToken)
-            .where(
-                RefreshToken.user_id == record.user_id,
-                RefreshToken.revoked.is_(False),
-            )
-            .values(revoked=True)
+        agora = datetime.now(timezone.utc)
+        dentro_da_janela = (
+            record.revoked_at is not None and agora - record.revoked_at <= ROTATION_REUSE_GRACE
         )
+        if not dentro_da_janela:
+            # Token já rotacionado sendo reapresentado fora da janela é sinal
+            # de roubo. Revogar todas as sessões evita manter um sucessor
+            # comprometido ativo. `revoked_at` fica NULL aqui de propósito: é
+            # um cascateamento, não uma rotação individual, e não pode virar
+            # elegível para a própria janela de tolerância se alguém
+            # reapresentar uma dessas sessões momentos depois (o cascateamento
+            # tem que ser terminal, sem ressuscitar nada).
+            await db.execute(
+                update(RefreshToken)
+                .where(RefreshToken.user_id == record.user_id, RefreshToken.revoked.is_(False))
+                .values(revoked=True)
+            )
+            await db.commit()
+            return None
+        # Dentro da janela: sucessor NOVO para quem ficou com o antecessor. O
+        # sucessor anterior continua válido; o servidor só tem o hash dele.
+        user = await db.get(User, record.user_id)
+        if user is None:
+            return None
+        new_refresh = _new_refresh(str(user.id), db)
         await db.commit()
-        return None
+        return create_access_token(str(user.id)), new_refresh, user
 
     if record.expires_at <= datetime.now(timezone.utc):
         return None
@@ -112,6 +127,7 @@ async def rotate_refresh_token(raw: str, db: AsyncSession) -> tuple[str, str, Us
         return None
 
     record.revoked = True
+    record.revoked_at = datetime.now(timezone.utc)
     new_refresh = _new_refresh(str(user.id), db)
     await db.commit()
 
@@ -136,6 +152,12 @@ async def revoke_refresh_token(raw: str, db: AsyncSession) -> None:
     if record is None:
         return
 
+    # `revoked_at` fica de fora nos dois pontos abaixo, de propósito: o logout
+    # nunca consulta a janela de tolerância (#130, SEC-01), e se gravasse o
+    # instante aqui um refresh apresentado segundos depois do logout leria
+    # esse instante recente e ganharia a graça de uma rotação legítima — a
+    # sessão encerrada voltaria à vida. `revoked_at` só tem sentido para a
+    # rotação individual normal, que é a única fonte de reuso tolerável.
     if record.revoked:
         await db.execute(
             update(RefreshToken)
@@ -158,6 +180,13 @@ async def revoke_refresh_token(raw: str, db: AsyncSession) -> None:
 # este chega por e-mail e caixa comprometida é o vetor que ele abre.
 
 RESET_TTL = timedelta(minutes=settings.password_reset_expire_minutes)
+
+# #130: janela em que reapresentar um refresh já rotacionado é tratado como
+# resposta perdida (aba fechada em voo, conexão caída, 502 depois do commit)
+# ou como duas abas restaurando juntas, e não como roubo. Maior que o timeout
+# de 15 s do refresh no frontend, para o retry depois dele ainda caber aqui.
+# Fora da janela, reuso continua derrubando todas as sessões.
+ROTATION_REUSE_GRACE = timedelta(seconds=30)
 
 
 async def create_password_reset(user_id: str, db: AsyncSession) -> str:

--- a/backend/tests/test_refresh.py
+++ b/backend/tests/test_refresh.py
@@ -1,8 +1,12 @@
 import asyncio
+from datetime import datetime, timedelta, timezone
 
 import pytest
+from sqlalchemy import update
 
 from app.config import get_settings
+from app.models.sql_models import RefreshToken
+from app.services.auth_service import ROTATION_REUSE_GRACE
 
 REG = {
     "name": "Bob",
@@ -30,7 +34,7 @@ async def test_the_refresh_token_never_travels_in_the_body(client):
 
 
 @pytest.mark.asyncio
-async def test_refresh_rotates_and_invalidates_old_token(client):
+async def test_refresh_rotates_and_invalidates_old_token(client, db_session):
     await _register(client)
     old_refresh = client.cookies.get(COOKIE)
 
@@ -44,6 +48,17 @@ async def test_refresh_rotates_and_invalidates_old_token(client):
     # O novo refresh continua válido.
     again = await client.post("/auth/refresh")
     assert again.status_code == 200
+
+    # #130: dentro dos 30s de ROTATION_REUSE_GRACE, reapresentar o antigo
+    # ganharia um sucessor novo em vez de falhar (resposta perdida). Este
+    # teste quer o antigo comportamento — token rotacionado É inválido —,
+    # então envelhece a revogação para além da janela antes de reapresentar.
+    await db_session.execute(
+        update(RefreshToken)
+        .where(RefreshToken.revoked.is_(True))
+        .values(revoked_at=datetime.now(timezone.utc) - ROTATION_REUSE_GRACE - timedelta(seconds=1))
+    )
+    await db_session.commit()
 
     # O refresh antigo foi rotacionado: usá-lo de novo deve falhar. O jar do
     # httpx já guarda o cookie mais recente; apresenta o antigo explicitamente
@@ -214,32 +229,64 @@ async def test_refresh_with_invalid_token_401(client):
 
 
 @pytest.mark.asyncio
-async def test_concurrent_rotation_issues_only_one_successor(client):
-    # Duas rotações simultâneas do MESMO refresh: só uma pode vencer.
-    # Sem FOR UPDATE, as duas validam o token ainda não revogado e emitem
-    # dois sucessores válidos — o token roubado mantém sessão paralela.
+async def test_concurrent_rotations_both_succeed_within_the_grace(client):
+    # Duas abas restaurando ao mesmo tempo apresentam o MESMO cookie. O FOR
+    # UPDATE serializa: a segunda vê o token já rotacionado há milissegundos,
+    # dentro da janela, e ganha um sucessor próprio em vez de derrubar tudo.
     await _register(client)
-
     res_a, res_b = await asyncio.gather(
         client.post("/auth/refresh"),
         client.post("/auth/refresh"),
     )
-    assert sorted([res_a.status_code, res_b.status_code]) == [200, 401]
+    assert [res_a.status_code, res_b.status_code] == [200, 200]
+    assert res_a.json()["access_token"] and res_b.json()["access_token"]
 
 
 @pytest.mark.asyncio
-async def test_reusing_rotated_token_revokes_all_sessions(client):
-    # Reuso de um token já rotacionado = sinal de roubo. Derruba tudo.
+async def test_reusing_a_just_rotated_token_within_the_grace_keeps_the_session(client):
+    # Resposta perdida: o servidor rotacionou r0 -> r1, o navegador ficou com r0.
+    await _register(client)
+    r0 = client.cookies.get(COOKIE)
+    await client.post("/auth/refresh")
+    r1 = client.cookies.get(COOKIE)
+
+    client.cookies.clear()
+    client.cookies.set(COOKIE, r0)
+    res = await client.post("/auth/refresh")
+    assert res.status_code == 200
+    # res.cookies, não client.cookies: o jar do httpx guarda o cookie setado
+    # à mão acima (domain="") e o que o servidor acabou de emitir (domain do
+    # host efetivo) como duas entradas distintas com o mesmo nome — CookieConflict
+    # no client.cookies.get(). res.cookies só tem o que ESTA resposta setou.
+    r2 = res.cookies.get(COOKIE)
+    assert r2 and r2 not in (r0, r1)
+
+    # Nada foi derrubado: r1 e r2 continuam válidos.
+    for token in (r1, r2):
+        client.cookies.clear()
+        client.cookies.set(COOKIE, token)
+        assert (await client.post("/auth/refresh")).status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_reusing_rotated_token_revokes_all_sessions(client, db_session):
+    # Reuso de um token rotacionado FORA da janela = sinal de roubo. Derruba tudo.
     await _register(client)
     r1 = client.cookies.get(COOKIE)
     await client.post("/auth/refresh")
     r2 = client.cookies.get(COOKIE)
 
-    # r1 já foi rotacionado; reapresentá-lo é o sinal de roubo.
+    # Envelhece a revogação para além da janela.
+    await db_session.execute(
+        update(RefreshToken)
+        .where(RefreshToken.revoked.is_(True))
+        .values(revoked_at=datetime.now(timezone.utc) - ROTATION_REUSE_GRACE - timedelta(seconds=1))
+    )
+    await db_session.commit()
+
     client.cookies.clear()
     client.cookies.set(COOKIE, r1)
     assert (await client.post("/auth/refresh")).status_code == 401
-    # O sucessor legítimo também morre: a sessão inteira foi invalidada.
     client.cookies.clear()
     client.cookies.set(COOKIE, r2)
     assert (await client.post("/auth/refresh")).status_code == 401
@@ -284,7 +331,7 @@ async def test_login_sets_an_httponly_refresh_cookie(client):
 
 
 @pytest.mark.asyncio
-async def test_refresh_works_from_the_cookie_alone(client):
+async def test_refresh_works_from_the_cookie_alone(client, db_session):
     await _register(client)
     antigo = client.cookies.get(COOKIE)
 
@@ -294,6 +341,16 @@ async def test_refresh_works_from_the_cookie_alone(client):
     # Rotacionou: o cookie novo é outro, e o antigo já não vale.
     novo = client.cookies.get(COOKIE)
     assert novo and novo != antigo
+
+    # #130: fora dos 30s de ROTATION_REUSE_GRACE, reapresentar o antigo
+    # continua inválido (dentro da janela ganharia um sucessor novo).
+    await db_session.execute(
+        update(RefreshToken)
+        .where(RefreshToken.revoked.is_(True))
+        .values(revoked_at=datetime.now(timezone.utc) - ROTATION_REUSE_GRACE - timedelta(seconds=1))
+    )
+    await db_session.commit()
+
     client.cookies.clear()
     client.cookies.set(COOKIE, antigo)
     reused = await client.post("/auth/refresh")


### PR DESCRIPTION
Closes #130. A refresh token presented again within 30 s of its rotation now gets a new successor instead of revoking every session: that covers a lost response and two tabs restoring together, the cases the boot-time refresh made common. Outside the window reuse still cascades; logout never tolerates a stale token. Adds refresh_tokens.revoked_at (additive migration, existing revoked rows keep NULL and stay outside the window).