### PR TITLE
feat(ai): daily token and call quota per user

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -298,6 +298,17 @@ logs de produção por algumas semanas.
 Rotas **autenticadas** usam `user_key` em `app/limiter.py`, chaveando pelo id
 do usuário: `/ai/*` e, desde 2026-08-15, `DELETE /auth/me`.
 
+**Cota diária de IA (#21, ADR 0003):** dois tetos por usuário por dia da cota
+(UTC-8 fixo, o dia em que o Google zera o RPD do projeto): 120k tokens reais do
+`usage_metadata` e 100 chamadas, em `ai_usage_daily` com upsert e sem purga.
+Checagem e débito no helper `_com_cota` do `ai_service`, em volta das duas
+chamadas de rede; insight cacheado não conta. Recusa é
+`PlanRefused("AI_DAILY_CAP_REACHED")` com `resets_at`: o chat a sobe antes do
+503 genérico, o insight cai no 200 degradado com a mensagem. Vale para trial e
+independe de `paywall_enabled`. A chave de produção está no tier gratuito
+(RPD 500 compartilhado por todos os usuários): os 100 são RPD/5. A rajada de
+até 10 chamadas concorrentes no último token é aceita.
+
 Login e cadastro (anônimos) **não seguem mais por IP.** Desde 2026-08-16 usam
 atraso progressivo **por conta**: a chave é o HMAC-SHA256 do email
 normalizado (lower + trim) com o `secret_key` do servidor — o email cru nunca
@@ -375,17 +386,6 @@ protege o token é a entropia dos 48 bytes, não o contador.
   a documentação navegável é um ativo para o portfólio.
 - Usuários criados antes da migration `b2c3d4e5f6a7` têm `privacy_accepted_at`
   nulo. NULL significa "aceite não registrado", nunca "aceitou".
-
-**Cota diária de IA (#21, ADR 0003):** dois tetos por usuário por dia da cota
-(UTC-8 fixo, o dia em que o Google zera o RPD do projeto): 120k tokens reais do
-`usage_metadata` e 100 chamadas, em `ai_usage_daily` com upsert e sem purga.
-Checagem e débito no helper `_com_cota` do `ai_service`, em volta das duas
-chamadas de rede; insight cacheado não conta. Recusa é
-`PlanRefused("AI_DAILY_CAP_REACHED")` com `resets_at`: o chat a sobe antes do
-503 genérico, o insight cai no 200 degradado com a mensagem. Vale para trial e
-independe de `paywall_enabled`. A chave de produção está no tier gratuito
-(RPD 500 compartilhado por todos os usuários): os 100 são RPD/5. A rajada de
-até 10 chamadas concorrentes no último token é aceita.
 
 **Armadilhas já resolvidas (não reintroduzir):**
 - `VITE_API_URL` na Vercel **tem que ser `https://`**. Com `http://`, o Railway

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -376,6 +376,17 @@ protege o token é a entropia dos 48 bytes, não o contador.
 - Usuários criados antes da migration `b2c3d4e5f6a7` têm `privacy_accepted_at`
   nulo. NULL significa "aceite não registrado", nunca "aceitou".
 
+**Cota diária de IA (#21, ADR 0003):** dois tetos por usuário por dia da cota
+(UTC-8 fixo, o dia em que o Google zera o RPD do projeto): 120k tokens reais do
+`usage_metadata` e 100 chamadas, em `ai_usage_daily` com upsert e sem purga.
+Checagem e débito no helper `_com_cota` do `ai_service`, em volta das duas
+chamadas de rede; insight cacheado não conta. Recusa é
+`PlanRefused("AI_DAILY_CAP_REACHED")` com `resets_at`: o chat a sobe antes do
+503 genérico, o insight cai no 200 degradado com a mensagem. Vale para trial e
+independe de `paywall_enabled`. A chave de produção está no tier gratuito
+(RPD 500 compartilhado por todos os usuários): os 100 são RPD/5. A rajada de
+até 10 chamadas concorrentes no último token é aceita.
+
 **Armadilhas já resolvidas (não reintroduzir):**
 - `VITE_API_URL` na Vercel **tem que ser `https://`**. Com `http://`, o Railway
   responde 301 → https e o redirect rebaixa **POST→GET** → todo POST (login,

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -23,6 +23,8 @@ Resolvido pelo [ADR 0001](docs/adr/0001-modelo-de-assinatura.md) (issue #19).
 | **carência** (`GRACE`) | 72 horas exatas depois de `premium_until` em que o vencido ainda escapa do teto de carteiras. A IA já parou | `premium_until <= now < premium_until + 72h` |
 | **teto de carteiras** | Limite de 2 carteiras ativas. Vale para free e para vencido fora da carência | `premium_until IS NULL OR now >= premium_until + 72h` |
 | **carteira excedente** | Carteira acima do teto: fica somente-leitura, mas **continua contando em todo total** | as 2 mais antigas nunca são excedentes |
+| **cota diária de IA** | 120k tokens **ou** 100 chamadas por dia da cota, para quem pode gerar. Vale com o paywall desligado | linha de `ai_usage_daily` do dia abaixo dos dois tetos |
+| **dia da cota** | Dia em UTC-8, o dia em que o Google zera o RPD do projeto. Nem UTC nem Brasília | `dia_da_cota()` em `ai_service.py` |
 
 Os dois portões, escritos por extenso:
 
@@ -49,6 +51,7 @@ reescrito; `message` é livre.**
 | `WALLET_LIMIT_REACHED` | criar carteira além do teto |
 | `WALLET_READ_ONLY` | qualquer escrita numa carteira bloqueada, inclusive como destino |
 | `AI_REQUIRES_PREMIUM` | gerar IA sem trial e sem assinatura |
+| `AI_DAILY_CAP_REACHED` | gerar IA depois de estourar a cota diária (ADR 0003); traz `resets_at` |
 
 ### Termos que este glossário evita de propósito
 

--- a/backend/alembic/versions/7b3452a35a35_ai_usage_daily.py
+++ b/backend/alembic/versions/7b3452a35a35_ai_usage_daily.py
@@ -1,0 +1,45 @@
+"""ai_usage_daily
+
+Issue #21 (ADR 0003). Aditiva, nada existente é tocado.
+
+Uma linha por (usuário, dia da cota) com dois contadores: tokens reais lidos
+do `usage_metadata` do Gemini e número de chamadas. `day` é o dia em UTC-8
+(`QUOTA_TZ` em `ai_service.py`), o dia em que o Google zera o RPD do projeto,
+não o dia UTC nem o de Brasília. Sem purga de propósito: uma linha por
+usuário por dia não pesa, e o histórico é o instrumento que calibra os tetos
+(o número de hoje é estimativa; o p99 real, depois de um mês, é medida). Some
+com o usuário pelo `ON DELETE CASCADE`. Não entra no export da LGPD:
+contadores, não conteúdo.
+
+Revision ID: 7b3452a35a35
+Revises: ac5c445ac949
+Create Date: 2026-09-06 15:06:11.852539
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '7b3452a35a35'
+down_revision: Union[str, None] = 'ac5c445ac949'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'ai_usage_daily',
+        sa.Column('user_id', sa.UUID(), nullable=False),
+        sa.Column('day', sa.Date(), nullable=False),
+        sa.Column('tokens', sa.Integer(), server_default=sa.text('0'), nullable=False),
+        sa.Column('calls', sa.Integer(), server_default=sa.text('0'), nullable=False),
+        sa.ForeignKeyConstraint(['user_id'], ['users.id'], ondelete='CASCADE'),
+        sa.PrimaryKeyConstraint('user_id', 'day'),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table('ai_usage_daily')

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -63,9 +63,10 @@ async def _plan_refused_handler(request: Request, exc: PlanRefused) -> JSONRespo
     # `detail` em objeto de propósito: o frontend faz switch no `code`, que é
     # contrato e nunca é reescrito. Header próprio exigiria expose_headers no
     # CORS — a armadilha que este repo já pisou com o X-Total-Count.
-    return JSONResponse(
-        status_code=403, content={"detail": {"code": exc.code, "message": exc.message}}
-    )
+    detail = {"code": exc.code, "message": exc.message}
+    if exc.resets_at is not None:
+        detail["resets_at"] = exc.resets_at.isoformat()
+    return JSONResponse(status_code=403, content={"detail": detail})
 
 
 @app.exception_handler(WalletNotFound)

--- a/backend/app/models/sql_models.py
+++ b/backend/app/models/sql_models.py
@@ -131,6 +131,26 @@ class RefreshToken(Base):
 
     user: Mapped["User"] = relationship("User", back_populates="refresh_tokens")
 
+class AiUsageDaily(Base):
+    """Uso de IA por usuário e por dia da cota (issue #21, ADR 0003).
+
+    Uma linha por (usuário, dia). `day` é o dia em UTC-8 (ver `QUOTA_TZ` em
+    ai_service.py), o dia em que o Google zera o RPD do projeto, não o dia UTC
+    nem o de Brasília. Sem purga de propósito: uma linha por usuário por dia
+    não pesa, e o histórico é o instrumento que calibra os tetos (o número de
+    hoje é estimativa; o p99 real, depois de um mês, é medida). Some com o
+    usuário pelo ON DELETE CASCADE. Não entra no export da LGPD: contadores,
+    não conteúdo.
+    """
+    __tablename__ = "ai_usage_daily"
+
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("users.id", ondelete="CASCADE"), primary_key=True
+    )
+    day: Mapped[date] = mapped_column(Date, primary_key=True)
+    tokens: Mapped[int] = mapped_column(Integer, nullable=False, server_default=text("0"))
+    calls: Mapped[int] = mapped_column(Integer, nullable=False, server_default=text("0"))
+
 class PasswordResetToken(Base):
     """Token de recuperação de senha (#36).
 

--- a/backend/app/routers/ai.py
+++ b/backend/app/routers/ai.py
@@ -6,6 +6,7 @@ from app.dependencies import get_db, get_current_user, require_ai_access
 from app.limiter import limiter, user_key
 from app.models.sql_models import User
 from app.services.ai_service import get_or_generate_insight, chat_with_ai
+from app.services.plan_service import PlanRefused
 from app.schemas.ai import (
     ChatMessage,
     InsightResponse,
@@ -74,6 +75,10 @@ async def chat(
     # Chama o Gemini (se falhar, devolve 503 claro em vez de 500 sem headers de CORS)
     try:
         ai_response = await chat_with_ai(db, user_id, payload.message, history)
+    except PlanRefused:
+        # Cota diária (ADR 0003): sobe até o handler do main, que vira 403 com
+        # o código. Antes do genérico, que a transformaria num 503 sem motivo.
+        raise
     except Exception:
         logger.exception("Falha no chat com a IA (user=%s)", user_id)
         raise HTTPException(

--- a/backend/app/services/ai_service.py
+++ b/backend/app/services/ai_service.py
@@ -85,15 +85,21 @@ def _tokens_usados(resposta) -> int:
     pensa. Sem total, soma os componentes tratando `None` como zero. Sem
     `usage_metadata` (stub de teste, SDK quebrado) conta zero: o teto de
     chamadas continua valendo e segura o dia mesmo assim.
+
+    Os quatro campos são lidos com `getattr(..., None)`, não acesso direto:
+    isto roda DEPOIS da chamada de rede, então um `usage_metadata` com um
+    formato diferente (a migração para a Interactions API) não pode levantar
+    aqui — a chamada já aconteceu e precisa ser debitada de qualquer jeito.
     """
     uso = getattr(resposta, "usage_metadata", None)
     if uso is None:
         return 0
-    if uso.total_token_count is not None:
-        return uso.total_token_count
+    total = getattr(uso, "total_token_count", None)
+    if total is not None:
+        return total
     return (
-        (uso.prompt_token_count or 0)
-        + (uso.candidates_token_count or 0)
+        (getattr(uso, "prompt_token_count", None) or 0)
+        + (getattr(uso, "candidates_token_count", None) or 0)
         + (getattr(uso, "thoughts_token_count", None) or 0)
     )
 
@@ -176,20 +182,21 @@ async def _gerar_json(prompt: str) -> tuple[str, int]:
 
 
 async def _responder_chat(historico: list, mensagem: str) -> tuple[str, int]:
-    """Saída de rede do chat. A outra que os testes stubam."""
+    """Saída de rede do chat. A outra que os testes stubam.
+
+    A guarda de resposta vazia NÃO mora aqui: uma resposta vazia ou bloqueada
+    por safety filter já consumiu uma chamada de verdade e os tokens do
+    prompt — levantar antes de devolver o uso deixaria essa chamada sem
+    débito, um caminho sem teto para quem forjar um prompt que sempre cai no
+    filtro (achado de review de 2026-09-06). Quem levanta é `chat_with_ai`,
+    depois que `_com_cota` já debitou.
+    """
     chat = client.aio.chats.create(model=MODELO, history=historico)
     resposta = await chat.send_message(
         mensagem,
         config=types.GenerateContentConfig(max_output_tokens=MAX_TOKENS_CHAT),
     )
-    if not resposta.text:
-        # Vazia, bloqueada por safety filter ou truncada antes do primeiro
-        # token. Levantar preserva o 503 claro da rota: devolver "" gravaria
-        # uma bolha VAZIA no histórico como se a IA tivesse respondido. O SDK
-        # antigo levantava sozinho aqui; este devolve None, então a guarda
-        # passa a ser nossa.
-        raise ValueError("resposta vazia do Gemini")
-    return resposta.text, _tokens_usados(resposta)
+    return resposta.text or "", _tokens_usados(resposta)
 
 async def _get_user_financial_summary(db: AsyncSession, user_id: str) -> dict:
     """Resumo do mês corrente, reusando os agregados do dashboard.
@@ -371,7 +378,17 @@ async def chat_with_ai(db: AsyncSession, user_id: str, message: str, history: li
         role = "user" if msg.get("role") == "user" else "model"
         chat_history.append(types.Content(role=role, parts=[types.Part(text=content)]))
 
-    return await _com_cota(
+    resposta = await _com_cota(
         db, user_id,
         lambda: _responder_chat(chat_history, f"{system_context}\n\nUsuário: {message}"),
     )
+    if not resposta:
+        # Vazia, bloqueada por safety filter ou truncada antes do primeiro
+        # token. Levantar preserva o 503 claro da rota: devolver "" gravaria
+        # uma bolha VAZIA no histórico como se a IA tivesse respondido. O SDK
+        # antigo levantava sozinho aqui; este devolve None, então a guarda
+        # passa a ser nossa. Fica DEPOIS do `_com_cota` de propósito: a
+        # chamada já aconteceu e já foi debitada, então a guarda não pode
+        # mais impedir o débito — só decide o que a rota faz com o resultado.
+        raise ValueError("resposta vazia do Gemini")
+    return resposta

--- a/backend/app/services/ai_service.py
+++ b/backend/app/services/ai_service.py
@@ -1,12 +1,15 @@
 from google import genai
 from google.genai import types
-from datetime import datetime, timezone
+import uuid
+from datetime import date, datetime, time, timedelta, timezone
 from sqlalchemy import select, func
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 from app.database import ai_insights_collection
-from app.models.sql_models import Transaction, TransactionType
+from app.models.sql_models import AiUsageDaily, Transaction, TransactionType
 from app.services.dashboard_service import _income_expense, top_expense_categories
 from app.services.goal_service import current_month_range
+from app.services.plan_service import PlanRefused
 from app.services.score_service import compute_financial_score
 from app.config import get_settings
 import hashlib
@@ -36,12 +39,130 @@ MODELO = "gemini-3.5-flash-lite"
 MAX_TOKENS_INSIGHT = 512
 MAX_TOKENS_CHAT = 1024
 
+# --- Cota diária de IA (issue #21, ADR 0003) --------------------------------
+# Dois tetos por usuário e por dia da cota. Valem para quem passa pelo portão
+# de plano (trial incluído) e não dependem de `paywall_enabled`: a cota protege
+# a produção a partir do merge, não a partir da virada do paywall.
+#
+# Tokens: 120k é a faixa de equilíbrio do #18 contra os R$ 20/mês, dimensionada
+# para o tier PAGO de propósito, para não mudar quando o faturamento ligar.
+# Chamadas: a chave de produção está no tier gratuito, com RPD 500 compartilhado
+# por todos os usuários do projeto; 100 = RPD/5, para um script sozinho gastar
+# no máximo um quinto do dia de todo mundo. Um dia pesado legítimo (30 trocas
+# de chat + 20 regenerações de insight) cabe duas vezes.
+DAILY_TOKEN_CAP = 120_000
+DAILY_CALL_CAP = 100
+DAILY_CAP_MESSAGE = (
+    "Você atingiu o limite diário da assistente. "
+    "Ele libera de novo às 5h da manhã (horário de Brasília)."
+)
+# O dia da cota é o dia do Google: o RPD do projeto zera à meia-noite do
+# Pacífico e o painel do AI Studio usa UTC-8 fixo. Alinhar faz o teto por
+# usuário ser uma fração honesta do dia compartilhado (com dia UTC, um usuário
+# ganharia dois tetos dentro de um dia do Google). Se o Google seguir o horário
+# de verão do Pacífico, o reset dele cai uma hora antes do nosso: erro para o
+# lado seguro. Offset fixo de propósito: sem tabela de fuso.
+QUOTA_TZ = timezone(timedelta(hours=-8))
 
-async def _gerar_json(prompt: str) -> str:
+
+def dia_da_cota(now: datetime | None = None) -> date:
+    return (now or datetime.now(timezone.utc)).astimezone(QUOTA_TZ).date()
+
+
+def cota_zera_em(now: datetime | None = None) -> datetime:
+    """Próxima meia-noite UTC-8, devolvida em UTC (vai no `resets_at` do 403)."""
+    local = (now or datetime.now(timezone.utc)).astimezone(QUOTA_TZ)
+    meia_noite = datetime.combine(local.date() + timedelta(days=1), time.min, tzinfo=QUOTA_TZ)
+    return meia_noite.astimezone(timezone.utc)
+
+
+def _tokens_usados(resposta) -> int:
+    """Lê o `usage_metadata` da resposta do Gemini. Função única de propósito:
+    o Google já rotula `generate_content` como "Legacy" e a API nova
+    (Interactions) renomeia os campos; a migração toca só aqui.
+
+    `total_token_count` já inclui os tokens de raciocínio quando o modelo
+    pensa. Sem total, soma os componentes tratando `None` como zero. Sem
+    `usage_metadata` (stub de teste, SDK quebrado) conta zero: o teto de
+    chamadas continua valendo e segura o dia mesmo assim.
+    """
+    uso = getattr(resposta, "usage_metadata", None)
+    if uso is None:
+        return 0
+    if uso.total_token_count is not None:
+        return uso.total_token_count
+    return (
+        (uso.prompt_token_count or 0)
+        + (uso.candidates_token_count or 0)
+        + (getattr(uso, "thoughts_token_count", None) or 0)
+    )
+
+
+async def _exigir_cota(db: AsyncSession, user_id: str) -> None:
+    """Recusa ANTES da chamada se o dia já estourou um dos dois tetos.
+
+    select de colunas, não `db.get`: nada passa pelo identity map, então uma
+    leitura nunca devolve contadores velhos de um upsert anterior na mesma
+    sessão.
+    """
+    linha = (
+        await db.execute(
+            select(AiUsageDaily.tokens, AiUsageDaily.calls).where(
+                AiUsageDaily.user_id == uuid.UUID(user_id),
+                AiUsageDaily.day == dia_da_cota(),
+            )
+        )
+    ).one_or_none()
+    if linha and (linha.tokens >= DAILY_TOKEN_CAP or linha.calls >= DAILY_CALL_CAP):
+        # Sem texto do usuário: id e contadores bastam para ver quem bate no teto.
+        logger.warning(
+            "Cota diária de IA atingida (user=%s, tokens=%d, calls=%d)",
+            user_id, linha.tokens, linha.calls,
+        )
+        raise PlanRefused("AI_DAILY_CAP_REACHED", DAILY_CAP_MESSAGE, resets_at=cota_zera_em())
+
+
+async def _debitar_cota(db: AsyncSession, user_id: str, tokens: int) -> None:
+    """Soma DEPOIS da chamada, com o número real. Upsert atômico como o
+    `login_throttles`: duas chamadas concorrentes não perdem incremento."""
+    stmt = pg_insert(AiUsageDaily).values(
+        user_id=uuid.UUID(user_id), day=dia_da_cota(), tokens=tokens, calls=1
+    )
+    stmt = stmt.on_conflict_do_update(
+        index_elements=[AiUsageDaily.user_id, AiUsageDaily.day],
+        set_={"tokens": AiUsageDaily.tokens + tokens, "calls": AiUsageDaily.calls + 1},
+    )
+    await db.execute(stmt)
+    await db.commit()
+
+
+async def _com_cota(db: AsyncSession, user_id: str, chamada) -> str:
+    """Envolve UMA chamada de rede: exige a cota antes, debita o uso depois.
+
+    É o único caminho até o Gemini que conhece a cota, então um terceiro
+    ponto de chamada no futuro não tem como esquecer de contar. Fica no
+    service e não na dependency de propósito: a dependency roda antes do
+    corpo e barraria também o insight cacheado e o score determinístico, que
+    não custam nada.
+
+    Corrida aceita: a checagem lê o acumulado antes e o débito grava depois,
+    então até 10 chamadas concorrentes (o 10/min da rota) passam juntas no
+    último token. Uma rajada, uma vez por dia; depois dela tudo bloqueia até
+    virar o dia. Reservar antes seria um segundo UPDATE por chamada para
+    proteger o último minuto de abuso, não as horas.
+    """
+    await _exigir_cota(db, user_id)
+    texto, tokens = await chamada()
+    await _debitar_cota(db, user_id, tokens)
+    return texto
+
+
+async def _gerar_json(prompt: str) -> tuple[str, int]:
     """Saída de rede da geração de insight. É ela que os testes stubam.
 
     `response_mime_type` força JSON puro (sem cercas de markdown), o que torna
-    o parse confiável mesmo num modelo pequeno como o Lite.
+    o parse confiável mesmo num modelo pequeno como o Lite. Devolve também os
+    tokens usados, para quem chama debitar da cota diária.
     """
     resposta = await client.aio.models.generate_content(
         model=MODELO,
@@ -51,10 +172,10 @@ async def _gerar_json(prompt: str) -> str:
             max_output_tokens=MAX_TOKENS_INSIGHT,
         ),
     )
-    return resposta.text or ""
+    return resposta.text or "", _tokens_usados(resposta)
 
 
-async def _responder_chat(historico: list, mensagem: str) -> str:
+async def _responder_chat(historico: list, mensagem: str) -> tuple[str, int]:
     """Saída de rede do chat. A outra que os testes stubam."""
     chat = client.aio.chats.create(model=MODELO, history=historico)
     resposta = await chat.send_message(
@@ -68,7 +189,7 @@ async def _responder_chat(historico: list, mensagem: str) -> str:
         # antigo levantava sozinho aqui; este devolve None, então a guarda
         # passa a ser nossa.
         raise ValueError("resposta vazia do Gemini")
-    return resposta.text
+    return resposta.text, _tokens_usados(resposta)
 
 async def _get_user_financial_summary(db: AsyncSession, user_id: str) -> dict:
     """Resumo do mês corrente, reusando os agregados do dashboard.
@@ -165,10 +286,20 @@ async def get_or_generate_insight(db: AsyncSession, user_id: str) -> dict:
     # pode derrubar o score determinístico já calculado.
     bruto = ""
     try:
-        bruto = await _gerar_json(prompt)
+        bruto = await _com_cota(db, user_id, lambda: _gerar_json(prompt))
         data = json.loads(bruto)
         summary_text = data["summary_text"]
         suggested_action = data["suggested_action"]
+    except PlanRefused as recusa:
+        # Cota do dia estourada: o score é determinístico e continua real; só
+        # o texto não vem. Não cacheia. Antes do `except Exception`, que
+        # engoliria a recusa e mostraria "indisponível" no lugar do motivo.
+        return {
+            "score": score,
+            "summary_text": "",
+            "suggested_action": None,
+            "error": recusa.message,
+        }
     except Exception:
         # Nunca logar o texto cru: ele é a leitura financeira do usuário e pode
         # conter valores e categorias. Tipo da exceção + tamanho bastam para
@@ -240,4 +371,7 @@ async def chat_with_ai(db: AsyncSession, user_id: str, message: str, history: li
         role = "user" if msg.get("role") == "user" else "model"
         chat_history.append(types.Content(role=role, parts=[types.Part(text=content)]))
 
-    return await _responder_chat(chat_history, f"{system_context}\n\nUsuário: {message}")
+    return await _com_cota(
+        db, user_id,
+        lambda: _responder_chat(chat_history, f"{system_context}\n\nUsuário: {message}"),
+    )

--- a/backend/app/services/plan_service.py
+++ b/backend/app/services/plan_service.py
@@ -61,9 +61,11 @@ class PlanRefused(Exception):
     O `code` é contrato e NUNCA é reescrito; `message` é livre.
     """
 
-    def __init__(self, code: str, message: str):
+    def __init__(self, code: str, message: str, resets_at: datetime | None = None):
         self.code = code
         self.message = message
+        # Só a cota diária (ADR 0003) preenche: quando o bloqueio termina, em UTC.
+        self.resets_at = resets_at
         super().__init__(message)
 
 

--- a/backend/app/services/plan_service.py
+++ b/backend/app/services/plan_service.py
@@ -55,8 +55,9 @@ class PlanRefused(Exception):
     """Uma regra de plano recusou a operação.
 
     Carrega o `code` do contrato do ADR 0002 — `WALLET_LIMIT_REACHED`,
-    `WALLET_READ_ONLY`, `AI_REQUIRES_PREMIUM`. Quem traduz para 403 é o handler
-    registrado no main; service neste repo não conhece HTTP.
+    `WALLET_READ_ONLY`, `AI_REQUIRES_PREMIUM`, `AI_DAILY_CAP_REACHED` (ADR
+    0003; o único que também traz `resets_at`). Quem traduz para 403 é o
+    handler registrado no main; service neste repo não conhece HTTP.
 
     O `code` é contrato e NUNCA é reescrito; `message` é livre.
     """

--- a/backend/tests/test_ai.py
+++ b/backend/tests/test_ai.py
@@ -2,12 +2,13 @@ import uuid
 from decimal import Decimal
 
 import pytest
+from sqlalchemy import select
 
 from google.genai import chats as genai_chats
 
 import app.services.ai_service as ai
 from app.limiter import limiter
-from app.models.sql_models import User, Wallet
+from app.models.sql_models import AiUsageDaily, User, Wallet
 
 
 def _chat_que_registra(recebido: list):
@@ -339,11 +340,14 @@ async def test_both_gemini_calls_carry_an_output_ceiling(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_an_empty_chat_answer_raises_instead_of_being_stored(monkeypatch):
+async def test_an_empty_chat_answer_raises_instead_of_being_stored(db_session, monkeypatch):
     """O SDK antigo levantava quando a resposta vinha vazia ou bloqueada; este
     devolve None. Sem a guarda, o "" chegaria à rota, seria GRAVADO no
     histórico como mensagem da IA e viraria uma bolha vazia — em vez do 503
-    claro que a rota já sabe dar."""
+    claro que a rota já sabe dar. A guarda mora em `chat_with_ai`, DEPOIS do
+    `_com_cota`: a chamada já aconteceu e já foi debitada (achado de review de
+    2026-09-06, ver `_responder_chat`), então este teste confere o débito
+    também, não só o raise."""
     from types import SimpleNamespace
 
     async def _vazia(self, _mensagem, config=None):
@@ -351,5 +355,17 @@ async def test_an_empty_chat_answer_raises_instead_of_being_stored(monkeypatch):
 
     monkeypatch.setattr(genai_chats.AsyncChat, "send_message", _vazia)
 
+    user = await _novo_usuario(db_session)
     with pytest.raises(ValueError):
-        await ai._responder_chat([], "oi")
+        await ai.chat_with_ai(db_session, str(user.id), "oi", [])
+
+    user_id = user.id  # antes do expire_all, como em test_ai_quota.py
+    db_session.expire_all()
+    uso = (
+        await db_session.execute(
+            select(AiUsageDaily).where(
+                AiUsageDaily.user_id == user_id, AiUsageDaily.day == ai.dia_da_cota()
+            )
+        )
+    ).scalar_one()
+    assert uso.calls == 1

--- a/backend/tests/test_ai.py
+++ b/backend/tests/test_ai.py
@@ -15,8 +15,17 @@ def _chat_que_registra(recebido: list):
     que este teste precisa inspecionar."""
     async def _responder(historico, _mensagem):
         recebido.extend(historico)
-        return "resposta ok"
+        return "resposta ok", 0
     return _responder
+
+
+async def _novo_usuario(db_session) -> User:
+    """User de verdade: a cota diária (FK de `ai_usage_daily`) precisa de um
+    `user_id` que exista, e `uuid.UUID("user-1")` não é um UUID válido."""
+    user = User(name="Al", email=f"al_{uuid.uuid4().hex[:8]}@t.com", password_hash="x")
+    db_session.add(user)
+    await db_session.commit()
+    return user
 
 
 @pytest.mark.asyncio
@@ -69,11 +78,12 @@ async def test_insight_score_is_deterministic_not_from_llm(db_session, monkeypat
     monkeypatch.setattr(ai, "ai_insights_collection", _FakeInsights())
 
     async def _resposta(_prompt):
-        return '{"summary_text": "a|b|c", "suggested_action": "faça X"}'
+        return '{"summary_text": "a|b|c", "suggested_action": "faça X"}', 0
 
     monkeypatch.setattr(ai, "_gerar_json", _resposta)
 
-    result = await ai.get_or_generate_insight(db_session, "user-1")
+    user = await _novo_usuario(db_session)
+    result = await ai.get_or_generate_insight(db_session, str(user.id))
     assert result["score"] == 90
     assert result["summary_text"] == "a|b|c"
     assert result["suggested_action"] == "faça X"
@@ -98,11 +108,12 @@ async def test_insight_returns_score_when_llm_text_fails(db_session, monkeypatch
     monkeypatch.setattr(ai, "ai_insights_collection", _FakeInsights())
 
     async def _nao_e_json(_prompt):
-        return "desculpe, não consegui"
+        return "não é json", 0
 
     monkeypatch.setattr(ai, "_gerar_json", _nao_e_json)
 
-    result = await ai.get_or_generate_insight(db_session, "user-1")
+    user = await _novo_usuario(db_session)
+    result = await ai.get_or_generate_insight(db_session, str(user.id))
     assert result["score"] == 90
     assert result["summary_text"] == ""
     assert result.get("error")
@@ -131,7 +142,8 @@ async def test_insight_returns_score_when_llm_call_raises(db_session, monkeypatc
 
     monkeypatch.setattr(ai, "_gerar_json", _boom)
 
-    result = await ai.get_or_generate_insight(db_session, "user-1")
+    user = await _novo_usuario(db_session)
+    result = await ai.get_or_generate_insight(db_session, str(user.id))
     assert result["score"] == 90
     assert result["summary_text"] == ""
     assert result.get("error")
@@ -178,7 +190,8 @@ async def test_insight_recomputes_score_on_cache_hit(db_session, monkeypatch):
 
     monkeypatch.setattr(ai, "_gerar_json", _boom)
 
-    result = await ai.get_or_generate_insight(db_session, "user-1")
+    user = await _novo_usuario(db_session)
+    result = await ai.get_or_generate_insight(db_session, str(user.id))
     assert result["score"] == 90
     assert result["summary_text"] == "cached text"
 
@@ -223,11 +236,12 @@ async def test_insight_regenerates_text_when_data_changes(db_session, monkeypatc
     monkeypatch.setattr(ai, "ai_insights_collection", fake)
 
     async def _resposta(_prompt):
-        return '{"summary_text": "novo|texto|fresco", "suggested_action": "nova ação"}'
+        return '{"summary_text": "novo|texto|fresco", "suggested_action": "nova ação"}', 0
 
     monkeypatch.setattr(ai, "_gerar_json", _resposta)
 
-    result = await ai.get_or_generate_insight(db_session, "user-1")
+    user = await _novo_usuario(db_session)
+    result = await ai.get_or_generate_insight(db_session, str(user.id))
     assert result["score"] == 100
     assert result["summary_text"] == "novo|texto|fresco"  # regenerado, não o velho
     assert result["suggested_action"] == "nova ação"
@@ -317,8 +331,8 @@ async def test_both_gemini_calls_carry_an_output_ceiling(monkeypatch):
     monkeypatch.setattr(ai.client.aio.models, "generate_content", _fake_generate)
     monkeypatch.setattr(genai_chats.AsyncChat, "send_message", _fake_send)
 
-    assert await ai._gerar_json("prompt") == '{"summary_text": "a", "suggested_action": "b"}'
-    assert await ai._responder_chat([], "oi") == "ok"
+    assert (await ai._gerar_json("prompt"))[0] == '{"summary_text": "a", "suggested_action": "b"}'
+    assert (await ai._responder_chat([], "oi"))[0] == "ok"
 
     assert capturado["insight"] == ai.MAX_TOKENS_INSIGHT > 0
     assert capturado["chat"] == ai.MAX_TOKENS_CHAT > 0

--- a/backend/tests/test_ai_quota.py
+++ b/backend/tests/test_ai_quota.py
@@ -166,6 +166,11 @@ async def test_a_cached_insight_is_served_even_past_the_cap(
     assert segunda.json()["summary_text"] == "a|b|c"
     assert not segunda.json().get("error")
 
+    # "não debita" fica afirmado, não presumido: a 2ª leitura (cache) não soma
+    # nada aos (DAILY_TOKEN_CAP, 0) que o `_gastar` acima gravou.
+    uso = await _uso_de_hoje(db_session, user)
+    assert (uso.tokens, uso.calls) == (ai.DAILY_TOKEN_CAP, 0)
+
 
 @pytest.mark.asyncio
 async def test_an_uncached_insight_past_the_cap_degrades_with_the_cap_message(

--- a/backend/tests/test_ai_quota.py
+++ b/backend/tests/test_ai_quota.py
@@ -1,0 +1,249 @@
+"""Cota diária de IA (issue #21, ADR 0003).
+
+Dois tetos por usuário e por dia da cota: tokens reais lidos do
+`usage_metadata` e número de chamadas. Valem para todo mundo que passa pelo
+portão de plano, trial incluído, e não dependem de `paywall_enabled`.
+"""
+
+from datetime import date, datetime, timedelta, timezone
+from decimal import Decimal
+from types import SimpleNamespace
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import select
+
+import app.services.ai_service as ai
+from app.config import get_settings
+from app.models.sql_models import AiUsageDaily, Transaction, TransactionType, User, Wallet
+
+INSIGHT = '{"summary_text": "a|b|c", "suggested_action": "faça X"}'
+
+
+@pytest_asyncio.fixture
+async def mongo(monkeypatch):
+    """Sombra o `mongo` do conftest só neste arquivo. O original rebinda as
+    coleções do `account_service`; `ai_service.py` e `routers/ai.py` importam
+    a coleção do `database` direto no módulo, e este é o primeiro arquivo a
+    bater de verdade em `/ai/chat` e `/ai/insight` mais de uma vez na mesma
+    sessão. Sem rebindar as duas também, os testes caem no cliente de import,
+    preso ao primeiro event loop que o tocou: RuntimeError "Event loop is
+    closed" do 2º teste em diante. Mesmo truque de `monkeypatch.setattr` que
+    test_ai.py e test_ai_history.py já usam para essas duas coleções, com a
+    coleção real do fixture no lugar de um fake."""
+    from motor.motor_asyncio import AsyncIOMotorClient
+    from app import database
+    import app.services.account_service as acc
+    import app.routers.ai as ai_router
+
+    client = AsyncIOMotorClient(database.settings.mongodb_url)
+    db = client["norby_db"]
+    insights = db["ai_insights"]
+    history = db["chat_history"]
+
+    monkeypatch.setattr(acc, "ai_insights_collection", insights)
+    monkeypatch.setattr(acc, "chat_history_collection", history)
+    monkeypatch.setattr(ai, "ai_insights_collection", insights)
+    monkeypatch.setattr(ai_router, "chat_history_collection", history)
+    try:
+        yield {"ai_insights": insights, "chat_history": history}
+    finally:
+        client.close()
+
+
+@pytest.fixture
+def paywall_ligado():
+    settings = get_settings()
+    antes = settings.paywall_enabled
+    settings.paywall_enabled = True
+    yield
+    settings.paywall_enabled = antes
+
+
+@pytest.fixture
+def gemini_stubado(monkeypatch):
+    """Nenhum teste aqui bate na API real. Os stubs devolvem (texto, tokens),
+    o mesmo contrato das funções de rede."""
+
+    async def _chat(_historico, _mensagem):
+        return "resposta ok", 700
+
+    async def _insight(_prompt):
+        return INSIGHT, 300
+
+    monkeypatch.setattr(ai, "_responder_chat", _chat)
+    monkeypatch.setattr(ai, "_gerar_json", _insight)
+
+
+async def _usuario(ac, db_session) -> User:
+    me = (await ac.get("/auth/me")).json()
+    return (await db_session.execute(select(User).where(User.id == me["id"]))).scalar_one()
+
+
+async def _gastar(db_session, user: User, *, tokens=0, calls=0, day: date | None = None):
+    # merge, não add: a linha do dia pode já existir se o teste gerou antes.
+    await db_session.merge(
+        AiUsageDaily(user_id=user.id, day=day or ai.dia_da_cota(), tokens=tokens, calls=calls)
+    )
+    await db_session.commit()
+
+
+async def _uso_de_hoje(db_session, user: User) -> AiUsageDaily:
+    # user.id ANTES do expire_all: expirar e só depois ler um atributo do
+    # próprio `user` pediria um refresh síncrono fora de contexto async
+    # (MissingGreenlet) — a linha do dia é o que precisa vir fresco.
+    user_id = user.id
+    db_session.expire_all()
+    return (
+        await db_session.execute(
+            select(AiUsageDaily).where(
+                AiUsageDaily.user_id == user_id, AiUsageDaily.day == ai.dia_da_cota()
+            )
+        )
+    ).scalar_one()
+
+
+@pytest.mark.asyncio
+async def test_chat_past_the_daily_token_cap_is_refused_with_the_code(
+    make_auth_client, db_session, mongo, gemini_stubado
+):
+    # Sem a fixture do paywall: flag desligado, o estado da produção. A cota
+    # protege a produção a partir do merge, não a partir da virada.
+    alice = await make_auth_client("Alice")
+    await _gastar(db_session, await _usuario(alice, db_session), tokens=ai.DAILY_TOKEN_CAP)
+
+    res = await alice.post("/ai/chat", json={"message": "e aí?"})
+    assert res.status_code == 403, res.text
+    detail = res.json()["detail"]
+    assert detail["code"] == "AI_DAILY_CAP_REACHED"
+    assert detail["message"] == ai.DAILY_CAP_MESSAGE
+    assert datetime.fromisoformat(detail["resets_at"]) > datetime.now(timezone.utc)
+
+
+@pytest.mark.asyncio
+async def test_the_call_ceiling_refuses_on_its_own(
+    make_auth_client, db_session, mongo, gemini_stubado
+):
+    # No tier gratuito o limite do projeto é em requisições (RPD 500): o teto
+    # de chamadas é o que protege esse dia compartilhado, tokens à parte.
+    alice = await make_auth_client("Alice")
+    await _gastar(db_session, await _usuario(alice, db_session), tokens=0, calls=ai.DAILY_CALL_CAP)
+
+    res = await alice.post("/ai/chat", json={"message": "e aí?"})
+    assert res.status_code == 403, res.text
+    assert res.json()["detail"]["code"] == "AI_DAILY_CAP_REACHED"
+
+
+@pytest.mark.asyncio
+async def test_each_call_debits_the_real_token_count_and_one_call(
+    make_auth_client, db_session, mongo, gemini_stubado
+):
+    alice = await make_auth_client("Alice")
+    user = await _usuario(alice, db_session)
+
+    for _ in range(2):
+        assert (await alice.post("/ai/chat", json={"message": "oi"})).status_code == 200
+
+    uso = await _uso_de_hoje(db_session, user)
+    assert (uso.tokens, uso.calls) == (1400, 2)
+
+
+@pytest.mark.asyncio
+async def test_a_cached_insight_is_served_even_past_the_cap(
+    make_auth_client, db_session, mongo, gemini_stubado
+):
+    # Cache por fingerprint: não chama o Gemini, não debita, não é barrado.
+    alice = await make_auth_client("Alice")
+    user = await _usuario(alice, db_session)
+    primeira = await alice.get("/ai/insight")
+    assert primeira.status_code == 200, primeira.text
+    assert primeira.json()["summary_text"] == "a|b|c"
+
+    await _gastar(db_session, user, tokens=ai.DAILY_TOKEN_CAP)
+
+    segunda = await alice.get("/ai/insight")
+    assert segunda.status_code == 200, segunda.text
+    assert segunda.json()["summary_text"] == "a|b|c"
+    assert not segunda.json().get("error")
+
+
+@pytest.mark.asyncio
+async def test_an_uncached_insight_past_the_cap_degrades_with_the_cap_message(
+    make_auth_client, db_session, mongo, gemini_stubado
+):
+    # O score é determinístico e continua real; só o texto não vem. 200, não
+    # 403: o widget do dashboard já sabe mostrar esse estado.
+    alice = await make_auth_client("Alice")
+    user = await _usuario(alice, db_session)
+    # compute_financial_score devolve None sem nenhuma transação no mês (conta
+    # nova de verdade não tem nenhuma). Uma renda garante um score numérico de
+    # verdade, que é exatamente o que a asserção abaixo verifica.
+    wallet = Wallet(user_id=user.id, name="Main", balance=Decimal("1000"))
+    db_session.add(wallet)
+    await db_session.flush()
+    db_session.add(Transaction(
+        user_id=user.id, wallet_id=wallet.id, type=TransactionType.INCOME,
+        amount=Decimal("1000"), category="Salário", date=date.today(),
+    ))
+    await db_session.commit()
+    await _gastar(db_session, user, tokens=ai.DAILY_TOKEN_CAP)
+
+    res = await alice.get("/ai/insight")
+    assert res.status_code == 200, res.text
+    corpo = res.json()
+    assert corpo["error"] == ai.DAILY_CAP_MESSAGE
+    assert corpo["summary_text"] == ""
+    assert isinstance(corpo["score"], (int, float))
+
+
+@pytest.mark.asyncio
+async def test_yesterdays_usage_does_not_count_today(
+    make_auth_client, db_session, mongo, gemini_stubado
+):
+    alice = await make_auth_client("Alice")
+    ontem = ai.dia_da_cota() - timedelta(days=1)
+    await _gastar(
+        db_session, await _usuario(alice, db_session),
+        tokens=ai.DAILY_TOKEN_CAP, calls=ai.DAILY_CALL_CAP, day=ontem,
+    )
+
+    assert (await alice.post("/ai/chat", json={"message": "oi"})).status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_a_trial_user_is_capped_too(
+    make_auth_client, db_session, mongo, gemini_stubado, paywall_ligado
+):
+    # Cadastro concede 7 dias de trial de IA sem cartão: a conta mais barata
+    # de criar por script. A cota vale para ela como para o premium, e o
+    # código é o da cota, não o AI_REQUIRES_PREMIUM.
+    alice = await make_auth_client("Alice")
+    await _gastar(db_session, await _usuario(alice, db_session), tokens=ai.DAILY_TOKEN_CAP)
+
+    res = await alice.post("/ai/chat", json={"message": "oi"})
+    assert res.status_code == 403, res.text
+    assert res.json()["detail"]["code"] == "AI_DAILY_CAP_REACHED"
+
+
+def test_tokens_usados_reads_the_total_and_treats_missing_thoughts_as_zero():
+    com_total = SimpleNamespace(usage_metadata=SimpleNamespace(
+        prompt_token_count=7, candidates_token_count=1,
+        thoughts_token_count=None, total_token_count=8,
+    ))
+    sem_total = SimpleNamespace(usage_metadata=SimpleNamespace(
+        prompt_token_count=7, candidates_token_count=1,
+        thoughts_token_count=None, total_token_count=None,
+    ))
+    assert ai._tokens_usados(com_total) == 8
+    assert ai._tokens_usados(sem_total) == 8
+    # Stub sem usage_metadata: zero tokens; o teto de chamadas segura o dia.
+    assert ai._tokens_usados(SimpleNamespace(text="stub")) == 0
+
+
+def test_the_quota_day_turns_at_pacific_midnight():
+    # 08:00 UTC é a meia-noite em UTC-8, o instante em que o Google zera o RPD.
+    antes = datetime(2026, 9, 6, 7, 59, tzinfo=timezone.utc)
+    depois = datetime(2026, 9, 6, 8, 0, tzinfo=timezone.utc)
+    assert ai.dia_da_cota(antes) == date(2026, 9, 5)
+    assert ai.dia_da_cota(depois) == date(2026, 9, 6)
+    assert ai.cota_zera_em(depois) == datetime(2026, 9, 7, 8, 0, tzinfo=timezone.utc)

--- a/docs/adr/0002-onde-o-paywall-e-aplicado.md
+++ b/docs/adr/0002-onde-o-paywall-e-aplicado.md
@@ -140,6 +140,10 @@ matar.
 **Três códigos, e só:** `WALLET_LIMIT_REACHED`, `WALLET_READ_ONLY`,
 `AI_REQUIRES_PREMIUM`.
 
+**Emenda (ADR 0003, 2026-09-06):** quarto código, `AI_DAILY_CAP_REACHED`, para
+a cota diária de IA. O contrato do objeto não muda; esse código é o único que
+também traz `resets_at`.
+
 Não existe código separado para "trial acabou" versus "nunca teve": a mensagem
 na tela difere, mas o frontend deriva isso do `plan.ai_trial_ends_at` estar
 preenchido e no passado. Código novo para um fato que já viaja no `plan` seria

--- a/docs/adr/0003-cota-diaria-de-ia.md
+++ b/docs/adr/0003-cota-diaria-de-ia.md
@@ -1,0 +1,55 @@
+# ADR 0003 — Cota diária de IA
+
+- **Status:** aceito
+- **Data:** 2026-09-06
+- **Issue:** [#21](https://github.com/DigoDuck/Norby/issues/21), parte do mapa da v2 ([#15](https://github.com/DigoDuck/Norby/issues/15)); pesquisa de custo em [#18](https://github.com/DigoDuck/Norby/issues/18).
+- **Depende de:** [ADR 0002](0002-onde-o-paywall-e-aplicado.md), que define o portão de IA e o contrato da recusa.
+- **Decide:** quanto de IA um usuário pode gastar por dia, como isso é contado, onde é guardado, e o que a API responde ao recusar.
+- **Não decide:** os limites por minuto (continuam como estão), o tratamento do 429 do próprio Google, o medidor de uso na tela (#25).
+
+## Contexto
+
+O Gemini responde com `usage_metadata` nas duas chamadas (insight e chat), e cada chamada já tem teto de saída (`MAX_TOKENS_INSIGHT = 512`, `MAX_TOKENS_CHAT = 1024`, #40). Faltava um teto por dia: no 10/min da rota de chat, um script sozinho faz 14.400 chamadas por dia.
+
+A chave de produção está no **tier gratuito** do Google AI Studio (projeto Lumea), por decisão do dono até haver clientes. Isso muda o que a cota protege:
+
+| Limite do projeto (`gemini-3.5-flash-lite`, gratuito) | Valor | Pico real até 2026-09-06 |
+|---|---|---|
+| Requisições por minuto (RPM) | 15 | 4 |
+| Tokens de entrada por minuto (TPM) | 250.000 | 564 |
+| Requisições por dia (RPD) | 500 | 12 |
+
+Os limites são do projeto, compartilhados por todos os usuários da chave, e o RPD zera à meia-noite do Pacífico (o painel usa UTC-8). No gratuito, o que apaga a luz de todo mundo é o RPD: um script no 10/min esvazia 500 requisições em 50 minutos e todo usuário fica sem IA até as 5h de Brasília. O custo em dinheiro é zero; no tier pago seria US$ 0,30 por milhão de tokens de entrada e US$ 2,50 por milhão de saída.
+
+No gratuito o Google também pode usar o conteúdo enviado para aprimorar seus produtos (o pago é isento). A política de privacidade passou a dizer isso.
+
+O #18 propôs duas faixas para o teto em tokens: 150k a 200k (cinco vezes um dia pesado de ~33k) ou 80k a 120k (o pior caso perto do ponto de equilíbrio contra os R$ 20/mês).
+
+## Decisão
+
+1. **Dois tetos por usuário por dia da cota:** 120.000 tokens **e** 100 chamadas. Estourou um, recusa. Constantes em `ai_service.py` (`DAILY_TOKEN_CAP`, `DAILY_CALL_CAP`); mudar é PR, não variável de ambiente, porque deixa rastro e no Railway trocar env também é redeploy.
+   - 120k é a faixa de equilíbrio do #18, dimensionada para o tier pago de propósito: não muda quando o faturamento ligar.
+   - 100 = RPD/5: um script sozinho gasta no máximo um quinto do dia compartilhado. Um dia pesado legítimo (30 trocas de chat + 20 regenerações de insight) cabe duas vezes.
+2. **Contagem real, depois da chamada:** `total_token_count` do `usage_metadata` (já inclui tokens de raciocínio; sem total, soma dos componentes com `None` como zero). Sem `usage_metadata`, zero tokens e uma chamada: o teto de chamadas segura o dia mesmo assim. A leitura mora numa função só (`_tokens_usados`), porque o Google já rotula `generate_content` como "Legacy" e a API nova (Interactions) renomeia os campos.
+3. **Dia da cota em UTC-8 fixo** (`QUOTA_TZ`), o dia do Google. Com dia UTC, um usuário ganharia dois tetos dentro de um dia do Google e a parcela dele viraria 200 de 500. Se o Google seguir o horário de verão do Pacífico, o reset dele cai às 4h de Brasília e o nosso às 5h: erro para o lado seguro. Sem tabela de fuso.
+4. **Tabela `ai_usage_daily(user_id, day, tokens, calls)`**, chave primária composta, upsert `ON CONFLICT DO UPDATE` como o `login_throttles`, sem purga: uma linha por usuário por dia não pesa, e o histórico é o instrumento que calibra os tetos (o número de hoje é estimativa; o p99 real, depois de um mês, é medida). Some com o usuário pelo `ON DELETE CASCADE`. Não entra no export da LGPD: contadores, não conteúdo.
+5. **Vale para todo mundo que passa por `require_ai_access`,** trial incluído, com o mesmo número, e **não depende de `paywall_enabled`**: a cota protege a produção a partir do merge, não a partir da virada. Conta de trial é a mais barata de criar por script.
+6. **Insight e chat contam e são barrados.** Insight cacheado (fingerprint igual) continua servido: não chama o Gemini, não debita. Excluir o insight abriria um buraco: a 30/min, editar uma transação e recarregar o dashboard regenera 43 mil vezes por dia.
+7. **Checagem e débito num helper do `ai_service` (`_com_cota`)** em volta das duas chamadas de rede, e não na dependency: a dependency roda antes do corpo e barraria também o insight cacheado e o score determinístico, que não custam nada. A cota não é regra de plano (essa fica na dependency); é uso do próprio serviço. Um terceiro ponto de chamada no futuro passa pelo mesmo helper e não tem como esquecer de contar.
+8. **Recusa:** `PlanRefused("AI_DAILY_CAP_REACHED", ...)`, o quarto código do contrato do ADR 0002, pelo mesmo handler: `403` com `detail.code`, `detail.message` autossuficiente ("libera às 5h da manhã, horário de Brasília") e `detail.resets_at` em ISO/UTC para o medidor futuro (#25). O chat sobe a recusa antes do `except` genérico que vira 503. O insight sem cache cai no `200` degradado que já existe, com score real e a mensagem da cota em `error`. Uma linha de log em WARNING por recusa, com id e contadores, sem texto do usuário.
+9. **Os limites por minuto continuam** (30/min insight, 10/min chat, em memória): freiam rajada, a cota freia o dia. Não dobrar um no outro.
+
+## Consequências aceitas
+
+- **Rajada no último token:** a checagem lê antes e o débito grava depois, então até 10 chamadas concorrentes passam juntas. Uma rajada por dia, no pior caso ~130k tokens; depois, bloqueio até virar o dia. Reservar antes seria um segundo UPDATE por chamada para proteger o último minuto, não as horas.
+- **Os limites por minuto por usuário (10 + 30) passam do RPM 15 do projeto inteiro.** Um estouro por minuto se cura no minuto seguinte; o do dia trava o dia. Não mexer.
+- **O 429 do próprio Google continua 503 genérico** ("tente novamente em instantes"), que mente por horas se o projeto esgotar o RPD. Com o teto de 100, esgotar exige cinco usuários no máximo ao mesmo tempo. Reabrir quando virar pago ou quando acontecer.
+- **O insight regenera a cada mudança nos totais do mês.** Quem lança 30 transações num dia e olha o dashboard entre elas gasta 30 das 100 chamadas. Fora deste ADR.
+- **Tier gratuito por decisão do dono,** até haver clientes; os primeiros serão pessoas conhecidas. Virar pago é um clique no console do AI Studio e não muda nenhum número deste ADR: os tetos ficam, e o RPD deixa de ser o gargalo.
+
+## Quando rever
+
+- Virar pago: nada cai. Rever o item do 429 e a frase da política de privacidade.
+- Trocar por um modelo que pensa: `_tokens_usados` já soma `thoughts_token_count`; rever só os tetos.
+- Migrar para a Interactions API: só `_tokens_usados` muda.
+- Depois de um mês de linhas em `ai_usage_daily`: recalibrar os dois tetos pelo p99 real.

--- a/frontend/src/pages/AIAnalyst.jsx
+++ b/frontend/src/pages/AIAnalyst.jsx
@@ -1,6 +1,7 @@
 import { useState, useRef, useEffect } from "react";
 import { Send, Plus, MessageCircle, Shield } from "lucide-react";
 import { aiApi } from "@/api/ai";
+import { apiErrorMessage } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import NorthStar from "@/components/shared/NorthStar";
@@ -72,12 +73,14 @@ export default function AIAnalyst() {
         ...prev,
         { role: "assistant", content: res.data.response },
       ]);
-    } catch {
+    } catch (err) {
       setMessages((prev) => [
         ...prev,
         {
           role: "assistant",
-          content: "Erro ao conectar com a IA. Tente novamente.",
+          // Recusa de plano ou de cota (403 com detail.message) chega como
+          // fala da assistente, com o motivo; o resto cai no genérico.
+          content: apiErrorMessage(err, "Erro ao conectar com a IA. Tente novamente."),
         },
       ]);
     } finally {

--- a/frontend/src/pages/Privacidade.jsx
+++ b/frontend/src/pages/Privacidade.jsx
@@ -52,7 +52,7 @@ export default function Privacidade() {
             <p className="leading-relaxed text-content-2">Tratamos seus dados com as seguintes bases legais (art. 7º da LGPD):</p>
             <ul className="mt-3 list-disc space-y-1 pl-5 leading-relaxed text-content-2">
               <li><strong>Execução de contrato (art. 7º, V):</strong> cadastro, autenticação e funcionamento do organizador financeiro — sem esses dados o serviço não existe. Também é a base do plano pago: sem os identificadores da seção 5 não há como saber que a assinatura está válida.</li>
-              <li><strong>Consentimento (art. 7º, I):</strong> envio dos seus dados financeiros ao provedor de IA (Google Gemini) para gerar insights e responder no chat. Você pode deixar de usar os recursos de IA a qualquer momento.</li>
+              <li><strong>Consentimento (art. 7º, I):</strong> envio dos seus dados financeiros ao provedor de IA (Google Gemini) para gerar insights e responder no chat. Você pode deixar de usar os recursos de IA a qualquer momento. Nas condições atuais do serviço do Google, o conteúdo enviado à IA pode ser usado por ele para aprimorar seus produtos.</li>
               <li><strong>Cumprimento de obrigação legal/regulatória (art. 7º, II):</strong> quando aplicável, para atender determinações legais.</li>
             </ul>
           </section>


### PR DESCRIPTION
## Summary

Two per-user daily ceilings around the two Gemini calls (insight and chat),
protecting the shared production quota (issue #21, ADR 0003).

- **120,000 tokens or 100 calls per user per quota day**, whichever is hit
  first refuses further generation for the day. Both are code constants in
  `ai_service.py` (`DAILY_TOKEN_CAP`, `DAILY_CALL_CAP`), by design not env
  vars: changing them is a PR, and on Railway an env change is a redeploy
  anyway.
- **Quota day is fixed UTC-8** (`QUOTA_TZ`), matching the instant Google
  resets the project's daily request limit (RPD) on the free tier the
  production key currently uses. A UTC day would let one user burn two
  Google-side days' worth of the shared RPD inside one.
- **Checking and debiting live in one helper, `_com_cota`**, wrapping each of
  the two network calls in `ai_service.py`. It reads real token usage from
  the Gemini response's `usage_metadata` after the call and upserts into a
  new `ai_usage_daily(user_id, day, tokens, calls)` table (composite PK,
  `ON CONFLICT DO UPDATE`, no purge — one row per user per day is cheap and
  the history is what will calibrate the caps later). Cached insights never
  call Gemini, so they're never counted or blocked.
- **Refusal is the fourth code in the ADR 0002 refusal contract,**
  `AI_DAILY_CAP_REACHED`, through the same `PlanRefused` exception and
  handler. It's the only code that also carries `resets_at` (ISO/UTC), for a
  future usage meter (#25). Applies to trial users exactly like paid ones,
  and independently of the `paywall_enabled` rollout flag — the quota
  protects production usage starting at merge, not at flag flip.
- Chat re-raises `PlanRefused` before the generic exception handler so it
  reaches the 403 instead of being swallowed into a 503. The insight route is
  unchanged: on refusal it degrades to its existing 200 response, with the
  real deterministic score and the cap message in `error`.
- Frontend: the chat's catch block now surfaces `detail.message` from a 403
  (plan or quota refusal) instead of a generic error; the privacy policy
  discloses that the free tier lets Google use submitted content to improve
  its products.

Refs #21

## Test plan

- [x] `docker exec norby_backend pytest -q` — 349 passed (340 baseline + 9 new)
- [x] `docker exec norby_backend alembic upgrade head && alembic check` — clean, no drift
- [x] `cd frontend && npm run lint && npx vitest run && npm run build` — all green