### PR TITLE
test: shared mongo fixture covers ai_service and routers.ai

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -90,27 +90,32 @@ async def client():
 
 
 @pytest_asyncio.fixture
-async def mongo():
+async def mongo(monkeypatch):
     # Motor liga o cliente ao event loop no primeiro await. Como o cliente de
     # produção é criado no import, ele fica preso ao loop do 1º teste e quebra nos
     # seguintes ("Event loop is closed"). Aqui criamos um cliente fresco no loop
-    # do teste atual e religamos as referências que o account_service usa.
+    # do teste atual e religamos as referências. account_service usa a coleção
+    # direto; ai_service e routers/ai também a importam de `app.database` no
+    # nível do módulo, então precisam do próprio rebind, senão continuam
+    # presos ao cliente de import mesmo com o account_service corrigido.
     from motor.motor_asyncio import AsyncIOMotorClient
     from app import database
     import app.services.account_service as acc
+    import app.services.ai_service as ai_service
+    import app.routers.ai as ai_router
 
     client = AsyncIOMotorClient(database.settings.mongodb_url)
     db = client["norby_db"]
     ai = db["ai_insights"]
     ch = db["chat_history"]
 
-    previous = (acc.ai_insights_collection, acc.chat_history_collection)
-    acc.ai_insights_collection = ai
-    acc.chat_history_collection = ch
+    monkeypatch.setattr(acc, "ai_insights_collection", ai)
+    monkeypatch.setattr(acc, "chat_history_collection", ch)
+    monkeypatch.setattr(ai_service, "ai_insights_collection", ai)
+    monkeypatch.setattr(ai_router, "chat_history_collection", ch)
     try:
         yield {"ai_insights": ai, "chat_history": ch}
     finally:
-        acc.ai_insights_collection, acc.chat_history_collection = previous
         client.close()
 
 

--- a/backend/tests/test_ai_quota.py
+++ b/backend/tests/test_ai_quota.py
@@ -10,7 +10,6 @@ from decimal import Decimal
 from types import SimpleNamespace
 
 import pytest
-import pytest_asyncio
 from sqlalchemy import select
 
 import app.services.ai_service as ai
@@ -18,37 +17,6 @@ from app.config import get_settings
 from app.models.sql_models import AiUsageDaily, Transaction, TransactionType, User, Wallet
 
 INSIGHT = '{"summary_text": "a|b|c", "suggested_action": "faça X"}'
-
-
-@pytest_asyncio.fixture
-async def mongo(monkeypatch):
-    """Sombra o `mongo` do conftest só neste arquivo. O original rebinda as
-    coleções do `account_service`; `ai_service.py` e `routers/ai.py` importam
-    a coleção do `database` direto no módulo, e este é o primeiro arquivo a
-    bater de verdade em `/ai/chat` e `/ai/insight` mais de uma vez na mesma
-    sessão. Sem rebindar as duas também, os testes caem no cliente de import,
-    preso ao primeiro event loop que o tocou: RuntimeError "Event loop is
-    closed" do 2º teste em diante. Mesmo truque de `monkeypatch.setattr` que
-    test_ai.py e test_ai_history.py já usam para essas duas coleções, com a
-    coleção real do fixture no lugar de um fake."""
-    from motor.motor_asyncio import AsyncIOMotorClient
-    from app import database
-    import app.services.account_service as acc
-    import app.routers.ai as ai_router
-
-    client = AsyncIOMotorClient(database.settings.mongodb_url)
-    db = client["norby_db"]
-    insights = db["ai_insights"]
-    history = db["chat_history"]
-
-    monkeypatch.setattr(acc, "ai_insights_collection", insights)
-    monkeypatch.setattr(acc, "chat_history_collection", history)
-    monkeypatch.setattr(ai, "ai_insights_collection", insights)
-    monkeypatch.setattr(ai_router, "chat_history_collection", history)
-    try:
-        yield {"ai_insights": insights, "chat_history": history}
-    finally:
-        client.close()
 
 
 @pytest.fixture


### PR DESCRIPTION
The shared \`mongo\` fixture in \`backend/tests/conftest.py\` only rebound the Mongo collections used by \`account_service\`, but \`app/services/ai_service.py\` and \`app/routers/ai.py\` import those same collections from \`app.database\` at module level. Any test file that hits \`/ai/chat\` or \`/ai/insight\` more than once within the same session kept the import-time client tied to a closed event loop, raising \`RuntimeError: Event loop is closed\` from the second test onward. \`test_ai_quota.py\` had already worked around this with a local fixture shadowing the shared one.

This moves that fix into the shared fixture (rebinding all four references via \`monkeypatch.setattr\`, so restoration is automatic) and removes the now-redundant local fixture from \`test_ai_quota.py\`. Found during the review of PR #133.

Verified with \`test_ai_quota.py\`, \`test_ai.py\`, \`test_ai_history.py\`, \`test_paywall_ai.py\` (30 passed) and the full suite (349 passed) inside the \`norby_backend\` container.