### PR TITLE
feat(admin): admin area with password step-up and audit trail

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -309,6 +309,20 @@ independe de `paywall_enabled`. A chave de produção está no tier gratuito
 (RPD 500 compartilhado por todos os usuários): os 100 são RPD/5. A rajada de
 até 10 chamadas concorrentes no último token é aceita.
 
+**Área de admin (#23, ADR 0004):** `users.is_admin` é escrito só por SQL;
+`require_admin` devolve 404 com o corpo do FastAPI para não-admin; router
+`/admin/*` próprio; as três ações exigem a senha atual e gravam uma linha em
+`admin_actions` (sem FK no alvo, com `target_email` de snapshot, sem purga,
+fora do export). Cancelamento é imediato e aplicado na hora pelo
+`aplicar_assinatura`; exclusão reusa `delete_account`; recuperação reusa
+`mandar_link_de_recuperacao`. O schema `AdminUserOut` é a garantia de que
+nenhum dado financeiro de terceiro sai.
+
+Primeiro admin, depois da migration: no console do banco,
+`UPDATE users SET is_admin = true WHERE lower(email) = '<email>';`. Local:
+`docker exec norby_postgres psql -U $POSTGRES_USER -d $POSTGRES_DB -c "..."`
+(os nomes vêm do `.env`).
+
 Login e cadastro (anônimos) **não seguem mais por IP.** Desde 2026-08-16 usam
 atraso progressivo **por conta**: a chave é o HMAC-SHA256 do email
 normalizado (lower + trim) com o `secret_key` do servidor — o email cru nunca

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -53,6 +53,16 @@ reescrito; `message` é livre.**
 | `AI_REQUIRES_PREMIUM` | gerar IA sem trial e sem assinatura |
 | `AI_DAILY_CAP_REACHED` | gerar IA depois de estourar a cota diária (ADR 0003); traz `resets_at` |
 
+## Área de admin
+
+Resolvido pelo [ADR 0004](docs/adr/0004-area-de-admin.md) (issue #23).
+
+| Termo | Significa | Como se mede |
+|---|---|---|
+| **admin** | Quem tem `users.is_admin = true`. Só SQL escreve esta coluna; um só nesta v2 | `is_admin` |
+| **ação de admin** | Cancelar assinatura, excluir conta ou disparar recuperação de senha em nome de outro usuário. Sempre exige a senha atual do admin | uma linha nova em `admin_actions` por ação bem-sucedida |
+| **auditoria** | `admin_actions`: registro só-insert das ações de admin, sem chave estrangeira no alvo, sem tela | `target_email` (snapshot) e `detail` (só identificador, nunca conteúdo) |
+
 ### Termos que este glossário evita de propósito
 
 | Não usar | Usar | Por quê |
@@ -64,3 +74,4 @@ reescrito; `message` é livre.**
 | "trial" para período pago | trial de IA | O trial nunca concede carteira. Confundir os dois inverte o teto |
 | "carteira desativada" ou "arquivada" | carteira bloqueada | Ela não some nem para de contar nos totais: só não recebe escrita |
 | mensagem de erro como identificador | o `code` da recusa | `message` muda quando o texto melhora; quem o frontend testa é o `code` |
+| "moderador", "staff" | admin | Existe **um** papel de controlador nesta v2, sem hierarquia entre eles |

--- a/backend/alembic/versions/22b6c15c4699_admin_area.py
+++ b/backend/alembic/versions/22b6c15c4699_admin_area.py
@@ -1,0 +1,50 @@
+"""admin_area
+
+Issue #23 (ADR 0004). Aditiva, nada existente é tocado.
+
+`users.is_admin`: coluna, não lista de e-mails em config — a coluna morre com
+a linha, e um e-mail recadastrado depois de excluir a conta não herda nada.
+Nenhum endpoint escreve nela; o primeiro e único admin nasce por UPDATE manual
+no console do banco (ver AGENTS.md).
+
+`admin_actions`: auditoria só-insert das três ações do admin. `admin_id` e
+`target_user_id` são UUIDs SEM chave estrangeira, de propósito — excluir a
+conta é uma das ações auditadas, e uma FK com cascade apagaria junto o
+registro de que ela foi excluída. `target_email` é o snapshot que identifica
+o alvo depois que a linha dele some.
+
+Revision ID: 22b6c15c4699
+Revises: 7b3452a35a35
+Create Date: 2026-09-06 20:59:07.311127
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = '22b6c15c4699'
+down_revision: Union[str, None] = '7b3452a35a35'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column('users', sa.Column('is_admin', sa.Boolean(), server_default=sa.text('false'), nullable=False))
+    op.create_table('admin_actions',
+    sa.Column('id', sa.UUID(), nullable=False),
+    sa.Column('admin_id', sa.UUID(), nullable=False),
+    sa.Column('action', sa.String(length=32), nullable=False),
+    sa.Column('target_user_id', sa.UUID(), nullable=False),
+    sa.Column('target_email', sa.String(length=255), nullable=False),
+    sa.Column('at', sa.DateTime(timezone=True), nullable=False),
+    sa.Column('detail', postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+    sa.PrimaryKeyConstraint('id')
+    )
+
+
+def downgrade() -> None:
+    op.drop_table('admin_actions')
+    op.drop_column('users', 'is_admin')

--- a/backend/app/dependencies.py
+++ b/backend/app/dependencies.py
@@ -82,3 +82,14 @@ async def require_ai_access(current_user: User = Depends(get_current_user)) -> U
             "continuam aqui.",
         )
     return current_user
+
+async def require_admin(current_user: User = Depends(get_current_user)) -> User:
+    """Portão da área de admin (ADR 0004).
+
+    404 e não 403, com o MESMO corpo que o FastAPI dá para rota inexistente:
+    quem não é admin não fica sabendo que /admin existe. Um 403 confirmaria a
+    rota e convidaria a insistir.
+    """
+    if not current_user.is_admin:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Not Found")
+    return current_user

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -7,7 +7,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from slowapi import _rate_limit_exceeded_handler
 from slowapi.errors import RateLimitExceeded
-from app.routers import auth, wallets, transactions, ai, recurring, goals, dashboard, billing
+from app.routers import auth, wallets, transactions, ai, recurring, goals, dashboard, billing, admin
 from app.services.plan_service import PlanRefused
 from app.services.wallet_service import WalletNotFound
 from app.config import get_settings
@@ -143,6 +143,7 @@ app.include_router(recurring.router)
 app.include_router(goals.router)
 app.include_router(dashboard.router)
 app.include_router(billing.router)
+app.include_router(admin.router)
 
 @app.get("/health", tags=["Health"]) 
 async def health_check():

--- a/backend/app/models/sql_models.py
+++ b/backend/app/models/sql_models.py
@@ -8,7 +8,7 @@ from sqlalchemy import (
     String, DateTime, Date, Numeric, ForeignKey, LargeBinary,
     Enum, Integer, Boolean, CheckConstraint, Index, text
 )
-from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.database import Base
@@ -56,6 +56,14 @@ class User(Base):
     # frontend não deixa rastro — sem timestamp não há como demonstrar o aceite.
     privacy_accepted_at: Mapped[Optional[datetime]] = mapped_column(
         DateTime(timezone=True), nullable=True
+    )
+
+    # Área de admin (ADR 0004). Nenhum endpoint escreve aqui: o primeiro e
+    # único admin nasce por UPDATE manual no console do banco (ver AGENTS.md).
+    # Coluna, e não lista de e-mails em config: a coluna morre com a linha, e
+    # um e-mail recadastrado depois de excluir a conta não herda nada.
+    is_admin: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default=text("false")
     )
 
     # --- Plano e assinatura (ADR 0001, issue #19) ----------------------------
@@ -150,6 +158,28 @@ class AiUsageDaily(Base):
     day: Mapped[date] = mapped_column(Date, primary_key=True)
     tokens: Mapped[int] = mapped_column(Integer, nullable=False, server_default=text("0"))
     calls: Mapped[int] = mapped_column(Integer, nullable=False, server_default=text("0"))
+
+class AdminAction(Base):
+    """Auditoria da área de admin (issue #23, ADR 0004). Só insert.
+
+    `admin_id` e `target_user_id` são UUIDs SEM chave estrangeira, de
+    propósito: excluir a conta é uma das ações auditadas, e uma FK com cascade
+    apagaria junto o registro de que ela foi excluída. `target_email` é o
+    snapshot que identifica o alvo depois que a linha dele some. É PII numa
+    tabela sem purga, e é isso mesmo: o registro das operações do controlador
+    é obrigação da LGPD (art. 37), não entra no export do usuário e não é
+    apagado com a conta. `detail` guarda só identificadores (id de assinatura),
+    nunca conteúdo.
+    """
+    __tablename__ = "admin_actions"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    admin_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    action: Mapped[str] = mapped_column(String(32), nullable=False)
+    target_user_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    target_email: Mapped[str] = mapped_column(String(255), nullable=False)
+    at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, default=utcnow)
+    detail: Mapped[Optional[dict]] = mapped_column(JSONB, nullable=True)
 
 class PasswordResetToken(Base):
     """Token de recuperação de senha (#36).

--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -1,0 +1,92 @@
+"""Rotas da área de admin (issue #23, ADR 0004). Router próprio: `grep admin`
+responde "o que o admin alcança"."""
+
+import asyncio
+import uuid
+
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import get_settings
+from app.dependencies import get_db, require_admin
+from app.limiter import limiter, user_key
+from app.models.sql_models import User
+from app.routers.auth import ROTA_REDEFINIR, mandar_link_de_recuperacao
+from app.schemas.admin import AdminActionRequest, AdminMetrics, AdminUserOut
+from app.services import admin_service
+from app.services.auth_service import verify_password
+from app.services.billing_service import GatewayCancelFailed
+
+router = APIRouter(prefix="/admin", tags=["Admin"])
+
+
+async def _alvo(db: AsyncSession, admin: User, user_id: uuid.UUID, senha: str) -> User:
+    """Ordem fixa: senha, depois "é você mesmo", depois "existe". A senha vem
+    primeiro para que nenhuma outra resposta vaze antes do step-up."""
+    if not await asyncio.to_thread(verify_password, senha, admin.password_hash):
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Senha incorreta")
+    if user_id == admin.id:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Use as Configurações para agir na própria conta")
+    alvo = (await db.execute(select(User).where(User.id == user_id))).scalar_one_or_none()
+    if alvo is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Usuário não encontrado")
+    return alvo
+
+
+@router.get("/metrics", response_model=AdminMetrics)
+@limiter.limit("30/minute", key_func=user_key)
+async def metrics(request: Request, admin: User = Depends(require_admin), db: AsyncSession = Depends(get_db)):
+    return await admin_service.metricas(db)
+
+
+@router.get("/users", response_model=list[AdminUserOut])
+@limiter.limit("30/minute", key_func=user_key)
+async def users(request: Request, admin: User = Depends(require_admin), db: AsyncSession = Depends(get_db)):
+    return await admin_service.listar_usuarios(db)
+
+
+@router.post("/users/{user_id}/cancel-subscription", status_code=status.HTTP_204_NO_CONTENT)
+@limiter.limit("5/minute", key_func=user_key)
+async def cancel_subscription(
+    request: Request, user_id: uuid.UUID, payload: AdminActionRequest,
+    admin: User = Depends(require_admin), db: AsyncSession = Depends(get_db),
+):
+    alvo = await _alvo(db, admin, user_id, payload.password)
+    try:
+        await admin_service.cancelar_assinatura(db, admin=admin, alvo=alvo)
+    except admin_service.SemAssinatura:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Este usuário não tem assinatura ativa")
+    except GatewayCancelFailed:
+        raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail="O Stripe recusou o cancelamento. Tente de novo.")
+
+
+@router.delete("/users/{user_id}", status_code=status.HTTP_204_NO_CONTENT)
+@limiter.limit("5/minute", key_func=user_key)
+async def delete_user(
+    request: Request, user_id: uuid.UUID, payload: AdminActionRequest,
+    admin: User = Depends(require_admin), db: AsyncSession = Depends(get_db),
+):
+    alvo = await _alvo(db, admin, user_id, payload.password)
+    try:
+        await admin_service.excluir_conta(db, admin=admin, alvo=alvo)
+    except GatewayCancelFailed:
+        # Mesma regra do DELETE /auth/me: assinatura viva que o Stripe não
+        # cancelou, NADA é apagado.
+        raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail="O Stripe recusou o cancelamento; a conta não foi excluída.")
+
+
+@router.post("/users/{user_id}/recovery-email", status_code=status.HTTP_202_ACCEPTED)
+@limiter.limit("5/minute", key_func=user_key)
+async def recovery_email(
+    request: Request, user_id: uuid.UUID, payload: AdminActionRequest, background: BackgroundTasks,
+    admin: User = Depends(require_admin), db: AsyncSession = Depends(get_db),
+):
+    if not get_settings().brevo_api_key:
+        raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="Recuperação de senha indisponível")
+    alvo = await _alvo(db, admin, user_id, payload.password)
+    link = await admin_service.preparar_recuperacao(
+        db, admin=admin, alvo=alvo, base_url=get_settings().app_base_url, rota=ROTA_REDEFINIR,
+    )
+    background.add_task(mandar_link_de_recuperacao, alvo.email, link)
+    return {"detail": "Link de redefinição enviado ao e-mail do usuário."}

--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -2,6 +2,7 @@
 responde "o que o admin alcança"."""
 
 import asyncio
+import logging
 import uuid
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request, status
@@ -19,6 +20,7 @@ from app.services.auth_service import verify_password
 from app.services.billing_service import GatewayCancelFailed
 
 router = APIRouter(prefix="/admin", tags=["Admin"])
+logger = logging.getLogger("norby.admin")
 
 
 async def _alvo(db: AsyncSession, admin: User, user_id: uuid.UUID, senha: str) -> User:
@@ -57,7 +59,8 @@ async def cancel_subscription(
         await admin_service.cancelar_assinatura(db, admin=admin, alvo=alvo)
     except admin_service.SemAssinatura:
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Este usuário não tem assinatura ativa")
-    except GatewayCancelFailed:
+    except GatewayCancelFailed as erro:
+        logger.error("falha ao cancelar assinatura no gateway: %s", erro)
         raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail="O Stripe recusou o cancelamento. Tente de novo.")
 
 
@@ -70,9 +73,10 @@ async def delete_user(
     alvo = await _alvo(db, admin, user_id, payload.password)
     try:
         await admin_service.excluir_conta(db, admin=admin, alvo=alvo)
-    except GatewayCancelFailed:
+    except GatewayCancelFailed as erro:
         # Mesma regra do DELETE /auth/me: assinatura viva que o Stripe não
         # cancelou, NADA é apagado.
+        logger.error("falha ao cancelar assinatura no gateway: %s", erro)
         raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail="O Stripe recusou o cancelamento; a conta não foi excluída.")
 
 
@@ -82,9 +86,10 @@ async def recovery_email(
     request: Request, user_id: uuid.UUID, payload: AdminActionRequest, background: BackgroundTasks,
     admin: User = Depends(require_admin), db: AsyncSession = Depends(get_db),
 ):
+    # Step-up primeiro: senha errada é sempre 401, mesmo sem Brevo configurado.
+    alvo = await _alvo(db, admin, user_id, payload.password)
     if not get_settings().brevo_api_key:
         raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="Recuperação de senha indisponível")
-    alvo = await _alvo(db, admin, user_id, payload.password)
     link = await admin_service.preparar_recuperacao(
         db, admin=admin, alvo=alvo, base_url=get_settings().app_base_url, rota=ROTA_REDEFINIR,
     )

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -461,7 +461,7 @@ async def _forgot_body(request: Request, payload: ForgotPassword) -> ForgotPassw
     return payload
 
 
-async def _mandar_link(email: str, link: str) -> None:
+async def mandar_link_de_recuperacao(email: str, link: str) -> None:
     """Roda DEPOIS da resposta, via BackgroundTasks. Não é otimização.
 
     Enviando dentro da requisição, e-mail existente levaria o tempo do POST ao
@@ -469,6 +469,9 @@ async def _mandar_link(email: str, link: str) -> None:
     de enumeração de conta tão bom quanto uma mensagem diferente — só que
     medido no relógio em vez de lido na tela. Respondendo antes de enviar, os
     dois casos custam o mesmo.
+
+    Público (não `_`): a área de admin (ADR 0004) reusa esta função para o
+    reenvio manual disparado por um admin.
     """
     try:
         await enviar_email(
@@ -517,7 +520,7 @@ async def forgot_password(
     if user is not None:
         raw = await create_password_reset(str(user.id), db)
         base = get_settings().app_base_url.rstrip("/")
-        background.add_task(_mandar_link, user.email, f"{base}{ROTA_REDEFINIR}?token={raw}")
+        background.add_task(mandar_link_de_recuperacao, user.email, f"{base}{ROTA_REDEFINIR}?token={raw}")
 
     return {"detail": "Se este e-mail tiver conta, o link de redefinição chegou nele."}
 

--- a/backend/app/schemas/admin.py
+++ b/backend/app/schemas/admin.py
@@ -1,0 +1,43 @@
+"""Contratos da área de admin (ADR 0004).
+
+`AdminUserOut` é a garantia de que o admin nunca lê dado financeiro de
+terceiro: a lista de campos é fechada, e o teste que serializa um usuário com
+carteira e transação prova que nada além disto sai. Foto e ids do Stripe ficam
+fora de propósito: a foto é dado pessoal que o admin não precisa ver, e no
+Dashboard do Stripe a busca é por e-mail.
+"""
+
+from datetime import datetime
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class AdminUserOut(BaseModel):
+    id: UUID
+    name: str
+    email: str
+    created_at: datetime
+    premium_until: datetime | None
+    ai_trial_ends_at: datetime | None
+    subscription_status: str | None
+    cancel_at_period_end: bool
+    is_admin: bool
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class AdminMetrics(BaseModel):
+    users: int
+    premium: int
+    trial: int
+    expired: int
+    mrr_brl: int
+    ai_calls_today: int
+    ai_calls_project_limit: int
+
+
+class AdminActionRequest(BaseModel):
+    # Step-up: a conta de admin é protegida só por senha, e as três ações agem
+    # sobre a conta de OUTRA pessoa. Mesmo contrato do DeleteAccountRequest.
+    password: str = Field(min_length=1, max_length=128)

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -59,6 +59,7 @@ class UserResponse(BaseModel):
     # cache, em vez de ser rebaixado a passageiro de todo /auth/me. Nulo
     # significa "sem foto", e é também a chave de cache do cliente.
     photo_updated_at: datetime | None
+    is_admin: bool
     plan: PlanResponse
 
     model_config = ConfigDict(from_attributes=True)
@@ -82,6 +83,7 @@ class UserResponse(BaseModel):
             "email": data.email,
             "created_at": data.created_at,
             "photo_updated_at": data.photo_updated_at,
+            "is_admin": data.is_admin,
             "plan": {
                 "ai_allowed": ai_gate_open(data),
                 "wallet_cap_applies": wallet_cap_active(data),

--- a/backend/app/services/admin_service.py
+++ b/backend/app/services/admin_service.py
@@ -6,6 +6,7 @@ primeiro, recusa aborta tudo), `cancel_subscription` (imediato) e
 métricas. Service não conhece HTTP: as exceções daqui viram status no router.
 """
 
+import logging
 import uuid
 from datetime import datetime, timezone
 
@@ -21,6 +22,8 @@ from app.services.billing_service import (
     cancel_subscription,
     fetch_subscription,
 )
+
+logger = logging.getLogger(__name__)
 
 # Limite de requisições por dia do projeto Gemini no tier gratuito (ADR 0003),
 # só para a tela mostrar "X de 500". Não é aplicado em lugar nenhum: quem
@@ -76,13 +79,18 @@ async def metricas(db: AsyncSession) -> dict:
 
 
 async def _registrar(
-    db: AsyncSession, *, admin: User, acao: str, alvo_id: uuid.UUID, alvo_email: str,
+    db: AsyncSession, *, admin_id: uuid.UUID, acao: str, alvo_id: uuid.UUID, alvo_email: str,
     detail: dict | None = None,
 ) -> None:
+    # admin_id em vez de `admin: User`, de propósito: um `db.rollback()` (ver
+    # `cancelar_assinatura`) expira TODOS os objetos ORM da sessão, e reler
+    # `admin.id` depois disso estoura MissingGreenlet. O id já é um valor
+    # simples, sem esse risco — mesma razão de `alvo_id`/`alvo_email` abaixo.
+    #
     # DEPOIS da ação, em commit próprio: ação que falhou não deixa linha, e a
     # linha não depende de o alvo ainda existir (ver AdminAction).
     db.add(AdminAction(
-        admin_id=admin.id, action=acao, target_user_id=alvo_id,
+        admin_id=admin_id, action=acao, target_user_id=alvo_id,
         target_email=alvo_email, detail=detail,
     ))
     await db.commit()
@@ -99,25 +107,48 @@ async def cancelar_assinatura(db: AsyncSession, *, admin: User, alvo: User) -> N
     if not alvo.stripe_subscription_id:
         raise SemAssinatura()
     sub_id = alvo.stripe_subscription_id
+    # Capturados ANTES do try: um `db.rollback()` no except expira os
+    # atributos do objeto ORM, e reler um atributo expirado fora de um
+    # `await` explícito estoura MissingGreenlet no SQLAlchemy async.
+    admin_id, alvo_id, alvo_email = admin.id, alvo.id, alvo.email
     await cancel_subscription(sub_id)  # GatewayCancelFailed sobe até o router
-    aplicar_assinatura(alvo, await fetch_subscription(sub_id))
-    await db.commit()
+
+    # A partir daqui o Stripe JÁ cancelou. Se o fetch ou o commit falharem
+    # (rede, 5xx), o cancelamento não pode virar erro 500 nem ficar sem
+    # auditoria: ele aconteceu. Sem esta guarda, o admin tentaria de novo, o
+    # Stripe recusaria cancelar uma assinatura já cancelada
+    # (GatewayCancelFailed para sempre), e a linha de auditoria de uma ação
+    # que de fato ocorreu nunca seria escrita. O webhook
+    # `customer.subscription.deleted` fecha `premium_until` quando chegar.
+    detail = {"stripe_subscription_id": sub_id}
+    try:
+        aplicar_assinatura(alvo, await fetch_subscription(sub_id))
+        await db.commit()
+    except Exception as erro:  # noqa: BLE001 — rede, credencial ou 5xx do Stripe
+        await db.rollback()
+        logger.warning(
+            "admin: assinatura %s cancelada no Stripe mas o fetch/aplicação falhou "
+            "para o usuário %s: %s", sub_id, alvo_id, erro,
+        )
+        detail["aplicado"] = False
+
     await _registrar(
-        db, admin=admin, acao="cancel_subscription", alvo_id=alvo.id, alvo_email=alvo.email,
-        detail={"stripe_subscription_id": sub_id},
+        db, admin_id=admin_id, acao="cancel_subscription", alvo_id=alvo_id, alvo_email=alvo_email,
+        detail=detail,
     )
 
 
 async def excluir_conta(db: AsyncSession, *, admin: User, alvo: User) -> None:
-    alvo_id, alvo_email = alvo.id, alvo.email
+    admin_id, alvo_id, alvo_email = admin.id, alvo.id, alvo.email
     await delete_account(alvo, db)  # Stripe primeiro; GatewayCancelFailed sobe
-    await _registrar(db, admin=admin, acao="delete_account", alvo_id=alvo_id, alvo_email=alvo_email)
+    await _registrar(db, admin_id=admin_id, acao="delete_account", alvo_id=alvo_id, alvo_email=alvo_email)
 
 
 async def preparar_recuperacao(db: AsyncSession, *, admin: User, alvo: User, base_url: str, rota: str) -> str:
     """Cria o token e devolve o link. Quem ENVIA é o router, em background,
     pelo mesmo helper do /auth/forgot-password: o service não conhece
     BackgroundTasks."""
-    raw = await create_password_reset(str(alvo.id), db)
-    await _registrar(db, admin=admin, acao="send_recovery_email", alvo_id=alvo.id, alvo_email=alvo.email)
+    admin_id, alvo_id, alvo_email = admin.id, alvo.id, alvo.email
+    raw = await create_password_reset(str(alvo_id), db)
+    await _registrar(db, admin_id=admin_id, acao="send_recovery_email", alvo_id=alvo_id, alvo_email=alvo_email)
     return f"{base_url.rstrip('/')}{rota}?token={raw}"

--- a/backend/app/services/admin_service.py
+++ b/backend/app/services/admin_service.py
@@ -1,0 +1,123 @@
+"""Área de admin (issue #23, ADR 0004).
+
+As três ações REUSAM o que já existe e já é testado: `delete_account` (Stripe
+primeiro, recusa aborta tudo), `cancel_subscription` (imediato) e
+`create_password_reset`. O que este módulo acrescenta é a auditoria e as
+métricas. Service não conhece HTTP: as exceções daqui viram status no router.
+"""
+
+import uuid
+from datetime import datetime, timezone
+
+from sqlalchemy import func, or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.sql_models import AdminAction, AiUsageDaily, User
+from app.services.account_service import delete_account
+from app.services.ai_service import dia_da_cota
+from app.services.auth_service import create_password_reset
+from app.services.billing_service import (
+    aplicar_assinatura,
+    cancel_subscription,
+    fetch_subscription,
+)
+
+# Limite de requisições por dia do projeto Gemini no tier gratuito (ADR 0003),
+# só para a tela mostrar "X de 500". Não é aplicado em lugar nenhum: quem
+# aplica por usuário é a cota diária do ai_service.
+PROJECT_RPD = 500
+PRECO_MENSAL_BRL = 20
+LIMITE_LISTA = 500
+
+
+class SemAssinatura(Exception):
+    """Cancelar quem não tem assinatura no Stripe. Router traduz para 409."""
+
+
+async def listar_usuarios(db: AsyncSession) -> list[User]:
+    # Todos, mais novos primeiro. Paginação quando a base passar do teto; hoje
+    # a lista inteira cabe numa resposta e o filtro é no cliente.
+    return list(
+        (await db.execute(select(User).order_by(User.created_at.desc()).limit(LIMITE_LISTA))).scalars()
+    )
+
+
+async def metricas(db: AsyncSession) -> dict:
+    """Uma consulta com `count(*) filter`, ao vivo. A base é pequena; cache
+    e agregação entram no dia em que este `count` doer."""
+    agora = datetime.now(timezone.utc)
+    sem_premium = or_(User.premium_until.is_(None), User.premium_until <= agora)
+    linha = (
+        await db.execute(
+            select(
+                func.count(User.id).label("users"),
+                func.count(User.id).filter(User.premium_until > agora).label("premium"),
+                func.count(User.id).filter(User.premium_until <= agora).label("expired"),
+                func.count(User.id).filter(User.ai_trial_ends_at > agora, sem_premium).label("trial"),
+            )
+        )
+    ).one()
+    chamadas_hoje = (
+        await db.execute(
+            select(func.coalesce(func.sum(AiUsageDaily.calls), 0)).where(
+                AiUsageDaily.day == dia_da_cota()
+            )
+        )
+    ).scalar_one()
+    return {
+        "users": linha.users,
+        "premium": linha.premium,
+        "trial": linha.trial,
+        "expired": linha.expired,
+        "mrr_brl": linha.premium * PRECO_MENSAL_BRL,
+        "ai_calls_today": int(chamadas_hoje),
+        "ai_calls_project_limit": PROJECT_RPD,
+    }
+
+
+async def _registrar(
+    db: AsyncSession, *, admin: User, acao: str, alvo_id: uuid.UUID, alvo_email: str,
+    detail: dict | None = None,
+) -> None:
+    # DEPOIS da ação, em commit próprio: ação que falhou não deixa linha, e a
+    # linha não depende de o alvo ainda existir (ver AdminAction).
+    db.add(AdminAction(
+        admin_id=admin.id, action=acao, target_user_id=alvo_id,
+        target_email=alvo_email, detail=detail,
+    ))
+    await db.commit()
+
+
+async def cancelar_assinatura(db: AsyncSession, *, admin: User, alvo: User) -> None:
+    """Cancela no Stripe na hora e aplica o estado que o Stripe devolve.
+
+    Imediato, e não no fim do período: o caminho normal de quem quer cancelar
+    é o Customer Portal. Este é o excepcional (fraude, chargeback, pessoa que
+    não consegue usar o Portal), e a assinatura tem que parar agora. Aplicar
+    pelo `aplicar_assinatura` faz o acesso cair sem esperar o webhook.
+    """
+    if not alvo.stripe_subscription_id:
+        raise SemAssinatura()
+    sub_id = alvo.stripe_subscription_id
+    await cancel_subscription(sub_id)  # GatewayCancelFailed sobe até o router
+    aplicar_assinatura(alvo, await fetch_subscription(sub_id))
+    await db.commit()
+    await _registrar(
+        db, admin=admin, acao="cancel_subscription", alvo_id=alvo.id, alvo_email=alvo.email,
+        detail={"stripe_subscription_id": sub_id},
+    )
+
+
+async def excluir_conta(db: AsyncSession, *, admin: User, alvo: User) -> None:
+    alvo_id, alvo_email = alvo.id, alvo.email
+    await delete_account(alvo, db)  # Stripe primeiro; GatewayCancelFailed sobe
+    await _registrar(db, admin=admin, acao="delete_account", alvo_id=alvo_id, alvo_email=alvo_email)
+
+
+async def preparar_recuperacao(db: AsyncSession, *, admin: User, alvo: User, base_url: str, rota: str) -> str:
+    """Cria o token e devolve o link. Quem ENVIA é o router, em background,
+    pelo mesmo helper do /auth/forgot-password: o service não conhece
+    BackgroundTasks."""
+    raw = await create_password_reset(str(alvo.id), db)
+    await _registrar(db, admin=admin, acao="send_recovery_email", alvo_id=alvo.id, alvo_email=alvo.email)
+    return f"{base_url.rstrip('/')}{rota}?token={raw}"

--- a/backend/app/services/billing_service.py
+++ b/backend/app/services/billing_service.py
@@ -266,6 +266,25 @@ async def fetch_subscription(subscription_id: str) -> dict:
     return sub.to_dict()
 
 
+def aplicar_assinatura(user: User, sub: dict) -> None:
+    """Aplica ao usuário uma assinatura lida do Stripe, pelo mesmo `_aplicar`
+    do webhook, e não por uma segunda escrita paralela: duas rotas escrevendo
+    as mesmas colunas divergem, e a divergência aqui é acesso pago errado. O
+    tipo sintetizado escolhe o ramo certo — assinatura terminada tem
+    `ended_at`, que é a única data que vale num cancelamento imediato.
+
+    Usada pela reconciliação preguiçosa e pelo cancelamento feito pelo admin
+    (ADR 0004), que precisa do acesso caindo NA HORA, sem esperar o webhook.
+    """
+    tipo = (
+        "customer.subscription.deleted"
+        if sub.get("status") in STATUS_TERMINAIS
+        else "customer.subscription.updated"
+    )
+    evento = {"id": f"reconcile:{sub.get('id')}", "type": tipo, "data": {"object": sub}}
+    _aplicar(user, evento, _projecao(evento))
+
+
 def precisa_reconciliar(user: User, now: datetime | None = None) -> bool:
     """Gatilho estreito de propósito.
 
@@ -313,19 +332,7 @@ async def reconcile_subscription(user: User, db: AsyncSession) -> bool:
         )
         return False
 
-    # O mesmo `_aplicar` do webhook, e não uma segunda escrita paralela: duas
-    # rotas escrevendo as mesmas colunas divergem, e a divergência aqui é
-    # acesso pago errado. O tipo sintetizado escolhe o ramo certo — assinatura
-    # terminada tem `ended_at`, que é a única data que vale num cancelamento
-    # imediato.
-    tipo = (
-        "customer.subscription.deleted"
-        if sub.get("status") in STATUS_TERMINAIS
-        else "customer.subscription.updated"
-    )
-    evento = {"id": f"reconcile:{user.stripe_subscription_id}", "type": tipo,
-              "data": {"object": sub}}
-    _aplicar(user, evento, _projecao(evento))
+    aplicar_assinatura(user, sub)
 
     # `stripe_event_at` NÃO se move aqui. Ela é a marca d'água de ORDEM dos
     # eventos, e carimbá-la com o nosso relógio faria um webhook legítimo que

--- a/backend/app/services/email_service.py
+++ b/backend/app/services/email_service.py
@@ -34,8 +34,8 @@ class EmailNotConfigured(Exception):
     O router já barra isso alto, ANTES de agendar o envio (checagem em
     `auth.py`, resposta 503) — na prática esta exceção é a última linha de
     defesa, só alcançável se a chave sumir entre o pre-check e a BackgroundTask
-    rodar. `_mandar_link` a engole em silêncio, sem logar: a resposta já foi
-    entregue e não há para quem reportar o erro.
+    rodar. `mandar_link_de_recuperacao` a engole em silêncio, sem logar: a
+    resposta já foi entregue e não há para quem reportar o erro.
     """
 
 

--- a/backend/tests/test_admin.py
+++ b/backend/tests/test_admin.py
@@ -1,0 +1,294 @@
+"""Área de admin (issue #23, ADR 0004).
+
+Critério de saída do ticket: usuário comum recebe 404 em TODA rota de admin,
+e nenhum endpoint de admin devolve dado financeiro de terceiro. O resto
+prova o step-up por senha, a auditoria e as três ações.
+"""
+
+import uuid
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+
+import pytest
+from sqlalchemy import select, func
+
+import app.routers.admin as admin_router
+import app.routers.auth as auth_router
+import app.services.admin_service as admin_service
+import app.services.account_service as account_service
+import app.services.ai_service as ai
+from app.config import get_settings
+from app.models.sql_models import (
+    AdminAction, AiUsageDaily, Transaction, TransactionType, User, Wallet,
+)
+
+SENHA = "secret123"  # a senha que o make_auth_client cadastra
+
+
+@pytest.fixture(autouse=True)
+def brevo_configurado(monkeypatch):
+    """Vários testes aqui usam /recovery-email sem testar o Brevo em si; sem
+    isto, herdariam o `brevo_api_key` vazio do ambiente e cairiam no 503 antes
+    de chegar no step-up de senha. Os dois testes sobre o Brevo (configurado e
+    ausente) sobrescrevem por cima dentro do próprio teste, e restauram o que
+    encontraram — que passa a ser este valor, não o vazio do ambiente."""
+    settings = get_settings()
+    monkeypatch.setattr(settings, "brevo_api_key", "xkeysib-teste")
+
+
+async def _usuario(ac, db_session) -> User:
+    me = (await ac.get("/auth/me")).json()
+    return (await db_session.execute(select(User).where(User.id == me["id"]))).scalar_one()
+
+
+async def _promover(ac, db_session) -> User:
+    user = await _usuario(ac, db_session)
+    user.is_admin = True
+    await db_session.commit()
+    return user
+
+
+async def _auditoria(db_session) -> list[AdminAction]:
+    db_session.expire_all()
+    return list((await db_session.execute(select(AdminAction))).scalars())
+
+
+def _rotas_de_admin():
+    """Toda rota do router, com método e um path preenchido. Varrer o router
+    em vez de listar à mão: rota nova entra no teste sem ninguém lembrar."""
+    alvo = uuid.uuid4()
+    for rota in admin_router.router.routes:
+        for metodo in rota.methods:
+            yield metodo, rota.path.replace("{user_id}", str(alvo))
+
+
+@pytest.mark.asyncio
+async def test_every_admin_route_answers_404_to_a_regular_user(make_auth_client, db_session):
+    comum = await make_auth_client("Comum")
+    rotas = list(_rotas_de_admin())
+    assert len(rotas) >= 5
+    for metodo, path in rotas:
+        res = await comum.request(metodo, path, json={"password": SENHA})
+        # O corpo é o mesmo do FastAPI para rota inexistente: quem não é admin
+        # não fica sabendo que a rota existe.
+        assert res.status_code == 404, (metodo, path, res.text)
+        assert res.json() == {"detail": "Not Found"}, (metodo, path)
+
+
+@pytest.mark.asyncio
+async def test_an_admin_never_receives_third_party_financial_data(make_auth_client, db_session):
+    admin = await make_auth_client("Admin")
+    await _promover(admin, db_session)
+    alvo_client = await make_auth_client("Alvo")
+    alvo = await _usuario(alvo_client, db_session)
+    carteira = Wallet(user_id=alvo.id, name="Carteira Secreta", balance=Decimal("1234.56"))
+    db_session.add(carteira)
+    await db_session.flush()
+    db_session.add(Transaction(
+        user_id=alvo.id, wallet_id=carteira.id, type=TransactionType.EXPENSE,
+        amount=Decimal("987.65"), category="Aluguel", date=datetime.now(timezone.utc).date(),
+    ))
+    await db_session.commit()
+
+    res = await admin.get("/admin/users")
+    assert res.status_code == 200, res.text
+    linha = next(u for u in res.json() if u["id"] == str(alvo.id))
+    # Garantia por construção: o schema é a lista fechada de campos.
+    assert set(linha) == {
+        "id", "name", "email", "created_at", "premium_until", "ai_trial_ends_at",
+        "subscription_status", "cancel_at_period_end", "is_admin",
+    }
+    for vazamento in ("Carteira Secreta", "1234.56", "987.65", "Aluguel", "photo"):
+        assert vazamento not in res.text
+
+
+@pytest.mark.asyncio
+async def test_me_reports_is_admin(make_auth_client, db_session):
+    alice = await make_auth_client("Alice")
+    assert (await alice.get("/auth/me")).json()["is_admin"] is False
+    await _promover(alice, db_session)
+    assert (await alice.get("/auth/me")).json()["is_admin"] is True
+
+
+@pytest.mark.asyncio
+async def test_metrics_count_the_plan_bands_and_todays_ai_calls(make_auth_client, db_session):
+    admin = await make_auth_client("Admin")
+    await _promover(admin, db_session)
+    agora = datetime.now(timezone.utc)
+    premium = await _usuario(await make_auth_client("Premium"), db_session)
+    premium.premium_until = agora + timedelta(days=20)
+    vencido = await _usuario(await make_auth_client("Vencido"), db_session)
+    vencido.premium_until = agora - timedelta(days=2)
+    vencido.ai_trial_ends_at = agora - timedelta(days=30)
+    free = await _usuario(await make_auth_client("Free"), db_session)
+    free.ai_trial_ends_at = agora - timedelta(days=1)
+    # "Trial": cadastro novo (7 dias de IA), sem premium. O admin também está
+    # em trial, porque acabou de se cadastrar: conta como trial e como usuário.
+    trial = await _usuario(await make_auth_client("Trial"), db_session)
+    db_session.add(AiUsageDaily(user_id=trial.id, day=ai.dia_da_cota(), tokens=900, calls=3))
+    db_session.add(AiUsageDaily(user_id=premium.id, day=ai.dia_da_cota(), tokens=100, calls=2))
+    db_session.add(AiUsageDaily(
+        user_id=premium.id, day=ai.dia_da_cota() - timedelta(days=1), tokens=100, calls=50,
+    ))
+    await db_session.commit()
+
+    res = await admin.get("/admin/metrics")
+    assert res.status_code == 200, res.text
+    m = res.json()
+    assert m["users"] == 5
+    assert m["premium"] == 1
+    assert m["expired"] == 1
+    assert m["trial"] == 2  # admin + trial
+    assert m["mrr_brl"] == 20
+    assert m["ai_calls_today"] == 5  # ontem não conta
+    assert m["ai_calls_project_limit"] == admin_service.PROJECT_RPD
+
+
+@pytest.mark.asyncio
+async def test_wrong_password_refuses_and_leaves_no_audit_row(make_auth_client, db_session):
+    admin = await make_auth_client("Admin")
+    await _promover(admin, db_session)
+    alvo = await _usuario(await make_auth_client("Alvo"), db_session)
+
+    res = await admin.post(f"/admin/users/{alvo.id}/recovery-email", json={"password": "errada"})
+    assert res.status_code == 401, res.text
+    assert await _auditoria(db_session) == []
+
+
+@pytest.mark.asyncio
+async def test_acting_on_yourself_is_refused(make_auth_client, db_session):
+    admin = await make_auth_client("Admin")
+    eu = await _promover(admin, db_session)
+
+    # httpx >=0.20 não aceita `json=` em `.delete()` (verbo sem corpo por
+    # design da lib); `.request("DELETE", ...)` manda o corpo que a rota exige.
+    res = await admin.request("DELETE", f"/admin/users/{eu.id}", json={"password": SENHA})
+    assert res.status_code == 400, res.text
+    assert await _auditoria(db_session) == []
+
+
+@pytest.mark.asyncio
+async def test_cancel_calls_stripe_and_ends_premium_now(make_auth_client, db_session, monkeypatch):
+    admin = await make_auth_client("Admin")
+    eu = await _promover(admin, db_session)
+    eu_id = eu.id
+    alvo = await _usuario(await make_auth_client("Alvo"), db_session)
+    alvo_id = alvo.id
+    alvo.stripe_subscription_id = "sub_teste"
+    alvo.premium_until = datetime.now(timezone.utc) + timedelta(days=20)
+    await db_session.commit()
+
+    cancelados = []
+
+    async def _cancel(subscription_id):
+        cancelados.append(subscription_id)
+
+    # A assinatura como o Stripe a devolve DEPOIS de cancelar: copie o
+    # dicionário de assinatura cancelada que tests/test_billing_reconcile.py já
+    # usa (status "canceled" e `ended_at` no passado imediato).
+    async def _fetch(subscription_id):
+        return {
+            "id": subscription_id,
+            "status": "canceled",
+            "ended_at": int(datetime.now(timezone.utc).timestamp()),
+            "current_period_end": int((datetime.now(timezone.utc) + timedelta(days=20)).timestamp()),
+            "cancel_at_period_end": False,
+            "created": int(datetime.now(timezone.utc).timestamp()),
+        }
+
+    monkeypatch.setattr(admin_service, "cancel_subscription", _cancel)
+    monkeypatch.setattr(admin_service, "fetch_subscription", _fetch)
+
+    res = await admin.post(f"/admin/users/{alvo_id}/cancel-subscription", json={"password": SENHA})
+    assert res.status_code == 204, res.text
+    assert cancelados == ["sub_teste"]
+
+    db_session.expire_all()
+    alvo = (await db_session.execute(select(User).where(User.id == alvo_id))).scalar_one()
+    assert alvo.premium_until <= datetime.now(timezone.utc)
+    alvo_email = alvo.email
+    (linha,) = await _auditoria(db_session)
+    assert (linha.admin_id, linha.action, linha.target_user_id, linha.target_email) == (
+        eu_id, "cancel_subscription", alvo_id, alvo_email,
+    )
+    assert linha.detail == {"stripe_subscription_id": "sub_teste"}
+
+
+@pytest.mark.asyncio
+async def test_cancel_without_a_subscription_is_a_409(make_auth_client, db_session):
+    admin = await make_auth_client("Admin")
+    await _promover(admin, db_session)
+    alvo = await _usuario(await make_auth_client("Alvo"), db_session)
+
+    res = await admin.post(f"/admin/users/{alvo.id}/cancel-subscription", json={"password": SENHA})
+    assert res.status_code == 409, res.text
+    assert await _auditoria(db_session) == []
+
+
+@pytest.mark.asyncio
+async def test_delete_reuses_delete_account_and_audits_with_the_email_snapshot(
+    make_auth_client, db_session, mongo, monkeypatch
+):
+    admin = await make_auth_client("Admin")
+    await _promover(admin, db_session)
+    alvo = await _usuario(await make_auth_client("Alvo"), db_session)
+    alvo_id, alvo_email = alvo.id, alvo.email
+
+    async def _nao_deveria_ser_chamado(_id):
+        raise AssertionError("sem assinatura, o Stripe não é chamado")
+
+    monkeypatch.setattr(account_service, "cancel_subscription", _nao_deveria_ser_chamado)
+
+    res = await admin.request("DELETE", f"/admin/users/{alvo_id}", json={"password": SENHA})
+    assert res.status_code == 204, res.text
+
+    db_session.expire_all()
+    assert (await db_session.execute(select(User).where(User.id == alvo_id))).scalar_one_or_none() is None
+    (linha,) = await _auditoria(db_session)
+    assert (linha.action, linha.target_user_id, linha.target_email) == (
+        "delete_account", alvo_id, alvo_email,
+    )
+
+
+@pytest.mark.asyncio
+async def test_recovery_email_is_queued_and_audited(make_auth_client, db_session, monkeypatch):
+    admin = await make_auth_client("Admin")
+    await _promover(admin, db_session)
+    alvo = await _usuario(await make_auth_client("Alvo"), db_session)
+    alvo_email = alvo.email
+
+    enviados = []
+
+    async def _fake(*, para, assunto, html):
+        enviados.append((para, assunto))
+        return "msg-1"
+
+    # O helper de envio mora no router de auth e resolve `enviar_email` de lá.
+    monkeypatch.setattr(auth_router, "enviar_email", _fake)
+    settings = get_settings()
+    antes = settings.brevo_api_key
+    settings.brevo_api_key = "chave-de-teste"
+    try:
+        res = await admin.post(f"/admin/users/{alvo.id}/recovery-email", json={"password": SENHA})
+    finally:
+        settings.brevo_api_key = antes
+    assert res.status_code == 202, res.text
+    assert enviados and enviados[0][0] == alvo_email
+    (linha,) = await _auditoria(db_session)
+    assert (linha.action, linha.target_email, linha.detail) == ("send_recovery_email", alvo_email, None)
+
+
+@pytest.mark.asyncio
+async def test_recovery_email_without_brevo_is_a_503(make_auth_client, db_session):
+    admin = await make_auth_client("Admin")
+    await _promover(admin, db_session)
+    alvo = await _usuario(await make_auth_client("Alvo"), db_session)
+    settings = get_settings()
+    antes = settings.brevo_api_key
+    settings.brevo_api_key = ""
+    try:
+        res = await admin.post(f"/admin/users/{alvo.id}/recovery-email", json={"password": SENHA})
+    finally:
+        settings.brevo_api_key = antes
+    assert res.status_code == 503, res.text
+    assert await _auditoria(db_session) == []

--- a/backend/tests/test_admin.py
+++ b/backend/tests/test_admin.py
@@ -10,7 +10,7 @@ from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 
 import pytest
-from sqlalchemy import select, func
+from sqlalchemy import select
 
 import app.routers.admin as admin_router
 import app.routers.auth as auth_router
@@ -23,17 +23,6 @@ from app.models.sql_models import (
 )
 
 SENHA = "secret123"  # a senha que o make_auth_client cadastra
-
-
-@pytest.fixture(autouse=True)
-def brevo_configurado(monkeypatch):
-    """Vários testes aqui usam /recovery-email sem testar o Brevo em si; sem
-    isto, herdariam o `brevo_api_key` vazio do ambiente e cairiam no 503 antes
-    de chegar no step-up de senha. Os dois testes sobre o Brevo (configurado e
-    ausente) sobrescrevem por cima dentro do próprio teste, e restauram o que
-    encontraram — que passa a ser este valor, não o vazio do ambiente."""
-    settings = get_settings()
-    monkeypatch.setattr(settings, "brevo_api_key", "xkeysib-teste")
 
 
 async def _usuario(ac, db_session) -> User:
@@ -212,6 +201,50 @@ async def test_cancel_calls_stripe_and_ends_premium_now(make_auth_client, db_ses
         eu_id, "cancel_subscription", alvo_id, alvo_email,
     )
     assert linha.detail == {"stripe_subscription_id": "sub_teste"}
+
+
+@pytest.mark.asyncio
+async def test_cancel_survives_a_failed_fetch_after_the_stripe_cancel(
+    make_auth_client, db_session, monkeypatch
+):
+    # O Stripe JÁ cancelou quando o fetch (ou a aplicação) falha depois. Isso
+    # não pode virar 500 nem ficar sem auditoria: repetir bateria num
+    # GatewayCancelFailed permanente (o Stripe recusa cancelar de novo o que
+    # já está cancelado), e a ação que de fato aconteceu sumiria sem rastro.
+    admin = await make_auth_client("Admin")
+    eu = await _promover(admin, db_session)
+    eu_id = eu.id
+    alvo = await _usuario(await make_auth_client("Alvo"), db_session)
+    alvo_id = alvo.id
+    alvo.stripe_subscription_id = "sub_teste"
+    alvo.premium_until = datetime.now(timezone.utc) + timedelta(days=20)
+    await db_session.commit()
+
+    cancelados = []
+
+    async def _cancel(subscription_id):
+        cancelados.append(subscription_id)
+
+    async def _fetch(subscription_id):
+        raise RuntimeError("stripe indisponível")
+
+    monkeypatch.setattr(admin_service, "cancel_subscription", _cancel)
+    monkeypatch.setattr(admin_service, "fetch_subscription", _fetch)
+
+    res = await admin.post(f"/admin/users/{alvo_id}/cancel-subscription", json={"password": SENHA})
+    assert res.status_code == 204, res.text
+    assert cancelados == ["sub_teste"]
+
+    db_session.expire_all()
+    alvo = (await db_session.execute(select(User).where(User.id == alvo_id))).scalar_one()
+    # A aplicação falhou: premium_until continua no futuro até o webhook
+    # `customer.subscription.deleted` fechar o portão.
+    assert alvo.premium_until > datetime.now(timezone.utc)
+    (linha,) = await _auditoria(db_session)
+    assert (linha.admin_id, linha.action, linha.target_user_id) == (
+        eu_id, "cancel_subscription", alvo_id,
+    )
+    assert linha.detail == {"stripe_subscription_id": "sub_teste", "aplicado": False}
 
 
 @pytest.mark.asyncio

--- a/docs/adr/0004-area-de-admin.md
+++ b/docs/adr/0004-area-de-admin.md
@@ -33,7 +33,11 @@ inexistente (`{"detail": "Not Found"}`), nunca 403.** Um 403 confirmaria que
 `/admin/*` existe e convidaria a insistir (senha errada, força bruta no id).
 404 faz a área inteira parecer não-existente para quem não é admin — o mesmo
 raciocínio do `WalletNotFound` em `main.py`, aplicado à existência da própria
-rota.
+rota. O disfarce vale para quem está autenticado e não é admin; uma
+requisição anônima leva 401 como qualquer rota autenticada (não passa nem de
+`get_current_user`), e `/openapi.json` lista `/admin/*` normalmente quando
+`docs_enabled` está ligado — a ocultação depende de docs continuarem
+desligados em produção.
 
 **As três ações exigem a senha atual (step-up), não só o access token.** A
 conta de admin é protegida só por senha — não há 2FA nesta v2, porque exigir

--- a/docs/adr/0004-area-de-admin.md
+++ b/docs/adr/0004-area-de-admin.md
@@ -1,0 +1,113 @@
+# ADR 0004 — Área de admin
+
+- **Status:** aceito
+- **Data:** 2026-09-06
+- **Issue:** [#23](https://github.com/DigoDuck/Norby/issues/23), parte do mapa da v2 ([#15](https://github.com/DigoDuck/Norby/issues/15))
+- **Depende de:** [ADR 0001](0001-modelo-de-assinatura.md) (`premium_until` como portão, `cancel_subscription`), [ADR 0003](0003-cota-diaria-de-ia.md) (RPD do projeto, `dia_da_cota`)
+- **Decide:** quem é admin e como isso é escrito, o que a área alcança, o step-up das três ações, o formato da auditoria, e o que as métricas mostram.
+- **Não decide:** a tela de admin no frontend (task separada), 2FA, paginação de usuários.
+
+## Contexto
+
+O #23 pede uma superfície de suporte: ver a base em números, listar usuários,
+e agir em nome de alguém que pede ajuda (cancelar assinatura por chargeback ou
+fraude, excluir conta a pedido, reenviar o link de recuperação de senha para
+quem não recebeu). Hoje isso só é possível com acesso direto ao banco.
+
+Não existe conceito de admin no schema. A área inteira nasce nesta task:
+coluna, tabela de auditoria, dependency de portão, router, service.
+
+## Decisão
+
+**`users.is_admin`, coluna e não lista de e-mails em config.** A coluna morre
+com a linha: um e-mail recadastrado depois de excluir a conta não herda
+privilégio nenhum. Uma lista em variável de ambiente sobreviveria à exclusão e
+recriação da conta, e ninguém lembraria de tirá-lo de lá. Nenhum endpoint
+escreve nesta coluna — o primeiro e único admin nasce por `UPDATE` manual no
+console do banco, depois da migration (procedimento no AGENTS.md). **Um admin
+só** nesta v2: promover um segundo é decisão de quem já é admin, e essa
+decisão não tem tela nem endpoint ainda.
+
+**`require_admin` devolve 404, com o corpo literal do FastAPI para rota
+inexistente (`{"detail": "Not Found"}`), nunca 403.** Um 403 confirmaria que
+`/admin/*` existe e convidaria a insistir (senha errada, força bruta no id).
+404 faz a área inteira parecer não-existente para quem não é admin — o mesmo
+raciocínio do `WalletNotFound` em `main.py`, aplicado à existência da própria
+rota.
+
+**As três ações exigem a senha atual (step-up), não só o access token.** A
+conta de admin é protegida só por senha — não há 2FA nesta v2, porque exigir
+um segundo fator faz sentido a partir do dia em que houver mais de um admin
+para coordenar. Com um admin só, a senha é a barreira toda, e as três ações
+(cancelar assinatura, excluir conta, disparar recuperação) mudam a vida de
+OUTRA pessoa: o mesmo contrato do `DeleteAccountRequest` que já protege
+`DELETE /auth/me`. A ordem de checagem é fixa — senha, depois "é você mesmo",
+depois "o alvo existe" — para que nenhuma resposta escape antes do step-up.
+
+**`AdminUserOut` é um schema fechado, e essa é a garantia central do ADR.**
+Ele não tem foto (dado pessoal que o admin não precisa ver) nem ids do Stripe
+(no Dashboard a busca é por e-mail). O teste que serializa um usuário com
+carteira e transação prova, por construção, que a lista de campos é só a que
+o schema declara — nenhum admin lê saldo, categoria ou descrição de terceiro.
+
+**A auditoria (`admin_actions`) é só-insert, sem FK, com `target_email` de
+snapshot.** `admin_id` e `target_user_id` são UUIDs sem chave estrangeira de
+propósito: excluir a conta é uma das três ações auditadas, e uma FK com
+cascade apagaria justamente o registro de que ela foi excluída.
+`target_email` existe para a linha continuar identificando o alvo depois que
+a conta dele já não existe. É PII numa tabela sem purga, e é isso mesmo: o
+registro das operações do controlador é obrigação da LGPD (art. 37), não
+entra no export do próprio usuário (é operação do admin, não dado dele) e não
+some com a exclusão da conta. `detail` guarda só identificadores — o id da
+assinatura cancelada — nunca conteúdo. Não há tela de auditoria nesta v2;
+quem precisar consultar, consulta o banco.
+
+**A linha é gravada DEPOIS da ação, em commit próprio.** Ação que falhou
+(senha errada, Stripe recusou, alvo é você mesmo) não deixa rastro — só o que
+de fato aconteceu é auditado.
+
+**Cancelamento é imediato, e aplicado na hora pelo `aplicar_assinatura`, não
+pelo webhook.** O caminho normal de quem quer cancelar é o Customer Portal; a
+ação do admin é o excepcional (fraude, chargeback, pessoa que não consegue
+usar o Portal), e o acesso pago tem que parar já, sem esperar o Stripe
+entregar o evento. `aplicar_assinatura` é a extração do fim de
+`reconcile_subscription` (mesmo `_aplicar` do webhook): duas rotas escrevendo
+as mesmas colunas por caminhos diferentes divergem, e a divergência aqui é
+acesso pago errado.
+
+**Exclusão de conta reusa `delete_account` inteiro**, sem reimplementar a
+ordem Stripe-primeiro-depois-Mongo-depois-Postgres. **Recuperação de senha
+reusa a cadeia inteira do "esqueci minha senha"**: `create_password_reset`
+para o token e `mandar_link_de_recuperacao` (renomeado de `_mandar_link`,
+agora público) para o envio em background — o admin dispara o mesmo link que
+`/auth/forgot-password` manda, só que sem a pessoa precisar pedir.
+
+**Métricas são uma consulta ao vivo, sem cache.** A base é pequena; uma
+`count(*) filter` por faixa de plano custa pouco. `ai_calls_project_limit` é o
+RPD 500 do ADR 0003 exposto como constante (`PROJECT_RPD`), só para a tela
+comparar "quantos hoje" com "quantos no total do projeto" — não é aplicado em
+lugar nenhum, quem aplica por usuário é a cota diária do `ai_service`.
+
+## Consequências aceitas
+
+- **Ação que falhou não deixa rastro nenhum**, nem de tentativa. Aceito
+  porque o objetivo da auditoria é registrar o que o admin FEZ, não o que
+  tentou — e senha errada já é bloqueada no 401 antes de chegar perto de
+  qualquer ação.
+- **Sem paginação em `/admin/users`** até a base passar de `LIMITE_LISTA`
+  (500) usuários. Hoje a lista inteira cabe numa resposta e o filtro é no
+  cliente.
+- **Sem 2FA.** Aceito enquanto houver um admin só; a senha é a barreira
+  inteira até esse dia.
+- **`detail` da auditoria nunca guarda conteúdo**, só identificador. Uma
+  investigação futura que precise de mais contexto (por que cancelou, a
+  conversa de suporte) não encontra isso aqui — fica em outra ferramenta.
+
+## Quando rever
+
+- **Segundo admin:** decidir quem promove quem (endpoint? SQL de novo?) e
+  ligar 2FA antes de multiplicar quem tem esse poder.
+- **Base acima de 500 usuários:** paginação e busca no servidor em
+  `/admin/users`.
+- **Tela de auditoria:** hoje `admin_actions` só existe para quem consulta o
+  banco direto.


### PR DESCRIPTION
## Summary

- Adds `users.is_admin`, an insert-only `admin_actions` audit table, and a `require_admin` dependency that answers 404 (not 403) to non-admins, so `/admin/*` looks nonexistent to anyone who isn't one.
- Five routes on a dedicated `/admin` router: `GET /admin/metrics`, `GET /admin/users`, `POST /admin/users/{id}/cancel-subscription`, `DELETE /admin/users/{id}`, `POST /admin/users/{id}/recovery-email`.
- The three actions reuse existing, already-tested code instead of duplicating it: `delete_account`, `cancel_subscription`/`fetch_subscription` (through a new `aplicar_assinatura`, extracted from `reconcile_subscription`, so an admin cancellation applies state immediately instead of waiting for the webhook), and the forgot-password chain (`_mandar_link` renamed to the public `mandar_link_de_recuperacao`).
- Step-up: every action requires the acting admin's current password, checked before target-is-self and target-exists. An audit row is written only after the action succeeds, in its own commit — a failed action leaves no trace.
- `AdminUserOut` is a closed response schema: no wallet, transaction, photo, or Stripe id ever reaches an admin response (proven by a test that seeds a wallet + transaction for the target user and asserts the fields and the raw body).
- Docs: ADR 0004, three new `CONTEXT.md` glossary terms (admin, ação de admin, auditoria), and an `AGENTS.md` paragraph plus the first-admin SQL procedure.

## Test plan

- [x] `tests/test_admin.py` — 11 new tests proving the ticket's exit criteria: every admin route 404s for a regular user, no third-party financial data ever comes back, `/auth/me` reports `is_admin`, metrics count the plan bands and today's AI calls, wrong password refuses with no audit row, acting on yourself is refused, cancel applies Stripe state immediately and audits, cancelling without a subscription is a 409, delete reuses `delete_account` and audits with an email snapshot, recovery email is queued and audited, and 503 without Brevo configured.
- [x] `tests/test_billing_reconcile.py` and `tests/test_password_reset.py` stay green after the `aplicar_assinatura` extraction and the `mandar_link_de_recuperacao` rename.
- [x] Full suite: 360 passed.
- [x] `alembic check`: `No new upgrade operations detected.`

Refs #23