### PR TITLE
docs: name the maintained Gemini SDK in the architecture diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ flowchart LR
     FE -->|axios + JWT| API["FastAPI<br/>(Railway, Docker)"]
     API -->|SQLAlchemy async / asyncpg| PG[("PostgreSQL<br/>(Neon)")]
     API -->|Motor| MG[("MongoDB<br/>(Atlas)")]
-    API -->|google-generativeai| GEM["Gemini 3.5 Flash-Lite"]
+    API -->|google-genai| GEM["Gemini 3.5 Flash-Lite"]
 ```
 
 ## Decisões técnicas de destaque


### PR DESCRIPTION
The README's architecture diagram still labelled the Gemini edge `google-generativeai`, the SDK that was archived in November 2025 and replaced by `google-genai` in #40. The stack table three lines above already says `google-genai`, so the two contradicted each other.

One word, diagram only. No code change.

Refs #40