### PR TITLE
fix(admin): keep the page mounted when a refresh fails, and hold the danger colour on hover

### DIFF
--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -33,6 +33,9 @@ describe("rota raiz", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     useAuthStore.getState().logout();
+    // Um teste navega para /admin via pushState; sem isto o próximo teste
+    // herdaria essa URL e o resultado dependeria da ordem de execução.
+    window.history.pushState({}, "", "/");
   });
 
   it("manda para o dashboard quem já tem sessão", async () => {

--- a/frontend/src/components/layout/Sidebar.jsx
+++ b/frontend/src/components/layout/Sidebar.jsx
@@ -39,7 +39,7 @@ function NavItem({ to, icon, label }) {
 
 export default function Sidebar() {
   const user = useAuthStore((s) => s.user);
-  const isAdmin = useAuthStore((s) => Boolean(s.user?.is_admin));
+  const isAdmin = Boolean(user?.is_admin);
   const navigate = useNavigate();
 
   async function handleLogout() {

--- a/frontend/src/components/shared/ConfirmDialog.jsx
+++ b/frontend/src/components/shared/ConfirmDialog.jsx
@@ -75,9 +75,11 @@ export function ConfirmDialog({
             type="password"
             aria-label="Sua senha atual"
             placeholder="Sua senha atual"
-            // "off" evita que o navegador tente casar este campo com um campo
-            // de usuário/e-mail vizinho (aqui, a busca) e o preencha sozinho.
-            autoComplete="off"
+            // O Chrome documenta que ignora autoComplete="off" em campos de
+            // credencial; "new-password" é o valor que ele de fato respeita
+            // para não tentar casar este campo com um campo de usuário/e-mail
+            // vizinho (aqui, a busca) e preenchê-lo sozinho.
+            autoComplete="new-password"
             value={password}
             onChange={(e) => setPassword(e.target.value)}
             className={shadcnInputCls}

--- a/frontend/src/pages/Admin.jsx
+++ b/frontend/src/pages/Admin.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { Search } from "lucide-react";
 
 import { adminApi } from "@/api/admin";
@@ -12,27 +12,26 @@ import { Input } from "@/components/ui/input";
 // nestes estados não há mais nada a cancelar no Stripe.
 const STATUS_TERMINAIS = new Set(["canceled", "incomplete_expired"]);
 
-// Card de métrica: rótulo em microlabel + número em destaque.
-function MetricCard({ label, value, danger }) {
+// Card de métrica: rótulo em microlabel + número em destaque. `tone` sinaliza
+// o valor sem trocar o layout: "warning" perto do limite, "danger" no limite.
+function MetricCard({ label, value, tone }) {
+  const toneClass =
+    tone === "danger" ? "text-danger" : tone === "warning" ? "text-warning" : "text-content";
   return (
     <div className="glass p-5">
       <p className="microlabel">{label}</p>
-      <p
-        className={`mt-2 text-2xl font-semibold tnum tracking-tight ${
-          danger ? "text-danger" : "text-content"
-        }`}
-      >
-        {value}
-      </p>
+      <p className={`mt-2 text-2xl font-semibold tnum tracking-tight ${toneClass}`}>{value}</p>
     </div>
   );
 }
 
 /**
- * Faixa de acesso do usuário, derivada com o MESMO critério do backend
- * (admin_service.metricas): premium quando `premium_until` está no futuro;
- * trial quando `ai_trial_ends_at` está no futuro e não há premium ativo;
- * vencido quando `premium_until` existe mas já passou; o resto é free.
+ * Faixa de acesso do usuário para a LINHA da lista. Usa os mesmos campos que
+ * `admin_service.metricas` (premium_until/ai_trial_ends_at), mas não é o
+ * mesmo cálculo: as métricas contam cada balde (premium/trial/vencido)
+ * separadamente e eles podem se sobrepor no dado bruto, enquanto aqui, por
+ * linha, o trial só aparece quando não há premium ativo — premium sempre
+ * ganha da exibição de trial.
  */
 function faixaUsuario(user) {
   const agora = new Date();
@@ -49,16 +48,17 @@ function AdminUserRow({ user, isSelf, onChanged }) {
     Boolean(user.subscription_status) && !STATUS_TERMINAIS.has(user.subscription_status);
 
   return (
-    <li
-      data-user-row
-      className="py-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between"
-    >
+    <li className="py-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
       <div className="min-w-0">
-        <p className="font-medium text-content truncate">{user.name}</p>
+        <div className="flex items-center gap-2">
+          <p className="font-medium text-content truncate">{user.name}</p>
+          {user.is_admin && <span className="microlabel text-accent shrink-0">Admin</span>}
+        </div>
         <p className="text-sm text-content-2 truncate">{user.email}</p>
         <p className="text-xs text-content-3 mt-1">
           {faixaUsuario(user)}
           {user.subscription_status ? ` · ${user.subscription_status}` : ""}
+          {user.cancel_at_period_end ? " · cancela no fim do período" : ""}
         </p>
       </div>
 
@@ -100,7 +100,7 @@ function AdminUserRow({ user, isSelf, onChanged }) {
               <Button
                 variant="outline"
                 size="sm"
-                className="text-danger border-danger/40 hover:bg-danger/10"
+                className="text-danger border-danger/40 hover:bg-danger/10 hover:text-danger"
               >
                 Excluir conta
               </Button>
@@ -122,7 +122,22 @@ export default function Admin() {
   const [users, setUsers] = useState([]);
   const [query, setQuery] = useState("");
   const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(null);
+  // Dois erros, não um: `loadError` só existe enquanto a tela nunca mostrou
+  // dado nenhum (substitui a página, com botão de tentar de novo). Depois da
+  // primeira carga bem-sucedida, uma releitura que falhar (chamada de novo
+  // pelas ações da linha via `onChanged`) vira `refreshError` — a lista e as
+  // métricas continuam montadas (ainda são dados válidos), só um aviso
+  // inline aparece. Sem essa separação, uma falha transitória de releitura
+  // depois de uma exclusão bem-sucedida apagava a tela inteira e trocava o
+  // <h1> por uma frase vermelha, na única tela cujo trabalho é ação
+  // destrutiva de operador.
+  const [loadError, setLoadError] = useState(null);
+  const [refreshError, setRefreshError] = useState(null);
+  // Ref, não estado: só decide qual mensagem de erro usar, nunca é lida no
+  // JSX, e um ref evita fechar `load` sobre um `metrics` desatualizado (o que
+  // obrigaria a listar `metrics` nas deps do useEffect de mount só por causa
+  // deste `if`).
+  const hasLoadedRef = useRef(false);
 
   async function load() {
     try {
@@ -132,9 +147,18 @@ export default function Admin() {
       ]);
       setMetrics(metricsRes.data);
       setUsers(usersRes.data);
-      setError(null);
+      setLoadError(null);
+      setRefreshError(null);
+      hasLoadedRef.current = true;
     } catch (err) {
-      setError(apiErrorMessage(err, "Não foi possível carregar os dados de admin."));
+      const message = apiErrorMessage(err, "Não foi possível carregar os dados de admin.");
+      if (hasLoadedRef.current) {
+        setRefreshError(
+          "Não foi possível atualizar os dados agora. Os números podem estar desatualizados.",
+        );
+      } else {
+        setLoadError(message);
+      }
     } finally {
       setLoading(false);
     }
@@ -168,12 +192,15 @@ export default function Admin() {
     );
   }
 
-  if (error) {
+  if (loadError) {
     return (
-      <div className="max-w-5xl mx-auto">
+      <div className="max-w-5xl mx-auto space-y-4">
         <p role="alert" className="text-danger text-sm">
-          {error}
+          {loadError}
         </p>
+        <Button variant="outline" onClick={load}>
+          Tentar novamente
+        </Button>
       </div>
     );
   }
@@ -182,6 +209,7 @@ export default function Admin() {
     metrics.ai_calls_project_limit > 0
       ? metrics.ai_calls_today / metrics.ai_calls_project_limit
       : 0;
+  const iaTone = iaProporcao >= 1 ? "danger" : iaProporcao >= 0.8 ? "warning" : undefined;
 
   return (
     <div className="max-w-5xl mx-auto space-y-5">
@@ -201,9 +229,15 @@ export default function Admin() {
         <MetricCard
           label="IA hoje"
           value={`${metrics.ai_calls_today} / ${metrics.ai_calls_project_limit}`}
-          danger={iaProporcao >= 0.8}
+          tone={iaTone}
         />
       </div>
+
+      {refreshError && (
+        <p role="alert" className="text-warning text-xs">
+          {refreshError}
+        </p>
+      )}
 
       <div className="glass p-6">
         <div className="flex items-center gap-3 mb-5">

--- a/frontend/src/pages/Admin.test.jsx
+++ b/frontend/src/pages/Admin.test.jsx
@@ -49,6 +49,20 @@ const USERS = [
     cancel_at_period_end: false,
     is_admin: false,
   },
+  // O admin logado (beforeEach) aparece na própria lista devolvida pela API,
+  // como no backend de verdade — precisa disto para testar que a própria
+  // linha não ganha botão de ação.
+  {
+    id: "admin1",
+    name: "Root",
+    email: "root@norby.dev",
+    created_at: "2025-01-01T00:00:00Z",
+    premium_until: null,
+    ai_trial_ends_at: null,
+    subscription_status: null,
+    cancel_at_period_end: false,
+    is_admin: true,
+  },
 ];
 
 function renderAdmin() {
@@ -57,6 +71,14 @@ function renderAdmin() {
       <Admin />
     </MemoryRouter>,
   );
+}
+
+// Timeout maior: o Dialog do Base UI monta em portal, e a máquina de CI pode
+// demorar mais que o padrão de 1s sob carga.
+async function fillPassword(value) {
+  fireEvent.change(await screen.findByLabelText("Sua senha atual", {}, { timeout: 3000 }), {
+    target: { value },
+  });
 }
 
 describe("Admin", () => {
@@ -116,23 +138,20 @@ describe("Admin", () => {
     renderAdmin();
     await screen.findByText("alice@test.com");
 
-    const linha = screen.getByText("alice@test.com").closest("[data-user-row]");
+    const linha = screen.getByText("alice@test.com").closest("li");
     fireEvent.click(
       within(linha).getByRole("button", { name: "Cancelar assinatura" }),
     );
 
-    // Timeout maior: o Dialog do Base UI monta em portal, e a máquina de CI
-    // pode demorar mais que o padrão de 1s sob carga.
-    fireEvent.change(await screen.findByLabelText("Sua senha atual", {}, { timeout: 3000 }), {
-      target: { value: "secret123" },
-    });
+    await fillPassword("secret123");
     fireEvent.click(screen.getByRole("button", { name: "Confirmar" }));
 
     await waitFor(() =>
       expect(adminApi.cancelSubscription).toHaveBeenCalledWith("u1", "secret123"),
     );
-    // A lista recarrega após o sucesso.
+    // A lista E as métricas recarregam após o sucesso.
     await waitFor(() => expect(adminApi.users).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(adminApi.metrics).toHaveBeenCalledTimes(2));
   });
 
   it("senha errada mostra o erro sem fechar o diálogo", async () => {
@@ -142,18 +161,48 @@ describe("Admin", () => {
     renderAdmin();
     await screen.findByText("alice@test.com");
 
-    const linha = screen.getByText("alice@test.com").closest("[data-user-row]");
+    const linha = screen.getByText("alice@test.com").closest("li");
     fireEvent.click(within(linha).getByRole("button", { name: "Excluir conta" }));
 
-    // Timeout maior: o Dialog do Base UI monta em portal, e a máquina de CI
-    // pode demorar mais que o padrão de 1s sob carga.
-    fireEvent.change(await screen.findByLabelText("Sua senha atual", {}, { timeout: 3000 }), {
-      target: { value: "senhaerrada" },
-    });
+    await fillPassword("senhaerrada");
     fireEvent.click(screen.getByRole("button", { name: "Confirmar" }));
 
     expect(await screen.findByText("Senha incorreta")).toBeInTheDocument();
     // O diálogo continua aberto: o campo de senha ainda está na tela.
     expect(screen.getByLabelText("Sua senha atual")).toBeInTheDocument();
+  });
+
+  it("a própria linha do admin logado não tem botão de ação", async () => {
+    renderAdmin();
+
+    const linha = (await screen.findByText("root@norby.dev")).closest("li");
+    expect(within(linha).queryByRole("button")).not.toBeInTheDocument();
+  });
+
+  it("mantém a tela montada e avisa quando a releitura falha após uma ação bem-sucedida", async () => {
+    adminApi.deleteUser.mockResolvedValue({ status: 204 });
+    renderAdmin();
+    await screen.findByText("alice@test.com");
+
+    const linha = screen.getByText("alice@test.com").closest("li");
+    fireEvent.click(within(linha).getByRole("button", { name: "Excluir conta" }));
+    await fillPassword("secret123");
+
+    // A exclusão em si funciona; só a releitura seguinte falha desta vez.
+    adminApi.users.mockRejectedValueOnce(new Error("falha de rede"));
+    fireEvent.click(screen.getByRole("button", { name: "Confirmar" }));
+
+    // O diálogo fecha: a ação pedida teve sucesso.
+    await waitFor(() =>
+      expect(screen.queryByLabelText("Sua senha atual")).not.toBeInTheDocument(),
+    );
+    // Cabeçalho e lista continuam na tela — não é o estado de erro de carga
+    // (que substitui a página inteira).
+    expect(screen.getByRole("heading", { name: "Admin" })).toBeInTheDocument();
+    expect(screen.getByText("alice@test.com")).toBeInTheDocument();
+    // Aviso inline de que os números podem estar desatualizados.
+    expect(
+      await screen.findByText(/não foi possível atualizar os dados/i),
+    ).toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -318,7 +318,7 @@ export default function Settings() {
             onClick={handleExport}
             disabled={exporting}
             variant="outline"
-            className="shrink-0 border-accent/40 bg-transparent text-accent hover:bg-accent/10"
+            className="shrink-0 border-accent/40 bg-transparent text-accent hover:bg-accent/10 hover:text-accent"
           >
             <Download size={15} /> {exporting ? "Exportando…" : "Exportar"}
           </Button>


### PR DESCRIPTION
Review fix round for #136, which was merged before this commit landed. Production has been serving the admin page with the two defects below since that merge.

**A failed refresh wiped the page after a destructive action.** The page kept one error state for two different failures. A transient failure of the reload that follows a delete or a cancel closed the dialog as if everything had worked, then replaced the header, the metric cards and the user list with a single red sentence and no way to retry. On the one screen whose whole job is destructive operator actions, "did my delete land?" became unanswerable without a full reload. The two failures are now separate: only a failed **initial** load replaces the page, and it offers a retry button; a refresh that fails after a successful action leaves the list and the metrics mounted and shows an inline warning that the numbers may be stale. The action's own failure still reports inside the dialog, unchanged.

**The destructive button lost its colour exactly on hover.** A `text-*` colour on a `variant="outline"` Button is overridden by the variant's own `hover:text-foreground`, which wins on specificity, so "Excluir conta" turned neutral the moment the pointer arrived. The same latent bug already existed on the "Exportar" button in `Settings.jsx`, so both are fixed here (`hover:text-danger`, `hover:text-accent`), verified live with `getComputedStyle` before and after hover.

Smaller items from the same review:

- The AI counter uses the `warning` token between 80% and 99% of the project limit and `danger` from 100%, so approaching the cap and hitting it no longer look identical.
- `is_admin` and `cancel_at_period_end` arrive in the payload and were dropped; the row now shows an "Admin" marker and "cancela no fim do período".
- The password field uses `autoComplete="new-password"`, the value Chromium honours for credential fields, instead of `"off"`, which it ignores.
- A test-only `data-user-row` attribute left production markup; `App.test.jsx` restores the history entry it pushes; `Sidebar.jsx` derives `is_admin` from the store subscription it already had.
- Two assertions the page's rules deserved: the signed-in admin's own row offers no actions, and a successful action reloads the metrics as well as the list.

## Test plan

- [x] `npm run lint` — clean
- [x] `npx vitest run` — 187/187 passing, run twice
- [x] `npm run build` — succeeds
- [x] Hover colours checked live in Chromium with `getComputedStyle` on both buttons, in both themes

Refs #23
