### PR TITLE
feat(search): server-side transaction search and a daily AI usage endpoint

### DIFF
--- a/backend/app/routers/ai.py
+++ b/backend/app/routers/ai.py
@@ -5,7 +5,14 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.dependencies import get_db, get_current_user, require_ai_access
 from app.limiter import limiter, user_key
 from app.models.sql_models import User
-from app.services.ai_service import get_or_generate_insight, chat_with_ai
+from app.services.ai_service import (
+    get_or_generate_insight,
+    chat_with_ai,
+    uso_de_hoje,
+    cota_zera_em,
+    DAILY_TOKEN_CAP,
+    DAILY_CALL_CAP,
+)
 from app.services.plan_service import PlanRefused
 from app.schemas.ai import (
     ChatMessage,
@@ -13,6 +20,7 @@ from app.schemas.ai import (
     ChatResponse,
     ChatSessionSummary,
     ChatSessionDetail,
+    AiUsageResponse,
 )
 from app.database import chat_history_collection
 import logging
@@ -44,7 +52,28 @@ async def get_dashboard_insight(
             "suggested_action": None,
             "error": "IA temporariamente indisponível"
         }
-        
+
+
+@router.get("/usage", response_model=AiUsageResponse)
+@limiter.limit("30/minute", key_func=user_key)
+async def get_usage(
+    request: Request,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Contadores do dia + os dois tetos. `get_current_user`, e não
+    `require_ai_access`: ler o próprio consumo não gasta token, e recusar
+    obrigaria a tela a tratar 403 para mostrar um número inofensivo."""
+    tokens, calls = await uso_de_hoje(db, str(current_user.id))
+    return {
+        "tokens": tokens,
+        "calls": calls,
+        "token_cap": DAILY_TOKEN_CAP,
+        "call_cap": DAILY_CALL_CAP,
+        "resets_at": cota_zera_em(),
+    }
+
+
 @router.post(
     "/chat",
     response_model=ChatResponse,

--- a/backend/app/routers/transactions.py
+++ b/backend/app/routers/transactions.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter, Depends, Query, HTTPException, status, Response
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy import func, select
+from sqlalchemy import func, or_, select
 from uuid import UUID
 from datetime import date
 from typing import Optional
@@ -12,6 +12,34 @@ from app.services.wallet_service import get_owned_wallet
 from app.services.goal_service import current_month_range
 
 router = APIRouter(prefix="/transactions", tags=["Transactions"])
+
+
+# Busca sem acento e sem caixa, do lado do banco (issue #24).
+#
+# `translate` em vez da extensão `unaccent` por três motivos: não exige
+# CREATE EXTENSION, que o Neon pode recusar e derrubaria o deploy; é
+# IMMUTABLE, então um índice funcional em cima dela é possível no dia em que
+# o volume pedir (a `unaccent` é STABLE e precisaria de um invólucro); e o
+# conjunto de caracteres do pt-BR cabe numa constante. As duas strings TÊM
+# que ter o mesmo comprimento.
+_ACENTOS = "áàâãäéèêëíìîïóòôõöúùûüç"
+_SEM_ACENTO = "aaaaaeeeeiiiiooooouuuuc"
+_TABELA = str.maketrans(_ACENTOS, _SEM_ACENTO)
+
+
+def normalizar(texto: str) -> str:
+    """Mesma normalização do lado do Python, para o termo buscado."""
+    return texto.lower().translate(_TABELA)
+
+
+def _escapar_like(texto: str) -> str:
+    """`%` e `_` são curingas do LIKE. Sem escapar, buscar `%` casa com TUDO —
+    um 'listar tudo' disfarçado de busca."""
+    return texto.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+
+
+def _sem_acento(coluna):
+    return func.translate(func.lower(coluna), _ACENTOS, _SEM_ACENTO)
 
 
 # ponytail: locks são adquiridos na ordem transação → carteira antiga → carteira
@@ -54,6 +82,7 @@ async def list_transactions(
     # Faixa obrigatória: sem ela, date(year, month, 1) levanta ValueError para
     # ano fora do suportado e o erro vira 500 no handler global.
     year: Optional[int] = Query(None, ge=1900, le=2100),
+    q: Optional[str] = Query(None, max_length=100),
     limit: int = Query(200, ge=1, le=500),
     offset: int = Query(0, ge=0),
     current_user: User = Depends(get_current_user),
@@ -64,6 +93,16 @@ async def list_transactions(
 
     if category:
         filters.append(Transaction.category.ilike(f"%{category}%"))
+    if q:
+        # Descrição é nula em muita transação: `translate(NULL)` é NULL e NULL
+        # LIKE nunca é verdadeiro, então o `or_` resolve sozinho, sem coalesce.
+        alvo = f"%{_escapar_like(normalizar(q))}%"
+        filters.append(
+            or_(
+                _sem_acento(Transaction.description).like(alvo, escape="\\"),
+                _sem_acento(Transaction.category).like(alvo, escape="\\"),
+            )
+        )
     if type:
         filters.append(Transaction.type == type)
     # month e year andam juntos. Aceitar um sozinho devolvia 200 com o filtro

--- a/backend/app/routers/transactions.py
+++ b/backend/app/routers/transactions.py
@@ -92,7 +92,7 @@ async def list_transactions(
     filters = [Transaction.user_id == current_user.id]
 
     if category:
-        filters.append(Transaction.category.ilike(f"%{category}%"))
+        filters.append(Transaction.category.ilike(f"%{_escapar_like(category)}%", escape="\\"))
     if q:
         # Descrição é nula em muita transação: `translate(NULL)` é NULL e NULL
         # LIKE nunca é verdadeiro, então o `or_` resolve sozinho, sem coalesce.

--- a/backend/app/schemas/ai.py
+++ b/backend/app/schemas/ai.py
@@ -43,3 +43,17 @@ class ChatMessage(BaseModel):
     # UUID em vez de str: o tipo nativo já valida formato e tamanho, e o código
     # sempre gerou str(uuid4()) — o formato no Mongo não muda.
     session_id: UUID | None = None
+
+
+class AiUsageResponse(BaseModel):
+    """Uso do dia e os dois tetos, para o medidor de Configurações (#25).
+
+    Os tetos vão na resposta em vez de serem constantes no frontend: eles são
+    decisão do backend (ADR 0003) e mudam por PR lá, não aqui.
+    """
+
+    tokens: int
+    calls: int
+    token_cap: int
+    call_cap: int
+    resets_at: datetime

--- a/backend/app/services/ai_service.py
+++ b/backend/app/services/ai_service.py
@@ -104,8 +104,8 @@ def _tokens_usados(resposta) -> int:
     )
 
 
-async def _exigir_cota(db: AsyncSession, user_id: str) -> None:
-    """Recusa ANTES da chamada se o dia já estourou um dos dois tetos.
+async def uso_de_hoje(db: AsyncSession, user_id: str) -> tuple[int, int]:
+    """(tokens, chamadas) do dia da cota. Zero quando ainda não há linha.
 
     select de colunas, não `db.get`: nada passa pelo identity map, então uma
     leitura nunca devolve contadores velhos de um upsert anterior na mesma
@@ -119,11 +119,15 @@ async def _exigir_cota(db: AsyncSession, user_id: str) -> None:
             )
         )
     ).one_or_none()
-    if linha and (linha.tokens >= DAILY_TOKEN_CAP or linha.calls >= DAILY_CALL_CAP):
-        # Sem texto do usuário: id e contadores bastam para ver quem bate no teto.
+    return (linha.tokens, linha.calls) if linha else (0, 0)
+
+
+async def _exigir_cota(db: AsyncSession, user_id: str) -> None:
+    """Recusa ANTES da chamada se o dia já estourou um dos dois tetos."""
+    tokens, calls = await uso_de_hoje(db, user_id)
+    if tokens >= DAILY_TOKEN_CAP or calls >= DAILY_CALL_CAP:
         logger.warning(
-            "Cota diária de IA atingida (user=%s, tokens=%d, calls=%d)",
-            user_id, linha.tokens, linha.calls,
+            "Cota diária de IA atingida (user=%s, tokens=%d, calls=%d)", user_id, tokens, calls
         )
         raise PlanRefused("AI_DAILY_CAP_REACHED", DAILY_CAP_MESSAGE, resets_at=cota_zera_em())
 

--- a/backend/tests/test_ai_usage.py
+++ b/backend/tests/test_ai_usage.py
@@ -65,4 +65,8 @@ async def test_usage_is_readable_without_ai_access(make_auth_client, db_session,
     user.ai_trial_ends_at = datetime.now(timezone.utc) - timedelta(days=1)
     await db_session.commit()
 
+    # Prova que o portão está mesmo fechado neste setup (senão o 200 abaixo
+    # não provaria nada: passaria igual se a fixture do paywall parasse de
+    # funcionar em silêncio).
+    assert (await alice.get("/ai/insight")).status_code == 403
     assert (await alice.get("/ai/usage")).status_code == 200

--- a/backend/tests/test_ai_usage.py
+++ b/backend/tests/test_ai_usage.py
@@ -1,0 +1,68 @@
+"""Leitura do próprio uso diário de IA (issue #25).
+
+Contadores próprios, sem portão de plano: ler o que já foi gasto não gasta
+nada. Quem escreve esses números é a cota do `ai_service` (ADR 0003).
+"""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import select
+
+from app.config import get_settings
+import app.services.ai_service as ai
+from app.models.sql_models import AiUsageDaily, User
+
+
+@pytest.fixture
+def paywall_ligado():
+    settings = get_settings()
+    antes = settings.paywall_enabled
+    settings.paywall_enabled = True
+    yield
+    settings.paywall_enabled = antes
+
+
+async def _usuario(ac, db_session) -> User:
+    me = (await ac.get("/auth/me")).json()
+    return (await db_session.execute(select(User).where(User.id == me["id"]))).scalar_one()
+
+
+@pytest.mark.asyncio
+async def test_usage_starts_at_zero_and_reports_the_caps(make_auth_client):
+    alice = await make_auth_client("Alice")
+
+    res = await alice.get("/ai/usage")
+    assert res.status_code == 200, res.text
+    corpo = res.json()
+    assert (corpo["tokens"], corpo["calls"]) == (0, 0)
+    assert corpo["token_cap"] == ai.DAILY_TOKEN_CAP
+    assert corpo["call_cap"] == ai.DAILY_CALL_CAP
+    assert datetime.fromisoformat(corpo["resets_at"]) > datetime.now(timezone.utc)
+
+
+@pytest.mark.asyncio
+async def test_usage_reflects_todays_row_and_ignores_yesterdays(make_auth_client, db_session):
+    alice = await make_auth_client("Alice")
+    user = await _usuario(alice, db_session)
+    db_session.add(AiUsageDaily(user_id=user.id, day=ai.dia_da_cota(), tokens=2100, calls=3))
+    db_session.add(AiUsageDaily(
+        user_id=user.id, day=ai.dia_da_cota() - timedelta(days=1), tokens=99_000, calls=90,
+    ))
+    await db_session.commit()
+
+    corpo = (await alice.get("/ai/usage")).json()
+    assert (corpo["tokens"], corpo["calls"]) == (2100, 3)
+
+
+@pytest.mark.asyncio
+async def test_usage_is_readable_without_ai_access(make_auth_client, db_session, paywall_ligado):
+    # Sem portão de plano de propósito: são os contadores da própria pessoa, e
+    # a tela decide se mostra. 403 aqui obrigaria o frontend a tratar recusa
+    # para ler um número que não custa nada.
+    alice = await make_auth_client("Alice")
+    user = await _usuario(alice, db_session)
+    user.ai_trial_ends_at = datetime.now(timezone.utc) - timedelta(days=1)
+    await db_session.commit()
+
+    assert (await alice.get("/ai/usage")).status_code == 200

--- a/backend/tests/test_transactions.py
+++ b/backend/tests/test_transactions.py
@@ -449,6 +449,11 @@ async def test_search_treats_wildcards_as_text_and_stays_scoped_to_the_user(make
     dela = await alice.get("/transactions/", params={"q": "feira"})
     assert [t["description"] for t in dela.json()] == ["Feira da semana"]
 
+    # Mesmo curinga, mas no filtro `category` pré-existente: sem escape ele
+    # também casaria com tudo, o mesmo "listar tudo" disfarçado que o `q` evita.
+    curinga_categoria = await alice.get("/transactions/", params={"category": "%"})
+    assert curinga_categoria.json() == []
+
 
 @pytest.mark.asyncio
 async def test_search_does_not_break_on_a_null_description(make_auth_client):

--- a/backend/tests/test_transactions.py
+++ b/backend/tests/test_transactions.py
@@ -357,3 +357,111 @@ async def test_total_count_respects_filters(make_auth_client):
     res = await ac.get("/transactions/?type=INCOME")
 
     assert res.headers["x-total-count"] == "1"
+
+
+async def _carteira(ac, nome="Main"):
+    res = await ac.post("/wallets/", json={"name": nome, "balance": "1000.00"})
+    assert res.status_code == 201, res.text
+    return res.json()["id"]
+
+
+async def _transacao(ac, wallet_id, *, category, description, amount="10.00"):
+    res = await ac.post(
+        "/transactions/",
+        json={
+            "wallet_id": wallet_id,
+            "type": "EXPENSE",
+            "amount": amount,
+            "category": category,
+            "description": description,
+            "date": "2026-09-01",
+        },
+    )
+    assert res.status_code == 201, res.text
+    return res.json()["id"]
+
+
+@pytest.mark.asyncio
+async def test_search_matches_description_and_category(make_auth_client):
+    alice = await make_auth_client("Alice")
+    w = await _carteira(alice)
+    await _transacao(alice, w, category="Mercado", description="Feira da semana")
+    await _transacao(alice, w, category="Transporte", description="Uber para o centro")
+
+    por_descricao = await alice.get("/transactions/", params={"q": "feira"})
+    assert [t["description"] for t in por_descricao.json()] == ["Feira da semana"]
+
+    por_categoria = await alice.get("/transactions/", params={"q": "transp"})
+    assert [t["category"] for t in por_categoria.json()] == ["Transporte"]
+
+
+@pytest.mark.asyncio
+async def test_search_ignores_case_and_accents(make_auth_client):
+    # As categorias reais do app têm acento ("Alimentação", "Saúde", "Salário")
+    # e quem digita no celular normalmente não põe. Sem isto a busca não acha
+    # justamente as categorias que o próprio app criou.
+    alice = await make_auth_client("Alice")
+    w = await _carteira(alice)
+    await _transacao(alice, w, category="Alimentação", description="Almoço no Sabor & Saúde")
+
+    for termo in ("alimentacao", "ALIMENTAÇÃO", "saude", "almoco"):
+        res = await alice.get("/transactions/", params={"q": termo})
+        assert len(res.json()) == 1, (termo, res.text)
+
+
+@pytest.mark.asyncio
+async def test_search_combines_with_the_existing_filters_and_the_total(make_auth_client):
+    # Busca DENTRO do filtro ativo, não no lugar dele. E o X-Total-Count conta
+    # o resultado da busca: sem isso a paginação diria "1 de 7 páginas" para um
+    # resultado de uma linha.
+    alice = await make_auth_client("Alice")
+    w = await _carteira(alice)
+    await _transacao(alice, w, category="Mercado", description="Feira da semana")
+    receita = await alice.post(
+        "/transactions/",
+        json={
+            "wallet_id": w, "type": "INCOME", "amount": "50.00",
+            "category": "Mercado", "description": "Feira devolvida", "date": "2026-09-01",
+        },
+    )
+    assert receita.status_code == 201, receita.text
+
+    res = await alice.get("/transactions/", params={"q": "feira", "type": "EXPENSE"})
+    assert len(res.json()) == 1
+    assert res.json()[0]["type"] == "EXPENSE"
+    assert res.headers["X-Total-Count"] == "1"
+
+
+@pytest.mark.asyncio
+async def test_search_treats_wildcards_as_text_and_stays_scoped_to_the_user(make_auth_client):
+    # `%` sem escape casaria com tudo, transformando a busca num "listar tudo"
+    # disfarçado. E a busca nunca pode furar o escopo do dono.
+    alice = await make_auth_client("Alice")
+    bob = await make_auth_client("Bob")
+    wa = await _carteira(alice)
+    wb = await _carteira(bob, "Bob Main")
+    await _transacao(alice, wa, category="Mercado", description="Feira da semana")
+    await _transacao(bob, wb, category="Mercado", description="Feira do Bob")
+
+    curinga = await alice.get("/transactions/", params={"q": "%"})
+    assert curinga.json() == []
+
+    dela = await alice.get("/transactions/", params={"q": "feira"})
+    assert [t["description"] for t in dela.json()] == ["Feira da semana"]
+
+
+@pytest.mark.asyncio
+async def test_search_does_not_break_on_a_null_description(make_auth_client):
+    # `translate(NULL)` é NULL e NULL LIKE nunca é verdadeiro: uma transação
+    # sem descrição não pode quebrar a busca nem aparecer como falso positivo.
+    alice = await make_auth_client("Alice")
+    w = await _carteira(alice)
+    await _transacao(alice, w, category="Mercado", description=None)
+
+    por_categoria = await alice.get("/transactions/", params={"q": "mercado"})
+    assert por_categoria.status_code == 200
+    assert len(por_categoria.json()) == 1
+
+    por_termo_qualquer = await alice.get("/transactions/", params={"q": "feira"})
+    assert por_termo_qualquer.status_code == 200
+    assert por_termo_qualquer.json() == []


### PR DESCRIPTION
## Summary

Two small, independent backend additions shipped together because neither
justifies its own PR and both are prerequisites of the same later frontend
task (#24, #25).

**`GET /transactions/?q=`** — an optional search term (max 100 chars) that
matches against `description` or `category`, combining with the existing
`category`/`type`/`month`/`year` filters (it searches *within* the active
filter, not instead of it) and counted in the existing `X-Total-Count`
header. No new index, no migration: `ILIKE`-equivalent scans over a few
hundred rows cost nothing, and an index can be added later without changing
the query shape.

- **Accent- and case-insensitive**: normalization is done with
  `func.translate(func.lower(column), ACCENTS, PLAIN)` on the DB side
  (mirrored in Python for the search term), not the `unaccent` extension.
  Three reasons: `translate` needs no `CREATE EXTENSION`, which Neon may
  refuse and would take down the deploy; `translate` is `IMMUTABLE`, so a
  functional index over it is possible the day volume asks for one, while
  `unaccent` is `STABLE` and would need an immutable wrapper first; and the
  pt-BR accented character set is small enough to live in a constant.
- **Wildcard-safe**: `%` and `_` are escaped before building the `LIKE`
  pattern, so searching for a literal `%` does not silently become "list
  everything".
- **NULL descriptions**: `translate(NULL, ...)` is `NULL`, and `NULL LIKE`
  is never true, so `or_()` already excludes transactions with no
  description without needing a `COALESCE`. Verified with a test that
  creates a transaction with `description: null` and confirms it is neither
  dropped from an unrelated search nor produced as a false match.

**`GET /ai/usage`** — returns today's AI token and call counters plus both
daily ceilings (`{tokens, calls, token_cap, call_cap, resets_at}`), for a
usage meter on the Settings screen. It depends on `get_current_user` only,
not `require_ai_access`: reading one's own counters costs nothing, and
gating it behind the plan check would force the frontend to handle a 403
just to show a number that isn't a Gemini call. The quota lookup that used
to live inline in `_exigir_cota` is extracted into `uso_de_hoje(db, user_id)
-> tuple[int, int]` so both the enforcement path and this new read path
share one query; `_exigir_cota`'s behavior (and `tests/test_ai_quota.py`)
is unchanged.

## Test plan

- [x] `docker exec norby_backend pytest -q tests/test_transactions.py tests/test_ai_usage.py tests/test_ai_quota.py` — all green
- [x] `docker exec norby_backend pytest -q` (full suite) — 369 passed
- [x] Manually confirmed the NULL-description case does not break or falsely match search

Closes #24