### PR TITLE
feat(search): reports search hits the server, and Settings shows today's AI usage

### DIFF
--- a/frontend/src/api/ai.js
+++ b/frontend/src/api/ai.js
@@ -5,4 +5,5 @@ export const aiApi = {
   chat: (data) => api.post("/ai/chat", data),
   getSessions: () => api.get("/ai/chat/sessions"),
   getSession: (id) => api.get(`/ai/chat/sessions/${encodeURIComponent(id)}`),
+  getUsage: () => api.get("/ai/usage"),
 };

--- a/frontend/src/components/shared/PlanCard.jsx
+++ b/frontend/src/components/shared/PlanCard.jsx
@@ -4,10 +4,24 @@ import { CreditCard } from "lucide-react";
 
 import { billingApi } from "@/api/billing";
 import { authApi } from "@/api/auth";
+import { aiApi } from "@/api/ai";
 import { useAuthStore } from "@/store/authStore";
 import { apiErrorMessage, formatDateBR } from "@/lib/utils";
 import { PRECO_MENSAL } from "@/lib/plano";
 import { Button } from "@/components/ui/button";
+
+/**
+ * Formata `resets_at` (ISO, UTC) no fuso do navegador — a pessoa quer saber
+ * quando a cota libera NA HORA DELA, não em UTC-8 (o dia da cota do backend).
+ */
+function formatResetsAt(resetsAt) {
+  return new Date(resetsAt).toLocaleString("pt-BR", {
+    day: "2-digit",
+    month: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
 
 /**
  * Estado do plano e as duas portas de saída para o Stripe (issue #46).
@@ -29,6 +43,7 @@ export default function PlanCard() {
   const [searchParams, setSearchParams] = useSearchParams();
   const [carregando, setCarregando] = useState("");
   const [erro, setErro] = useState("");
+  const [uso, setUso] = useState(null);
 
   // A VOLTA do Checkout. O Stripe devolve a pessoa para cá com o id da sessão
   // na URL, e o webhook pode ainda não ter chegado — sem isto ela volta de uma
@@ -71,6 +86,23 @@ export default function PlanCard() {
     plan?.premium_until && new Date(plan.premium_until) > new Date(),
   );
 
+  // Uso do dia para o medidor (#25). Só busca com acesso à IA — sem ele o
+  // cartão já não teria nada pra mostrar aqui. Falha de rede não vira erro na
+  // tela do plano: o medidor é informativo, então some em silêncio.
+  useEffect(() => {
+    if (!plan?.ai_allowed) return;
+    let vivo = true;
+    aiApi
+      .getUsage()
+      .then(({ data }) => {
+        if (vivo) setUso(data);
+      })
+      .catch(() => {});
+    return () => {
+      vivo = false;
+    };
+  }, [plan?.ai_allowed]);
+
   async function abrir(qual) {
     setErro("");
     setCarregando(qual);
@@ -111,6 +143,16 @@ export default function PlanCard() {
   // gratuito" sem ação vira ruído na tela de quem não pode fazer nada com ele.
   if (!plan || (!restringido && !temAssinatura)) return null;
 
+  // A barra é movida pelo teto mais próximo de estourar (tokens ou chamadas),
+  // não pela média dos dois: são limites independentes, e o primeiro a bater
+  // é o que de fato bloqueia. Mesmos limiares da métrica "IA hoje" do Admin.
+  const razaoTokens = uso && uso.token_cap > 0 ? uso.tokens / uso.token_cap : 0;
+  const razaoChamadas = uso && uso.call_cap > 0 ? uso.calls / uso.call_cap : 0;
+  const razaoUso = Math.max(razaoTokens, razaoChamadas);
+  const percentUso = Math.min(100, Math.round(razaoUso * 100));
+  const corBarra =
+    razaoUso >= 1 ? "bg-danger" : razaoUso >= 0.8 ? "bg-warning" : "bg-accent-fill";
+
   return (
     <div className="glass p-6">
       <div className="flex items-center gap-3 mb-5">
@@ -121,6 +163,32 @@ export default function PlanCard() {
       </div>
 
       <p className="text-sm text-content-2 leading-relaxed">{descricao()}</p>
+
+      {plan.ai_allowed && uso && (
+        <div className="mt-4">
+          <div
+            className="h-2 rounded-full bg-surface-inset overflow-hidden"
+            role="progressbar"
+            aria-label="Uso da IA hoje"
+            aria-valuenow={percentUso}
+            aria-valuemin={0}
+            aria-valuemax={100}
+          >
+            <div
+              className={`h-full rounded-full ${corBarra} transition-all duration-500`}
+              style={{ width: `${percentUso}%` }}
+            />
+          </div>
+          <p className="mt-2 text-xs text-content-3">
+            {uso.calls} de {uso.call_cap} conversas ·{" "}
+            {uso.tokens.toLocaleString("pt-BR")} de{" "}
+            {uso.token_cap.toLocaleString("pt-BR")} tokens
+          </p>
+          <p className="mt-1 text-xs text-content-3">
+            A cota diária renova em {formatResetsAt(uso.resets_at)}.
+          </p>
+        </div>
+      )}
 
       {erro && (
         <p role="alert" className="text-xs text-danger mt-3">

--- a/frontend/src/components/shared/PlanCard.jsx
+++ b/frontend/src/components/shared/PlanCard.jsx
@@ -152,6 +152,14 @@ export default function PlanCard() {
   const percentUso = Math.min(100, Math.round(razaoUso * 100));
   const corBarra =
     razaoUso >= 1 ? "bg-danger" : razaoUso >= 0.8 ? "bg-warning" : "bg-accent-fill";
+  // A cor não pode ser o único canal do estado (PRODUCT.md, semântica de cor):
+  // aria-valuetext nomeia a porcentagem e, perto do teto, também em palavra.
+  const textoValor =
+    razaoUso >= 1
+      ? `${percentUso}% — no teto`
+      : razaoUso >= 0.8
+        ? `${percentUso}% — perto do teto`
+        : `${percentUso}%`;
 
   return (
     <div className="glass p-6">
@@ -173,9 +181,10 @@ export default function PlanCard() {
             aria-valuenow={percentUso}
             aria-valuemin={0}
             aria-valuemax={100}
+            aria-valuetext={textoValor}
           >
             <div
-              className={`h-full rounded-full ${corBarra} transition-all duration-500`}
+              className={`h-full rounded-full ${corBarra} transition-[width] duration-200 ease-out`}
               style={{ width: `${percentUso}%` }}
             />
           </div>

--- a/frontend/src/components/shared/PlanCard.test.jsx
+++ b/frontend/src/components/shared/PlanCard.test.jsx
@@ -229,8 +229,8 @@ describe("PlanCard, medidor de uso de IA", () => {
     expect(barra).toHaveAttribute("aria-valuenow", "3");
 
     const cartao = screen.getByText("Plano").closest("div.glass");
-    expect(cartao.textContent).toContain("3");
-    expect(cartao.textContent).toContain("100");
+    expect(cartao.textContent).toContain("3 de 100 conversas");
+    expect(cartao.textContent).toContain("2.100 de 120.000 tokens");
   });
 
   it("a barra segue o teto mais próximo de estourar", async () => {

--- a/frontend/src/components/shared/PlanCard.test.jsx
+++ b/frontend/src/components/shared/PlanCard.test.jsx
@@ -4,6 +4,7 @@ import { MemoryRouter } from "react-router-dom";
 
 import { billingApi } from "@/api/billing";
 import { authApi } from "@/api/auth";
+import { aiApi } from "@/api/ai";
 import { useAuthStore } from "@/store/authStore";
 import { PRECO_MENSAL } from "@/lib/plano";
 import PlanCard from "./PlanCard";
@@ -18,6 +19,13 @@ vi.mock("@/api/billing", () => ({
 
 vi.mock("@/api/auth", () => ({
   authApi: { me: vi.fn() },
+}));
+
+vi.mock("@/api/ai", () => ({
+  // Rejeita por padrão: testes que não são sobre o medidor não precisam
+  // mockar sucesso, e a rejeição silenciosa é o próprio comportamento
+  // esperado de uma falha de rede (o medidor some, sem virar erro na tela).
+  aiApi: { getUsage: vi.fn(() => Promise.reject(new Error("not mocked"))) },
 }));
 
 const LIBERADO = {
@@ -190,5 +198,66 @@ describe("PlanCard", () => {
     expect(screen.getByRole("button", { name: "Gerenciar assinatura" })).toBeInTheDocument();
     const cartao = screen.getByText("Plano").closest("div.glass");
     expect(cartao.textContent).not.toContain(PRECO_MENSAL);
+  });
+});
+
+describe("PlanCard, medidor de uso de IA", () => {
+  // Card visível (subscription_status truthy) e com IA liberada, para o
+  // medidor ter onde aparecer.
+  const PREMIUM_COM_IA = {
+    ...LIBERADO,
+    ai_allowed: true,
+    subscription_status: "active",
+    premium_until: new Date(Date.now() + 20 * 86400000).toISOString(),
+  };
+
+  it("mostra o uso do dia", async () => {
+    aiApi.getUsage.mockResolvedValue({
+      data: {
+        tokens: 2100,
+        calls: 3,
+        token_cap: 120000,
+        call_cap: 100,
+        resets_at: "2026-09-07T05:00:00Z",
+      },
+    });
+    renderCard(PREMIUM_COM_IA);
+
+    const barra = await screen.findByRole("progressbar", { name: /uso da ia hoje/i });
+    // Razão de chamadas (3%) é maior que a de tokens (1,75%): a barra segue a
+    // chamada, não os tokens.
+    expect(barra).toHaveAttribute("aria-valuenow", "3");
+
+    const cartao = screen.getByText("Plano").closest("div.glass");
+    expect(cartao.textContent).toContain("3");
+    expect(cartao.textContent).toContain("100");
+  });
+
+  it("a barra segue o teto mais próximo de estourar", async () => {
+    aiApi.getUsage.mockResolvedValue({
+      data: {
+        tokens: 110000,
+        calls: 5,
+        token_cap: 120000,
+        call_cap: 100,
+        resets_at: "2026-09-07T05:00:00Z",
+      },
+    });
+    renderCard(PREMIUM_COM_IA);
+
+    // Tokens a 91,6% dominam a chamada a 5%: a barra tem de refletir o teto
+    // mais perto de estourar, não a média nem o primeiro dos dois.
+    const barra = await screen.findByRole("progressbar", { name: /uso da ia hoje/i });
+    expect(barra).toHaveAttribute("aria-valuenow", "92");
+  });
+
+  it("sem acesso à IA o medidor não aparece", async () => {
+    renderCard({ ...LIBERADO, ai_allowed: false, wallet_cap_applies: true });
+
+    // Espera o cartão terminar de montar antes de afirmar ausência: sem isto
+    // um efeito que disparasse tarde passaria despercebido.
+    await screen.findByText("Plano");
+    expect(aiApi.getUsage).not.toHaveBeenCalled();
+    expect(screen.queryByRole("progressbar")).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/Transactions.jsx
+++ b/frontend/src/pages/Transactions.jsx
@@ -117,11 +117,15 @@ export default function Transactions() {
   }, [filterType]);
 
   // Parâmetros do filtro de tipo + busca ativa, para toda chamada de load()
-  // que precisa preservá-los (paginação, reload após criar/editar/excluir).
-  function filtroAtivo() {
+  // que precisa preservá-los (paginação, reload após criar/editar/excluir,
+  // debounce da busca, clique nos botões de tipo). `tipo` é parametrizável
+  // porque o clique no botão de tipo passa o valor NOVO antes de setFilterType
+  // refletir no state — os demais chamadores usam o filtro atual por padrão.
+  // `trim()`: dois espaços não é uma busca válida.
+  function filtroAtivo(tipo = filterType) {
     return {
-      ...(filterType ? { type: filterType } : {}),
-      ...(search.length >= 2 ? { q: search } : {}),
+      ...(tipo ? { type: tipo } : {}),
+      ...(search.trim().length >= 2 ? { q: search.trim() } : {}),
     };
   }
 
@@ -150,14 +154,13 @@ export default function Transactions() {
       return;
     }
     const id = setTimeout(() => {
-      const tipo = filterTypeRef.current;
-      const params = {
-        ...(tipo ? { type: tipo } : {}),
-        ...(search.length >= 2 ? { q: search } : {}),
-      };
-      load(params, 0);
+      load(filtroAtivo(filterTypeRef.current), 0);
     }, 300);
     return () => clearTimeout(id);
+    // filtroAtivo de propósito fora: é recriada a cada render, e incluí-la
+    // reagendaria a busca a cada render (não só quando `search` muda). O tipo
+    // mais recente já chega pela ref, lida dentro do timeout, não do closure.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [search]);
 
   // Auto-seleciona a única carteira, sem sobrescrever uma escolha já feita nem
@@ -456,6 +459,7 @@ export default function Transactions() {
               placeholder="Buscar..."
               value={search}
               onChange={(e) => setSearch(e.target.value)}
+              maxLength={100}
               className="pl-9 bg-surface border-line/10 text-content placeholder:text-content-3"
             />
           </div>
@@ -467,13 +471,7 @@ export default function Transactions() {
                 aria-pressed={filterType === t}
                 onClick={() => {
                   setFilterType(t);
-                  load(
-                    {
-                      ...(t ? { type: t } : {}),
-                      ...(search.length >= 2 ? { q: search } : {}),
-                    },
-                    0,
-                  );
+                  load(filtroAtivo(t), 0);
                 }}
                 className={`rounded-xl px-3 py-2 text-sm transition-colors ${
                   filterType === t
@@ -487,9 +485,12 @@ export default function Transactions() {
           </div>
         </div>
 
-        {loading && (
-          <p className="pb-2 text-xs text-content-3">Carregando…</p>
-        )}
+        {/* Sempre montado (só o texto troca): sem isso a tabela pulava ~20px
+            a cada load, e o desmonte/remonte não é confiável para leitor de
+            tela anunciar — role="status" precisa do nó já existir no DOM. */}
+        <p role="status" className="pb-2 text-xs text-content-3">
+          {loading ? "Carregando…" : " "}
+        </p>
 
         <table className="hidden w-full md:table">
           <thead>
@@ -634,7 +635,7 @@ export default function Transactions() {
 
         {transactions.length === 0 && (
           <div className="text-center py-12 text-content-3 text-sm">
-            {search.length >= 2
+            {search.trim().length >= 2
               ? "Nenhuma transação encontrada para essa busca."
               : "Nenhuma transação encontrada."}
           </div>

--- a/frontend/src/pages/Transactions.jsx
+++ b/frontend/src/pages/Transactions.jsx
@@ -51,6 +51,7 @@ export default function Transactions() {
   const [filterType, setFilterType] = useState("");
   const [offset, setOffset] = useState(0);
   const [total, setTotal] = useState(0);
+  const [loading, setLoading] = useState(false);
   // false quando o header X-Total-Count não chegou (backend antigo, proxy,
   // CORS mal configurado): nesse caso `total` é só o length da página, não o
   // total real, e a UI não pode tratá-lo como se fosse.
@@ -81,6 +82,7 @@ export default function Transactions() {
 
   async function load(params = {}, novoOffset = 0) {
     const seq = ++requisicaoAtual.current;
+    setLoading(true);
     try {
       const res = await transactionsApi.list({
         ...params,
@@ -98,7 +100,29 @@ export default function Transactions() {
     } catch (err) {
       if (seq !== requisicaoAtual.current) return; // resposta obsoleta
       setServerError(apiErrorMessage(err, "Não foi possível carregar as transações."));
+    } finally {
+      if (seq === requisicaoAtual.current) setLoading(false);
     }
+  }
+
+  // Espelha `filterType` numa ref: o efeito de busca abaixo depende só de
+  // `search` (não de `filterType`), então o setTimeout já agendado por uma
+  // digitação precisa enxergar o filtro de tipo MAIS RECENTE quando disparar,
+  // não o que existia no instante em que foi agendado. A escrita mora num
+  // efeito à parte porque refs não podem ser lidas nem escritas durante o
+  // render (react-hooks/refs).
+  const filterTypeRef = useRef(filterType);
+  useEffect(() => {
+    filterTypeRef.current = filterType;
+  }, [filterType]);
+
+  // Parâmetros do filtro de tipo + busca ativa, para toda chamada de load()
+  // que precisa preservá-los (paginação, reload após criar/editar/excluir).
+  function filtroAtivo() {
+    return {
+      ...(filterType ? { type: filterType } : {}),
+      ...(search.length >= 2 ? { q: search } : {}),
+    };
   }
 
   useEffect(() => {
@@ -111,6 +135,30 @@ export default function Transactions() {
     // eslint-disable-next-line react-hooks/set-state-in-effect
     load();
   }, []);
+
+  // Busca no servidor, com espera de 300ms. Antes disto a busca era no
+  // CLIENTE, filtrando só a página já carregada (no máximo PAGE_SIZE itens
+  // por vez) — quem tivesse a transação numa página seguinte buscava e não
+  // achava nada, sem qualquer aviso de que havia mais dados fora da vista.
+  // Abaixo de 2 caracteres não busca: volta pra lista normal (sem `q`).
+  const primeiraRenderizacao = useRef(true);
+  useEffect(() => {
+    if (primeiraRenderizacao.current) {
+      // O mount já dispara load() acima; sem este corte o efeito repetiria a
+      // MESMA primeira página de novo, 300ms depois, à toa.
+      primeiraRenderizacao.current = false;
+      return;
+    }
+    const id = setTimeout(() => {
+      const tipo = filterTypeRef.current;
+      const params = {
+        ...(tipo ? { type: tipo } : {}),
+        ...(search.length >= 2 ? { q: search } : {}),
+      };
+      load(params, 0);
+    }, 300);
+    return () => clearTimeout(id);
+  }, [search]);
 
   // Auto-seleciona a única carteira, sem sobrescrever uma escolha já feita nem
   // atrapalhar a edição.
@@ -143,7 +191,7 @@ export default function Transactions() {
   // Delete desloca offsets (o item some e os seguintes sobem uma posição) —
   // voltar pra página 1 evita mostrar uma página com buracos. Mantido de
   // propósito, ver onSubmit para o caso de edição (que preserva a página).
-  const reload = () => load(filterType ? { type: filterType } : {}, 0);
+  const reload = () => load(filtroAtivo(), 0);
 
   const walletOptions = wallets.map((w) => ({ value: w.id, label: w.name }));
 
@@ -207,7 +255,7 @@ export default function Transactions() {
       // Editar não muda quantos itens existem: preserva a página atual em vez
       // de reload() (que sempre volta pra página 1).
       if (wasEditing) {
-        load(filterType ? { type: filterType } : {}, offset);
+        load(filtroAtivo(), offset);
       } else {
         reload();
       }
@@ -221,10 +269,8 @@ export default function Transactions() {
     reload();
   }
 
-  // A busca é client-side sobre a página carregada, não sobre todo o
-  // histórico. Se houver mais páginas, precisamos avisar em vez de afirmar
-  // que a transação não existe. Sem total conhecido (header ausente), uma
-  // página cheia é o sinal disponível de que pode haver mais.
+  // Sem total conhecido (header ausente), uma página cheia é o sinal
+  // disponível de que pode haver mais além dela.
   const haMaisPaginas = totalConhecido
     ? total > transactions.length
     : transactions.length === PAGE_SIZE;
@@ -232,12 +278,6 @@ export default function Transactions() {
   const podeAvancar = totalConhecido
     ? offset + PAGE_SIZE < total
     : transactions.length === PAGE_SIZE;
-
-  const filtered = transactions.filter(
-    (t) =>
-      t.category.toLowerCase().includes(search.toLowerCase()) ||
-      t.description?.toLowerCase().includes(search.toLowerCase()),
-  );
 
   return (
     <div className="space-y-6">
@@ -427,7 +467,13 @@ export default function Transactions() {
                 aria-pressed={filterType === t}
                 onClick={() => {
                   setFilterType(t);
-                  load(t ? { type: t } : {}, 0);
+                  load(
+                    {
+                      ...(t ? { type: t } : {}),
+                      ...(search.length >= 2 ? { q: search } : {}),
+                    },
+                    0,
+                  );
                 }}
                 className={`rounded-xl px-3 py-2 text-sm transition-colors ${
                   filterType === t
@@ -440,6 +486,10 @@ export default function Transactions() {
             ))}
           </div>
         </div>
+
+        {loading && (
+          <p className="pb-2 text-xs text-content-3">Carregando…</p>
+        )}
 
         <table className="hidden w-full md:table">
           <thead>
@@ -455,7 +505,7 @@ export default function Transactions() {
             </tr>
           </thead>
           <tbody>
-            {filtered.map((t) => (
+            {transactions.map((t) => (
               <tr
                 key={t.id}
                 className="border-b border-line/5 last:border-0 hover:bg-state/[0.03] transition-colors"
@@ -521,7 +571,7 @@ export default function Transactions() {
         </table>
 
         <div className="space-y-3 md:hidden">
-          {filtered.map((t) => (
+          {transactions.map((t) => (
             <article key={t.id} className="inset-panel p-4">
               <div className="flex items-start justify-between gap-3">
                 <div className="min-w-0">
@@ -582,47 +632,35 @@ export default function Transactions() {
           ))}
         </div>
 
-        {/* Independente do resultado ter vindo vazio: a busca só olha a página
-            carregada, então "poucos resultados" é tão enganoso quanto "zero". */}
-        {search && haMaisPaginas && (
-          <p className="pt-2 text-center text-xs text-content-3">
-            A busca cobre só as transações desta página. Pode haver mais resultados em outras páginas.
-          </p>
-        )}
-
-        {filtered.length === 0 && (
+        {transactions.length === 0 && (
           <div className="text-center py-12 text-content-3 text-sm">
-            Nenhuma transação encontrada.
+            {search.length >= 2
+              ? "Nenhuma transação encontrada para essa busca."
+              : "Nenhuma transação encontrada."}
           </div>
         )}
 
         {(haMaisPaginas || offset > 0) && (
           <div className="flex items-center justify-between gap-4 pt-2">
             <p className="text-sm text-content-2 tnum">
-              {search
-                ? "Busca ativa: contagem total oculta"
-                : totalConhecido
-                  ? `${offset + 1}–${Math.min(offset + PAGE_SIZE, total)} de ${total}`
-                  : transactions.length === 0
-                    ? "Nenhuma transação nesta página"
-                    : `${offset + 1}–${offset + transactions.length}`}
+              {totalConhecido
+                ? `${offset + 1}–${Math.min(offset + PAGE_SIZE, total)} de ${total}`
+                : transactions.length === 0
+                  ? "Nenhuma transação nesta página"
+                  : `${offset + 1}–${offset + transactions.length}`}
             </p>
             <div className="flex gap-2">
               <Button
                 variant="ghost"
                 disabled={offset === 0}
-                onClick={() =>
-                  load(filterType ? { type: filterType } : {}, offset - PAGE_SIZE)
-                }
+                onClick={() => load(filtroAtivo(), offset - PAGE_SIZE)}
               >
                 Anterior
               </Button>
               <Button
                 variant="ghost"
                 disabled={!podeAvancar}
-                onClick={() =>
-                  load(filterType ? { type: filterType } : {}, offset + PAGE_SIZE)
-                }
+                onClick={() => load(filtroAtivo(), offset + PAGE_SIZE)}
               >
                 Próxima
               </Button>

--- a/frontend/src/pages/Transactions.test.jsx
+++ b/frontend/src/pages/Transactions.test.jsx
@@ -187,6 +187,36 @@ describe("Transactions", () => {
     );
   });
 
+  it("a busca sobrevive à paginação: 'Próxima' carrega com o termo ativo", async () => {
+    transactionsApi.list
+      .mockResolvedValueOnce(pagina(50, 50, "p1-")) // mount
+      .mockResolvedValueOnce(pagina(50, 120, "busca-")) // resultado da busca
+      .mockResolvedValueOnce(pagina(50, 120, "busca2-")); // após "Próxima"
+
+    render(
+      <MemoryRouter>
+        <Transactions />
+      </MemoryRouter>,
+    );
+
+    await screen.findAllByText("Item p1-0");
+    vi.useFakeTimers();
+
+    fireEvent.change(screen.getByLabelText(/buscar transações/i), {
+      target: { value: "mercado" },
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(300);
+    });
+    expect(screen.getAllByText("Item busca-0").length).toBeGreaterThan(0);
+
+    fireEvent.click(screen.getByRole("button", { name: /próxima/i }));
+
+    expect(transactionsApi.list).toHaveBeenLastCalledWith(
+      expect.objectContaining({ q: "mercado", offset: 50 }),
+    );
+  });
+
   it("não mostra faixa invertida quando, sem X-Total-Count, a página seguinte vem vazia", async () => {
     // Heurística do modo fallback: "página veio cheia, habilita Próxima". Com
     // um total que é múltiplo exato de PAGE_SIZE isso é falso positivo — a

--- a/frontend/src/pages/Transactions.test.jsx
+++ b/frontend/src/pages/Transactions.test.jsx
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 
 import { transactionsApi } from "@/api/transactions";
@@ -42,6 +42,10 @@ function pagina(qtd, total, prefixo = "") {
 describe("Transactions", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it("pede a primeira página com limit e offset explícitos e renderiza os itens recebidos", async () => {
@@ -106,30 +110,6 @@ describe("Transactions", () => {
     expect(await screen.findByText(/120/)).toBeInTheDocument();
   });
 
-  it("avisa que a busca cobre só a página atual mesmo quando encontra resultados nela", async () => {
-    // Bug real: com 120 transações e busca batendo em 2 na página 1 e mais 9
-    // nas páginas seguintes, o usuário via só as 2 e não sabia que faltavam.
-    // O aviso não pode depender de filtered.length === 0.
-    transactionsApi.list.mockResolvedValue(pagina(50, 120, "p1-"));
-
-    render(
-      <MemoryRouter>
-        <Transactions />
-      </MemoryRouter>,
-    );
-
-    await screen.findAllByText("Item p1-0");
-    fireEvent.change(screen.getByLabelText(/buscar transações/i), {
-      target: { value: "p1-0" },
-    });
-
-    // A busca encontrou resultado (não é o caso de "zero resultados").
-    expect(screen.getAllByText("Item p1-0").length).toBeGreaterThan(0);
-    expect(
-      await screen.findByText(/busca cobre só as transações desta página/i),
-    ).toBeInTheDocument();
-  });
-
   it("mantém a paginação utilizável quando a resposta não traz X-Total-Count, contanto que a página venha cheia", async () => {
     // Backend/proxy sem o header: sem isso a página ficava travada em 50 itens
     // sem controles e sem aviso, mesmo tendo mais dados por trás.
@@ -150,6 +130,61 @@ describe("Transactions", () => {
     expect(proxima).toBeEnabled();
     // Sem total conhecido, o contador não pode inventar um "de X".
     expect(screen.getByText("1–50")).toBeInTheDocument();
+  });
+
+  it("busca consulta o servidor depois da espera", async () => {
+    transactionsApi.list.mockResolvedValue(pagina(50, 50, "p1-"));
+
+    render(
+      <MemoryRouter>
+        <Transactions />
+      </MemoryRouter>,
+    );
+
+    await screen.findAllByText("Item p1-0");
+    transactionsApi.list.mockClear();
+    vi.useFakeTimers();
+
+    fireEvent.change(screen.getByLabelText(/buscar transações/i), {
+      target: { value: "feira" },
+    });
+
+    // Antes de a espera terminar, nenhuma chamada nova.
+    expect(transactionsApi.list).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(300);
+    });
+
+    expect(transactionsApi.list).toHaveBeenCalledWith(
+      expect.objectContaining({ q: "feira" }),
+    );
+  });
+
+  it("busca curta não consulta", async () => {
+    transactionsApi.list.mockResolvedValue(pagina(50, 50, "p1-"));
+
+    render(
+      <MemoryRouter>
+        <Transactions />
+      </MemoryRouter>,
+    );
+
+    await screen.findAllByText("Item p1-0");
+    transactionsApi.list.mockClear();
+    vi.useFakeTimers();
+
+    fireEvent.change(screen.getByLabelText(/buscar transações/i), {
+      target: { value: "f" },
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(300);
+    });
+
+    expect(transactionsApi.list).not.toHaveBeenCalledWith(
+      expect.objectContaining({ q: expect.anything() }),
+    );
   });
 
   it("não mostra faixa invertida quando, sem X-Total-Count, a página seguinte vem vazia", async () => {


### PR DESCRIPTION
## Summary

- Reports search now debounces 300ms and queries the server via the new `q` param on `GET /transactions/` (accent- and case-insensitive, combined with the existing type/month/year filters), instead of filtering only the currently loaded page. Search below 2 characters returns to the normal list. Removed the client-side `filtered` array and the stale "search only covers this page" warning, which no longer applies now that the server's `X-Total-Count` already reflects the search.
- Settings' plan card gains a daily AI usage meter, fed by the new `GET /ai/usage` endpoint: an accessible progress bar (`role="progressbar"`, correct aria attributes, `aria-label="Uso da IA hoje"`) driven by whichever cap (tokens or calls) is closer to its limit, with the same 80%/100% warning/danger thresholds already used by the Admin AI counter. It only fetches when `plan.ai_allowed` is true, fails silently on network errors (never turns the plan card into an error surface), and stays entirely absent otherwise — no upsell copy.

## Test plan

- [x] `npx vitest run` — 191/191 passing, including the new debounce tests (with fake timers) and the three new PlanCard meter tests.
- [x] `npm run lint` — clean.
- [x] `npm run build` — succeeds.
- [x] Manual check against the local stack (`teste.login@norby.dev`):
  - Search "farmacia" / "farmácia" both match "Farmácia" — accent-insensitive confirmed.
  - Empty search shows "Nenhuma transação encontrada para essa busca."
  - Focus ring visible on the search input in both themes.
  - Meter verified end-to-end against the real `/ai/usage` endpoint (with a temporary local DB seed, reverted afterward): correct copy, warning color at 85%, danger color at 100%, in both light and dark themes.
  - Confirmed the meter is absent for a real account without AI access (`ai_allowed: false`).

Closes #25